### PR TITLE
pcp: apply primOrder/propertyOrder during composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+.claude/settings.local.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,9 +95,9 @@ Legend: :white_check_mark: Supported | :construction: Planned | :thinking: Consi
 | Populating the stage | `11.3` | :white_check_mark: | `0.2.0` | Lazy per-prim composition via `pcp::Cache` |
 | [Population mask](https://openusd.org/release/api/class_usd_stage_population_mask.html) | `11.3` | :construction: | | No subset-of-prims loading |
 | Ordered prim children | `11.3.1` | :white_check_mark: | `0.2.0` | Merged `primChildren` with relocate adjustment |
-| Ordered prim children (`primOrder` reordering) | `11.3.1` | :construction: | | `primOrder` field not applied |
+| Ordered prim children (`primOrder` reordering) | `11.3.1` | :white_check_mark: | `main` | Strongest opinion applied via `sdf::apply_ordering` |
 | Ordered property children | `11.3.2` | :white_check_mark: | `0.2.0` | Merged `propertyChildren` |
-| Ordered property children (`propertyOrder` reordering) | `11.3.2` | :construction: | | `propertyOrder` field not applied |
+| Ordered property children (`propertyOrder` reordering) | `11.3.2` | :white_check_mark: | `main` | Strongest opinion applied via `sdf::apply_ordering` |
 | [Scene graph instancing](https://openusd.org/release/glossary.html#usdglossary-instancing) | `11.3.3` | :construction: | | `instanceable` readable; shared representation not implemented |
 | Model hierarchy (kind) | `11.4` | :construction: | | `kind` readable; hierarchy validation not implemented |
 | [Stage queries](https://openusd.org/release/api/prim_flags_8h.html) (Active, Loaded, Defined, Abstract, Instance) | `11.5` | :construction: | | Predicate flags for traversal filtering |

--- a/fixtures/reorder.usda
+++ b/fixtures/reorder.usda
@@ -1,0 +1,31 @@
+#usda 1.0
+
+def "Root"
+{
+    reorder nameChildren = ["C", "A", "Missing"]
+
+    def "A"
+    {
+    }
+
+    def "B"
+    {
+    }
+
+    def "C"
+    {
+    }
+
+    def "D"
+    {
+    }
+}
+
+def "Props"
+{
+    reorder properties = ["y", "x"]
+
+    int x = 1
+    int y = 2
+    int z = 3
+}

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::sdf;
 use crate::sdf::schema::{ChildrenKey, FieldKey};
 use crate::sdf::{Path, SpecType, Value};
 
@@ -134,7 +135,15 @@ impl Cache {
     ///
     /// Merges the children field across all composition nodes, returning the
     /// union with strongest-first ordering. When relocates are present,
-    /// source children are hidden and target children are added.
+    /// source children are hidden and target children are added. Finally,
+    /// the strongest opinion of `primOrder` (if any) is applied to the
+    /// resulting list (see [`sdf::apply_ordering`]).
+    ///
+    /// Composition note: the strongest `primOrder` opinion wins outright,
+    /// matching how single-valued fields like `defaultPrim` compose. C++
+    /// `Pcp` instead folds each layer's order onto the running union as
+    /// nodes merge weakest-to-strongest, which can yield different results
+    /// when multiple sublayers contribute partial orderings.
     pub fn prim_children(&mut self, path: &Path) -> Result<Vec<String>> {
         let mut children = self.composed_children(path, ChildrenKey::PrimChildren)?;
 
@@ -142,12 +151,27 @@ impl Cache {
             self.apply_relocates_to_children(path, &mut children);
         }
 
+        self.apply_order_field(path, FieldKey::PrimOrder, &mut children)?;
         Ok(children)
     }
 
     /// Returns the composed list of property names for a prim path.
+    ///
+    /// Applies the strongest `propertyOrder` opinion to the unioned property
+    /// list. See [`Cache::prim_children`] for the composition-rule caveat.
     pub fn prim_properties(&mut self, path: &Path) -> Result<Vec<String>> {
-        self.composed_children(path, ChildrenKey::PropertyChildren)
+        let mut properties = self.composed_children(path, ChildrenKey::PropertyChildren)?;
+        self.apply_order_field(path, FieldKey::PropertyOrder, &mut properties)?;
+        Ok(properties)
+    }
+
+    /// Apply the strongest opinion of `field` (a `TokenVec`) as a child-list
+    /// ordering. The index for `path` must already be cached.
+    fn apply_order_field(&self, path: &Path, field: FieldKey, items: &mut [String]) -> Result<()> {
+        if let Some(Value::TokenVec(order)) = self.indices[path].resolve_field(field.as_str(), &self.stack, None)? {
+            sdf::apply_ordering(items, &order);
+        }
+        Ok(())
     }
 
     /// Returns the `defaultPrim` metadata from the root layer, if set.

--- a/src/sdf/mod.rs
+++ b/src/sdf/mod.rs
@@ -10,11 +10,13 @@ use bytemuck::{Pod, Zeroable};
 use strum::{Display, EnumCount, FromRepr};
 
 mod data;
+mod ordering;
 mod path;
 pub mod schema;
 mod value;
 
 pub use data::Data;
+pub use ordering::apply_ordering;
 pub use path::{path, Path};
 pub use schema::{ChildrenKey, FieldKey};
 pub use value::{Value, ValueConversionError};

--- a/src/sdf/ordering.rs
+++ b/src/sdf/ordering.rs
@@ -1,0 +1,86 @@
+//! Children list reordering helper.
+//!
+//! Mirrors C++ `Sdf_ApplyOrdering`: names listed in `order` are reshuffled
+//! into order-list sequence at the slots they currently occupy in `children`.
+//! Names not in the order list keep their positions; names in the order list
+//! that are not present in `children` are silently skipped.
+//!
+//! Example: `children = [a, b, c, d, e]`, `order = [c, a]` produces
+//! `[c, b, a, d, e]`.
+
+/// Reorder `children` in place according to `order`.
+///
+/// See the module-level documentation for the precise semantics. The function
+/// is a no-op when either input is empty or when no name in `children`
+/// appears in `order`.
+pub fn apply_ordering(children: &mut [String], order: &[String]) {
+    if order.is_empty() || children.is_empty() {
+        return;
+    }
+
+    let slots: Vec<usize> = children
+        .iter()
+        .enumerate()
+        .filter_map(|(i, name)| order.contains(name).then_some(i))
+        .collect();
+    if slots.is_empty() {
+        return;
+    }
+
+    let projected: Vec<&String> = order.iter().filter(|n| children.contains(*n)).collect();
+
+    for (slot, name) in slots.iter().zip(projected.iter()) {
+        children[*slot].clone_from(*name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn reorders_named_subset_in_place() {
+        let mut children = s(&["a", "b", "c", "d", "e"]);
+        apply_ordering(&mut children, &s(&["c", "a"]));
+        assert_eq!(children, s(&["c", "b", "a", "d", "e"]));
+    }
+
+    #[test]
+    fn full_reverse_works() {
+        let mut children = s(&["a", "b", "c"]);
+        apply_ordering(&mut children, &s(&["c", "b", "a"]));
+        assert_eq!(children, s(&["c", "b", "a"]));
+    }
+
+    #[test]
+    fn unknown_names_in_order_are_ignored() {
+        let mut children = s(&["a", "b", "c"]);
+        apply_ordering(&mut children, &s(&["b", "missing", "a"]));
+        assert_eq!(children, s(&["b", "a", "c"]));
+    }
+
+    #[test]
+    fn empty_order_is_noop() {
+        let mut children = s(&["a", "b", "c"]);
+        apply_ordering(&mut children, &[]);
+        assert_eq!(children, s(&["a", "b", "c"]));
+    }
+
+    #[test]
+    fn no_overlap_is_noop() {
+        let mut children = s(&["a", "b", "c"]);
+        apply_ordering(&mut children, &s(&["x", "y", "z"]));
+        assert_eq!(children, s(&["a", "b", "c"]));
+    }
+
+    #[test]
+    fn empty_children_is_noop() {
+        let mut children: Vec<String> = Vec::new();
+        apply_ordering(&mut children, &s(&["a", "b"]));
+        assert!(children.is_empty());
+    }
+}

--- a/src/usda/parser.rs
+++ b/src/usda/parser.rs
@@ -353,7 +353,7 @@ impl<'a> Parser<'a> {
             })?;
         }
 
-        let (children, props, variant_sets) = self.read_prim_body(&prim_path, data)?;
+        let (children, props, variant_sets) = self.read_prim_body(&prim_path, &mut spec, data)?;
         if !children.is_empty() {
             spec.add(ChildrenKey::PrimChildren, sdf::Value::TokenVec(children));
         }
@@ -374,9 +374,12 @@ impl<'a> Parser<'a> {
     /// Parse the body of a prim or variant (`{ ... }`).
     ///
     /// Returns the child prim names and property names found in the body.
+    /// `owner_spec` is the in-progress prim/variant spec that owns this body;
+    /// `reorder` statements write `primOrder`/`propertyOrder` directly into it.
     fn read_prim_body(
         &mut self,
         path: &sdf::Path,
+        owner_spec: &mut sdf::Spec,
         data: &mut HashMap<sdf::Path, sdf::Spec>,
     ) -> Result<(Vec<String>, Vec<String>, Vec<String>)> {
         let mut children = Vec::new();
@@ -403,7 +406,7 @@ impl<'a> Parser<'a> {
                     this.read_relationship(path, false, &mut properties, data, None)?;
                 }
                 Token::Reorder => {
-                    this.read_reorder(path, data)?;
+                    this.read_reorder(owner_spec)?;
                 }
                 _ => {
                     this.read_attribute(path, &mut properties, &mut suffixed_properties, data)?;
@@ -424,8 +427,8 @@ impl<'a> Parser<'a> {
     /// Parse `reorder nameChildren = [...]` or `reorder properties = [...]`.
     ///
     /// These statements set the `primOrder` or `propertyOrder` fields on the
-    /// owning prim spec, controlling child/property display order.
-    fn read_reorder(&mut self, path: &sdf::Path, data: &mut HashMap<sdf::Path, sdf::Spec>) -> Result<()> {
+    /// owning prim/variant spec, controlling child/property display order.
+    fn read_reorder(&mut self, owner_spec: &mut sdf::Spec) -> Result<()> {
         self.fetch_next()?; // consume `reorder`
 
         let token = self
@@ -440,13 +443,7 @@ impl<'a> Parser<'a> {
         self.ensure_pun('=')?;
 
         let names = self.one_or_list(|this| Ok(this.fetch_str()?.to_owned()))?;
-        if let Some(spec) = data.get_mut(path) {
-            spec.add(field_key, sdf::Value::TokenVec(names));
-        } else {
-            let mut spec = sdf::Spec::new(sdf::SpecType::Prim);
-            spec.add(field_key, sdf::Value::TokenVec(names));
-            data.insert(path.clone(), spec);
-        }
+        owner_spec.add(field_key, sdf::Value::TokenVec(names));
 
         Ok(())
     }
@@ -484,7 +481,7 @@ impl<'a> Parser<'a> {
             }
 
             // Variant body.
-            let (children, properties, variant_sets) = this.read_prim_body(&variant_path, data)?;
+            let (children, properties, variant_sets) = this.read_prim_body(&variant_path, &mut variant_spec, data)?;
             if !children.is_empty() {
                 variant_spec.add(ChildrenKey::PrimChildren, sdf::Value::TokenVec(children));
             }

--- a/src/usda/writer.rs
+++ b/src/usda/writer.rs
@@ -155,6 +155,8 @@ impl<W: Write> Emitter<'_, W> {
         writeln!(self.out, "{{")?;
         self.indent += 1;
 
+        self.emit_body_reorders(data, path)?;
+
         // Properties
         let props = property_children(data, path);
         for name in &props {
@@ -181,6 +183,19 @@ impl<W: Write> Emitter<'_, W> {
         self.write_indent()?;
         writeln!(self.out, "}}")?;
 
+        Ok(())
+    }
+
+    /// Emit `reorder nameChildren / properties` statements (if authored) at
+    /// the top of a prim or variant body. The grammar only accepts these
+    /// inside `{...}`, not in the metadata block.
+    fn emit_body_reorders(&mut self, data: &dyn AbstractData, path: &Path) -> Result<()> {
+        if let Some(Value::TokenVec(v)) = get_value(data, path, FieldKey::PrimOrder.as_str()) {
+            self.emit_reorder("nameChildren", &v)?;
+        }
+        if let Some(Value::TokenVec(v)) = get_value(data, path, FieldKey::PropertyOrder.as_str()) {
+            self.emit_reorder("properties", &v)?;
+        }
         Ok(())
     }
 
@@ -586,6 +601,8 @@ impl<W: Write> Emitter<'_, W> {
         writeln!(self.out, " {{")?;
         self.indent += 1;
 
+        self.emit_body_reorders(data, path)?;
+
         let props = property_children(data, path);
         for prop in &props {
             let prop_path = path.append_property(prop)?;
@@ -656,19 +673,6 @@ impl<W: Write> Emitter<'_, W> {
                 self.out.write_all(buf.as_bytes())?;
                 writeln!(self.out)?;
                 return Ok(());
-            }
-        }
-
-        // `primOrder` / `propertyOrder` are stored under those field names but
-        // the text grammar expresses them as `reorder nameChildren/properties`.
-        if name == FieldKey::PrimOrder.as_str() {
-            if let Value::TokenVec(v) = value {
-                return self.emit_reorder("nameChildren", v);
-            }
-        }
-        if name == FieldKey::PropertyOrder.as_str() {
-            if let Value::TokenVec(v) = value {
-                return self.emit_reorder("properties", v);
             }
         }
 
@@ -1365,6 +1369,8 @@ const SPLINE_FIELD: &str = "spline";
 const PRIM_STRUCTURAL_FIELDS: &[&str] = &[
     FieldKey::Specifier.as_str(),
     FieldKey::TypeName.as_str(),
+    FieldKey::PrimOrder.as_str(),
+    FieldKey::PropertyOrder.as_str(),
     ChildrenKey::PrimChildren.as_str(),
     ChildrenKey::PropertyChildren.as_str(),
     ChildrenKey::VariantChildren.as_str(),

--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -272,3 +272,26 @@ composition_tests! {
     VariantSpecializesAndReference_root,
     VariantSpecializesAndReferenceSurprisingBehavior_root,
 }
+
+#[cfg(test)]
+mod reorder {
+    use super::*;
+
+    fn open_fixture() -> Stage {
+        Stage::open("fixtures/reorder.usda").expect("open reorder fixture")
+    }
+
+    #[test]
+    fn prim_order_reorders_named_children() {
+        let stage = open_fixture();
+        let children = stage.prim_children(sdf::path("/Root").unwrap()).unwrap();
+        assert_eq!(children, vec!["C", "B", "A", "D"]);
+    }
+
+    #[test]
+    fn property_order_reorders_named_properties() {
+        let stage = open_fixture();
+        let props = stage.prim_properties(sdf::path("/Props").unwrap()).unwrap();
+        assert_eq!(props, vec!["y", "x", "z"]);
+    }
+}

--- a/tests/text_writer_roundtrip.rs
+++ b/tests/text_writer_roundtrip.rs
@@ -169,6 +169,7 @@ fixture_tests! {
     fixture_instanceable_metadata,
     fixture_payload,
     fixture_reference,
+    fixture_reorder,
     fixture_ref_external,
     fixture_ref_prim,
     fixture_ref_target,


### PR DESCRIPTION
Wire the strongest opinion of primOrder / propertyOrder through pcp::Cache, mirroring the Sdf_ApplyOrdering semantics from C++. Adds an sdf::apply_ordering helper, fixes a USDA parser bug where read_reorder wrote into data only to be overwritten by read_prim, and moves the writer to emit reorder statements at the top of the body.