### PR TITLE
pcp: implement specifier/variability/custom resolution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,10 +108,10 @@ Legend: :white_check_mark: Supported | :construction: Planned | :thinking: Consi
 | Feature | Spec | Status | Version | Notes |
 |---|---|---|---|---|
 | Metadata resolution (strongest opinion wins) | `12.2` | :white_check_mark: | `0.2.0` | `PrimIndex::resolve_field` with `ValueBlock` support |
-| Specifier resolution | `12.2.1` | :construction: | | Special rules for `def`/`over`/`class` not fully implemented |
+| Specifier resolution | `12.2.1` | :white_check_mark: | `main` | `def`/`class`/`over` precedence with direct-inherit awareness in `PrimIndex::resolve_specifier` |
 | typeName resolution (from prim definition) | `12.2.2` | :construction: | | Uses strongest opinion, not prim definition |
-| variability resolution (weakest opinion) | `12.2.3` | :construction: | | Uses strongest opinion instead of weakest |
-| custom field resolution (any-true) | `12.2.4` | :construction: | | Uses strongest opinion instead of any-true |
+| variability resolution (weakest opinion) | `12.2.3` | :white_check_mark: | `main` | Weakest authored opinion via `PrimIndex::resolve_variability` |
+| custom field resolution (any-true) | `12.2.4` | :white_check_mark: | `main` | Logical OR across opinions via `PrimIndex::resolve_custom` |
 | Dictionary combining | `12.2.5` | :construction: | | Recursive merge across opinions |
 | List op resolution | `12.2.6` | :white_check_mark: | `0.2.0` | Combined stack of opinions |
 | Layer metadata (root layer only) | `12.2.7` | :white_check_mark: | `0.2.0` | `defaultPrim`, timing fields, etc. |

--- a/fixtures/value_resolution.usda
+++ b/fixtures/value_resolution.usda
@@ -1,0 +1,42 @@
+#usda 1.0
+(
+    subLayers = [
+        @./value_resolution_weak.usda@
+    ]
+)
+
+# Specifier resolution (12.2.1): a local `over` opinion together with an
+# inherit from a `class` resolves to `class`. The defining opinion comes
+# from the inherit arc, and "all defining specifiers are class" → class.
+over "InheritOnly" (
+    inherits = </_AbstractBase>
+)
+{
+}
+
+class "_AbstractBase"
+{
+}
+
+# Specifier "all over" rule: every authored opinion is `over` → `over`.
+over "AllOver"
+{
+}
+
+# Specifier precedence: a defining opinion (def in this layer) beats the
+# `over` from a hypothetical weaker layer. Here only def is authored, so
+# this exercises the simple case.
+def "DefPrim"
+{
+}
+
+# Custom + variability tests: the strong layer omits both fields.
+def "CustomTest"
+{
+    int attr
+}
+
+def "VarTest"
+{
+    int attr
+}

--- a/fixtures/value_resolution_weak.usda
+++ b/fixtures/value_resolution_weak.usda
@@ -1,0 +1,15 @@
+#usda 1.0
+
+# Custom resolution (12.2.4): weak layer authors `custom`, strong layer omits it.
+# Result must be `true` (any-true) for the strong layer to inherit the marker.
+def "CustomTest"
+{
+    custom int attr
+}
+
+# Variability resolution (12.2.3): weak layer authors `uniform`, strong layer
+# omits variability. The weakest authored opinion wins.
+def "VarTest"
+{
+    uniform int attr
+}

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 
 use crate::sdf::schema::{ChildrenKey, FieldKey};
-use crate::sdf::{LayerData, LayerOffset, ListOp, Path, Payload, PayloadListOp, Reference, Value};
+use crate::sdf::{LayerData, LayerOffset, ListOp, Path, Payload, PayloadListOp, Reference, Specifier, Value};
 
 use super::mapping::MapFunction;
 use super::{Error, LayerStack, VariantFallbackMap};
@@ -255,36 +255,164 @@ impl PrimIndex {
         }
     }
 
-    /// Resolves a field by walking nodes from strongest to weakest, returning the first opinion.
+    /// Resolves a field across the composition graph.
+    ///
+    /// Most fields use strongest-opinion-wins (spec 12.2). Three fields have
+    /// special rules per spec 12.2.1, 12.2.3, 12.2.4:
+    ///
+    /// - `specifier`: precedence by `def`/`class`/`over` with direct-inherit handling
+    /// - `variability`: weakest authored opinion wins
+    /// - `custom`: any-true (logical OR across all authored opinions)
     ///
     /// When `prop_suffix` is `None`, queries use the node's path directly (zero-copy).
     /// When `Some`, appends the suffix to form a property path for each node.
-    /// A [`Value::ValueBlock`] explicitly blocks opinions from weaker layers.
+    /// A [`Value::ValueBlock`] blocks opinions from weaker layers.
     pub(crate) fn resolve_field(
         &self,
         field: &str,
         stack: &LayerStack,
         prop_suffix: Option<&str>,
     ) -> Result<Option<Value>> {
-        for node in self.nodes() {
-            let query_path = match prop_suffix {
-                Some(suffix) => Cow::Owned(Path::new(&format!("{}{suffix}", node.path))?),
-                None => Cow::Borrowed(&node.path),
-            };
+        if field == FieldKey::Specifier.as_str() {
+            return self.resolve_specifier(stack, prop_suffix);
+        }
+        if field == FieldKey::Variability.as_str() {
+            return self.resolve_variability(stack, prop_suffix);
+        }
+        if field == FieldKey::Custom.as_str() {
+            return self.resolve_custom(stack, prop_suffix);
+        }
+        self.resolve_strongest(field, stack, prop_suffix)
+    }
 
+    /// Builds the query path for a node, applying `prop_suffix` if given.
+    /// Borrows the node's path when no suffix is needed (zero-copy).
+    fn query_path<'a>(node: &'a Node, prop_suffix: Option<&str>) -> Result<Cow<'a, Path>> {
+        match prop_suffix {
+            Some(suffix) => Ok(Cow::Owned(Path::new(&format!("{}{suffix}", node.path))?)),
+            None => Ok(Cow::Borrowed(&node.path)),
+        }
+    }
+
+    /// Walks nodes from strongest to weakest, returning the first opinion.
+    /// A [`Value::ValueBlock`] returns `None`, blocking weaker layers.
+    fn resolve_strongest(&self, field: &str, stack: &LayerStack, prop_suffix: Option<&str>) -> Result<Option<Value>> {
+        for node in self.nodes() {
+            let query_path = Self::query_path(node, prop_suffix)?;
             let data = stack.layer(node.layer_index);
             if !data.has_field(&query_path, field) {
                 continue;
             }
-
             let value = data.get(&query_path, field)?;
             if matches!(value.as_ref(), Value::ValueBlock) {
                 return Ok(None);
             }
             return Ok(Some(value.into_owned()));
         }
-
         Ok(None)
+    }
+
+    /// Variability resolution per spec 12.2.3: weakest authored opinion wins.
+    /// Iterates strongest-to-weakest tracking the latest match, so a
+    /// [`Value::ValueBlock`] still blocks weaker opinions.
+    fn resolve_variability(&self, stack: &LayerStack, prop_suffix: Option<&str>) -> Result<Option<Value>> {
+        let field = FieldKey::Variability.as_str();
+        let mut weakest = None;
+        for node in self.nodes() {
+            let query_path = Self::query_path(node, prop_suffix)?;
+            let data = stack.layer(node.layer_index);
+            if !data.has_field(&query_path, field) {
+                continue;
+            }
+            let value = data.get(&query_path, field)?;
+            if matches!(value.as_ref(), Value::ValueBlock) {
+                break;
+            }
+            if matches!(value.as_ref(), Value::Variability(_)) {
+                weakest = Some(value.into_owned());
+            }
+        }
+        Ok(weakest)
+    }
+
+    /// `custom` resolution per spec 12.2.4: any-true across authored opinions.
+    /// Returns `Bool(true)` as soon as any opinion is true, `Bool(false)` if
+    /// at least one opinion was authored but none were true, and `None`
+    /// otherwise.
+    fn resolve_custom(&self, stack: &LayerStack, prop_suffix: Option<&str>) -> Result<Option<Value>> {
+        let field = FieldKey::Custom.as_str();
+        let mut saw_opinion = false;
+        for node in self.nodes() {
+            let query_path = Self::query_path(node, prop_suffix)?;
+            let data = stack.layer(node.layer_index);
+            if !data.has_field(&query_path, field) {
+                continue;
+            }
+            let value = data.get(&query_path, field)?;
+            if matches!(value.as_ref(), Value::ValueBlock) {
+                break;
+            }
+            saw_opinion = true;
+            if matches!(value.as_ref(), Value::Bool(true)) {
+                return Ok(Some(Value::Bool(true)));
+            }
+        }
+        Ok(saw_opinion.then_some(Value::Bool(false)))
+    }
+
+    /// Specifier resolution per spec 12.2.1.
+    ///
+    /// `over` is undefining; `def` and `class` are defining. The composed
+    /// specifier is `def` if the strongest defining opinion is `def`, or if
+    /// the strongest defining opinion not from a direct inherit is `def`.
+    /// It is `class` if the strongest defining opinion not from a direct
+    /// inherit is `class`, or if every defining opinion is `class`. It is
+    /// `over` only when every authored opinion is `over`.
+    fn resolve_specifier(&self, stack: &LayerStack, prop_suffix: Option<&str>) -> Result<Option<Value>> {
+        let field = FieldKey::Specifier.as_str();
+        let mut specs: Vec<(Specifier, ArcType)> = Vec::new();
+        for node in self.nodes() {
+            let query_path = Self::query_path(node, prop_suffix)?;
+            let data = stack.layer(node.layer_index);
+            if !data.has_field(&query_path, field) {
+                continue;
+            }
+            let value = data.get(&query_path, field)?;
+            if matches!(value.as_ref(), Value::ValueBlock) {
+                break;
+            }
+            if let Value::Specifier(s) = value.into_owned() {
+                specs.push((s, node.arc));
+            }
+        }
+        if specs.is_empty() {
+            return Ok(None);
+        }
+
+        let strongest_defining = specs.iter().find(|(s, _)| *s != Specifier::Over).map(|(s, _)| *s);
+        let Some(strongest) = strongest_defining else {
+            // All authored opinions are `over`.
+            return Ok(Some(Value::Specifier(Specifier::Over)));
+        };
+
+        let strongest_non_inherit_defining = specs
+            .iter()
+            .find(|(s, arc)| *s != Specifier::Over && *arc != ArcType::Inherit)
+            .map(|(s, _)| *s);
+
+        if strongest == Specifier::Def || strongest_non_inherit_defining == Some(Specifier::Def) {
+            return Ok(Some(Value::Specifier(Specifier::Def)));
+        }
+
+        let all_defining_class = specs
+            .iter()
+            .filter(|(s, _)| *s != Specifier::Over)
+            .all(|(s, _)| *s == Specifier::Class);
+        if strongest_non_inherit_defining == Some(Specifier::Class) || all_defining_class {
+            return Ok(Some(Value::Specifier(Specifier::Class)));
+        }
+
+        Ok(Some(Value::Specifier(strongest)))
     }
 }
 

--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -295,3 +295,65 @@ mod reorder {
         assert_eq!(props, vec!["y", "x", "z"]);
     }
 }
+
+#[cfg(test)]
+mod value_resolution {
+    use super::*;
+    use openusd::sdf::{FieldKey, Specifier, Value, Variability};
+
+    fn open_fixture() -> Stage {
+        Stage::open("fixtures/value_resolution.usda").expect("open value_resolution fixture")
+    }
+
+    #[test]
+    fn specifier_inherit_only_resolves_to_class() {
+        // Local `over` opinion plus an inherit from a `class`. With strongest-
+        // wins this would be `over`; per spec 12.2.1 it must be `class`.
+        let stage = open_fixture();
+        let value: Option<Value> = stage
+            .field(sdf::path("/InheritOnly").unwrap(), FieldKey::Specifier)
+            .unwrap();
+        assert_eq!(value, Some(Value::Specifier(Specifier::Class)));
+    }
+
+    #[test]
+    fn specifier_all_over_resolves_to_over() {
+        let stage = open_fixture();
+        let value: Option<Value> = stage
+            .field(sdf::path("/AllOver").unwrap(), FieldKey::Specifier)
+            .unwrap();
+        assert_eq!(value, Some(Value::Specifier(Specifier::Over)));
+    }
+
+    #[test]
+    fn specifier_def_resolves_to_def() {
+        let stage = open_fixture();
+        let value: Option<Value> = stage
+            .field(sdf::path("/DefPrim").unwrap(), FieldKey::Specifier)
+            .unwrap();
+        assert_eq!(value, Some(Value::Specifier(Specifier::Def)));
+    }
+
+    #[test]
+    fn variability_weakest_opinion_wins() {
+        // The weak sublayer authors `uniform` while the strong layer omits the
+        // field. Per spec 12.2.3 the resolved variability is the weakest
+        // authored opinion (`uniform`).
+        let stage = open_fixture();
+        let value: Option<Value> = stage
+            .field(sdf::path("/VarTest.attr").unwrap(), FieldKey::Variability)
+            .unwrap();
+        assert_eq!(value, Some(Value::Variability(Variability::Uniform)));
+    }
+
+    #[test]
+    fn custom_any_true() {
+        // Only the weak sublayer authors `custom`. Per spec 12.2.4 the
+        // resolved value is `true` because *any* opinion in the stack is true.
+        let stage = open_fixture();
+        let value: Option<Value> = stage
+            .field(sdf::path("/CustomTest.attr").unwrap(), FieldKey::Custom)
+            .unwrap();
+        assert_eq!(value, Some(Value::Bool(true)));
+    }
+}


### PR DESCRIPTION
Implements the special-case value resolution rules from spec sections 12.2.1, 12.2.3, and 12.2.4 in PrimIndex. specifier follows def/class/over precedence with direct-inherit awareness; variability returns the weakest authored opinion; custom is the logical OR across all authored opinions. All other fields keep the existing strongest-opinion-wins behavior.