### PR TITLE
feat(stage): add Stage::up_axis() -> Option<UpAxis>

### DIFF
--- a/fixtures/up_axis_absent.usda
+++ b/fixtures/up_axis_absent.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+(
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/fixtures/up_axis_y.usda
+++ b/fixtures/up_axis_y.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    upAxis = "Y"
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/fixtures/up_axis_z.usda
+++ b/fixtures/up_axis_z.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    upAxis = "Z"
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/src/sdf/schema.rs
+++ b/src/sdf/schema.rs
@@ -62,6 +62,7 @@ pub enum FieldKey {
     VariantSetNames,
     EndFrame,
     StartFrame,
+    UpAxis,
 }
 
 impl From<FieldKey> for &'static str {
@@ -138,6 +139,7 @@ impl FieldKey {
             FieldKey::VariantSetNames => "variantSetNames",
             FieldKey::EndFrame => "endFrame",
             FieldKey::StartFrame => "startFrame",
+            FieldKey::UpAxis => "upAxis",
         }
     }
 }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -34,6 +34,20 @@ use crate::compose::prim_index::{ArcType, Node, PrimIndex};
 use crate::sdf::schema::{ChildrenKey, FieldKey};
 use crate::sdf::{AbstractData, ListOp, Path, Payload, Reference, SpecType, Value};
 
+/// The scene's up-axis, as stored in the root layer's `upAxis` metadata.
+///
+/// USD defines two valid values: `"Y"` (Y-up, the default for many DCC tools)
+/// and `"Z"` (Z-up, used by e.g. OpenUSD's own reference scenes).
+///
+/// See <https://openusd.org/dev/api/group___usd_geom_up_axis__group.html>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpAxis {
+    /// Y axis points up.
+    Y,
+    /// Z axis points up.
+    Z,
+}
+
 /// A composed USD stage.
 ///
 /// Owns the loaded layer stack and provides composed access to prims,
@@ -83,6 +97,35 @@ impl Stage {
     /// Returns the `defaultPrim` metadata from the root layer, if set.
     pub fn default_prim(&self) -> Option<String> {
         self.field::<String>(&Path::abs_root(), FieldKey::DefaultPrim).ok()?
+    }
+
+    /// Returns the `upAxis` metadata from the root layer, if set.
+    ///
+    /// USD defines two valid values: `"Y"` and `"Z"`.  Any other authored
+    /// value (malformed data) is treated as `None` rather than an error so
+    /// that callers can continue inspecting the rest of the stage.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use openusd::{ar::DefaultResolver, Stage};
+    /// use openusd::stage::UpAxis;
+    ///
+    /// let resolver = DefaultResolver::new();
+    /// let stage = Stage::open(&resolver, "scene.usda").unwrap();
+    /// match stage.up_axis() {
+    ///     Some(UpAxis::Y) => println!("Y-up"),
+    ///     Some(UpAxis::Z) => println!("Z-up"),
+    ///     None => println!("upAxis not set"),
+    /// }
+    /// ```
+    pub fn up_axis(&self) -> Option<UpAxis> {
+        let raw = self.field::<String>(&Path::abs_root(), FieldKey::UpAxis).ok()??;
+        match raw.as_str() {
+            "Y" => Some(UpAxis::Y),
+            "Z" => Some(UpAxis::Z),
+            _ => None,
+        }
     }
 
     /// Returns the composed list of root prim names (children of the pseudo-root).
@@ -1032,6 +1075,44 @@ mod tests {
         // Local is yellow (0.8, 0.8, 0), source is red (0.8, 0, 0).
         let red = Value::Vec3f(vec![0.8, 0.0, 0.0]);
         assert_ne!(value.unwrap(), red, "local opinion should win over specialized");
+
+        Ok(())
+    }
+
+    // --- Stage::up_axis() ---
+
+    /// A stage with `upAxis = "Y"` should return `UpAxis::Y`.
+    #[test]
+    fn up_axis_y() -> Result<()> {
+        let path = fixture_path("up_axis_y.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.up_axis(), Some(UpAxis::Y));
+
+        Ok(())
+    }
+
+    /// A stage with `upAxis = "Z"` should return `UpAxis::Z`.
+    #[test]
+    fn up_axis_z() -> Result<()> {
+        let path = fixture_path("up_axis_z.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.up_axis(), Some(UpAxis::Z));
+
+        Ok(())
+    }
+
+    /// A stage without an `upAxis` metadata entry should return `None`.
+    #[test]
+    fn up_axis_absent_returns_none() -> Result<()> {
+        let path = fixture_path("up_axis_absent.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.up_axis(), None);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds a typed accessor for the root layer's `upAxis` metadata, which is the first piece of scene-convention metadata most downstream renderers / viewers need:

```rust
pub fn up_axis(&self) -> Option<UpAxis>
```

where `UpAxis` is a small `Y`/`Z` enum. USD defines only `"Y"` and `"Z"` as valid values; any other authored string is treated as `None` so callers can continue inspecting the rest of the stage without erroring on malformed data.

## Changes

- `src/sdf/schema.rs`: add `FieldKey::UpAxis` (`"upAxis"`).
- `src/stage.rs`: add `pub enum UpAxis { Y, Z }` and `Stage::up_axis()`.
- `fixtures/up_axis_y.usda`, `fixtures/up_axis_z.usda`, `fixtures/up_axis_absent.usda`: minimal fixtures.
- Tests added in `stage::tests`:
  - `up_axis_y`: Y-up fixture returns `Some(UpAxis::Y)`
  - `up_axis_z`: Z-up fixture returns `Some(UpAxis::Z)`
  - `up_axis_absent_returns_none`: no-metadata fixture returns `None`

## Rationale

The common alternative is to expose `upAxis` as a raw string via the existing `field::<String>` API, but:

1. Callers consistently want a typed enum (every downstream renderer writes the same 3-line match).
2. Malformed values should not crash callers doing asset inspection.

A companion PR for `Stage::meters_per_unit()` is coming separately so that each accessor can be reviewed independently.

## Test plan

- [x] `cargo test` passes (228 tests, 3 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean