### PR TITLE
feat(stage): add Stage::meters_per_unit() -> Option<f64>

### DIFF
--- a/fixtures/meters_per_unit_absent.usda
+++ b/fixtures/meters_per_unit_absent.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+(
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/fixtures/meters_per_unit_centimeters.usda
+++ b/fixtures/meters_per_unit_centimeters.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    metersPerUnit = 0.01
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/fixtures/meters_per_unit_meters.usda
+++ b/fixtures/meters_per_unit_meters.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    metersPerUnit = 1.0
+    defaultPrim = "Root"
+)
+
+def Xform "Root"
+{
+}

--- a/src/sdf/schema.rs
+++ b/src/sdf/schema.rs
@@ -62,6 +62,7 @@ pub enum FieldKey {
     VariantSetNames,
     EndFrame,
     StartFrame,
+    MetersPerUnit,
 }
 
 impl From<FieldKey> for &'static str {
@@ -138,6 +139,7 @@ impl FieldKey {
             FieldKey::VariantSetNames => "variantSetNames",
             FieldKey::EndFrame => "endFrame",
             FieldKey::StartFrame => "startFrame",
+            FieldKey::MetersPerUnit => "metersPerUnit",
         }
     }
 }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -85,6 +85,28 @@ impl Stage {
         self.field::<String>(&Path::abs_root(), FieldKey::DefaultPrim).ok()?
     }
 
+    /// Returns the `metersPerUnit` metadata from the root layer, if set.
+    ///
+    /// The value represents how many meters one scene unit corresponds to.
+    /// Common values are `0.01` (centimeters, used by many DCC tools) and
+    /// `1.0` (meters).  Returns `None` when the metadata is not authored;
+    /// the USD specification does not define a default value.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use openusd::{ar::DefaultResolver, Stage};
+    ///
+    /// let resolver = DefaultResolver::new();
+    /// let stage = Stage::open(&resolver, "scene.usda").unwrap();
+    /// if let Some(scale) = stage.meters_per_unit() {
+    ///     println!("1 unit = {scale} meters");
+    /// }
+    /// ```
+    pub fn meters_per_unit(&self) -> Option<f64> {
+        self.field::<f64>(&Path::abs_root(), FieldKey::MetersPerUnit).ok()?
+    }
+
     /// Returns the composed list of root prim names (children of the pseudo-root).
     pub fn root_prims(&self) -> Result<Vec<String>> {
         self.prim_children(Path::abs_root())
@@ -1032,6 +1054,44 @@ mod tests {
         // Local is yellow (0.8, 0.8, 0), source is red (0.8, 0, 0).
         let red = Value::Vec3f(vec![0.8, 0.0, 0.0]);
         assert_ne!(value.unwrap(), red, "local opinion should win over specialized");
+
+        Ok(())
+    }
+
+    // --- Stage::meters_per_unit() ---
+
+    /// A stage with `metersPerUnit = 0.01` should return `Some(0.01)`.
+    #[test]
+    fn meters_per_unit_centimeters() -> Result<()> {
+        let path = fixture_path("meters_per_unit_centimeters.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.meters_per_unit(), Some(0.01));
+
+        Ok(())
+    }
+
+    /// A stage with `metersPerUnit = 1.0` should return `Some(1.0)`.
+    #[test]
+    fn meters_per_unit_meters() -> Result<()> {
+        let path = fixture_path("meters_per_unit_meters.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.meters_per_unit(), Some(1.0));
+
+        Ok(())
+    }
+
+    /// A stage without `metersPerUnit` should return `None`.
+    #[test]
+    fn meters_per_unit_absent_returns_none() -> Result<()> {
+        let path = fixture_path("meters_per_unit_absent.usda");
+        let resolver = DefaultResolver::new();
+        let stage = Stage::open(&resolver, &path)?;
+
+        assert_eq!(stage.meters_per_unit(), None);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds a typed accessor for the root layer's `metersPerUnit` metadata:

```rust
pub fn meters_per_unit(&self) -> Option<f64>
```

`metersPerUnit` represents how many meters one scene unit corresponds to. Common values are `0.01` (centimeters, used by many DCC tools) and `1.0` (meters). This PR returns `None` when the metadata is not authored; the USD specification does not define a default value, so the calling application should decide (e.g. Houdini picks 1.0, Maya picks 0.01).

Companion to #42 (`Stage::up_axis()`) but fully independent - each PR introduces its own FieldKey, its own fixtures, and its own tests so they can be reviewed/merged in any order.

## Changes

- `src/sdf/schema.rs`: add `FieldKey::MetersPerUnit` (`"metersPerUnit"`).
- `src/stage.rs`: add `Stage::meters_per_unit()` accessor.
- `fixtures/meters_per_unit_centimeters.usda`, `meters_per_unit_meters.usda`, `meters_per_unit_absent.usda`: minimal fixtures.
- Tests added in `stage::tests`:
  - `meters_per_unit_centimeters`: fixture with `0.01` returns `Some(0.01)`
  - `meters_per_unit_meters`: fixture with `1.0` returns `Some(1.0)`
  - `meters_per_unit_absent_returns_none`: fixture without the field returns `None`

## Test plan

- [x] `cargo test` passes (228 tests, 3 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean