### PR TITLE
fix(pcp): anchor relative reference paths against layer parents

### DIFF
--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -1590,10 +1590,7 @@ mod tests {
         ];
         // `../Materials/Materials.usd` written inside `Props/link.usd`
         // should resolve to identifier index 1 (the Materials.usd).
-        assert_eq!(
-            find_layer("../Materials/Materials.usd", &identifiers),
-            Some(1)
-        );
+        assert_eq!(find_layer("../Materials/Materials.usd", &identifiers), Some(1));
         Ok(())
     }
 

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -7,9 +7,11 @@
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use anyhow::Result;
 
+use crate::ar::Resolver;
 use crate::sdf::schema::{ChildrenKey, FieldKey};
 use crate::sdf::{LayerData, LayerOffset, ListOp, Path, Payload, PayloadListOp, Reference, Specifier, Value};
 
@@ -903,7 +905,12 @@ impl<'a> IndexBuilder<'a> {
 
     fn get_sublayer_stack(&self, root_layer: usize) -> Vec<(usize, LayerOffset)> {
         self.stack.sublayer_stacks.get(&root_layer).cloned().unwrap_or_else(|| {
-            LayerStack::build_sublayer_stack(root_layer, &self.stack.layers, &self.stack.identifiers)
+            LayerStack::build_sublayer_stack(
+                root_layer,
+                &self.stack.layers,
+                &self.stack.identifiers,
+                &*self.stack.resolver,
+            )
         })
     }
 
@@ -1085,7 +1092,7 @@ impl<'a> IndexBuilder<'a> {
             // External reference — evaluate in a fresh sub-builder so the
             // target's layer stack doesn't share our `seen` set. The sub-builder
             // uses its own ancestor context derived from the target path.
-            let Some(layer_index) = find_layer(asset_path, &self.stack.identifiers) else {
+            let Some(layer_index) = find_layer(asset_path, &self.stack.identifiers, &*self.stack.resolver) else {
                 return Err(Error::UnresolvedLayer {
                     asset_path: asset_path.to_string(),
                     arc,
@@ -1324,17 +1331,18 @@ fn collect_payloads_in(nodes: &[Node], layers: &[LayerData]) -> Vec<Payload> {
 /// Finds a layer index whose identifier matches `asset_path`.
 ///
 /// Tries an exact match first, then suffix-matches at a path-separator
-/// boundary. Relative paths (`./foo`, `../foo`) won't suffix-match a
-/// canonical absolute identifier; for those, anchor the needle against
-/// each candidate identifier's parent directory, canonicalize, and look
-/// the result back up in the layer stack. Without this, multi-file
-/// asset hierarchies whose sub-layers reference siblings via parent-
-/// traversal paths (e.g. `../Materials/Materials.usd` from a prop
-/// USD) fail every composition lookup with `UnresolvedLayer`.
-pub(super) fn find_layer(asset_path: &str, identifiers: &[String]) -> Option<usize> {
+/// boundary. For relative paths that traverse parent directories (`../foo`,
+/// `..\foo`), these strategies fail against canonical absolute identifiers.
+/// The resolver anchors the path against each candidate identifier so that
+/// custom asset resolution backends work correctly without any filesystem
+/// access in this function.
+pub(super) fn find_layer(asset_path: &str, identifiers: &[String], resolver: &dyn Resolver) -> Option<usize> {
+    use crate::ar::ResolvedPath;
+
     let sep = std::path::MAIN_SEPARATOR as u8;
     let needle = asset_path.strip_prefix("./").unwrap_or(asset_path);
 
+    // Fast path: exact or suffix match against canonical identifiers.
     for (i, id) in identifiers.iter().enumerate() {
         if *id == needle {
             return Some(i);
@@ -1348,25 +1356,15 @@ pub(super) fn find_layer(asset_path: &str, identifiers: &[String]) -> Option<usi
         }
     }
 
-    let needs_anchor = needle.starts_with("./")
-        || needle.starts_with("../")
-        || needle.starts_with(".\\")
-        || needle.starts_with("..\\");
-    if needs_anchor {
-        let needle_path = std::path::Path::new(needle);
-        for id in identifiers.iter() {
-            let id_path = std::path::Path::new(id);
-            let Some(parent) = id_path.parent() else {
-                continue;
-            };
-            let candidate = parent.join(needle_path);
-            let Ok(canonical) = candidate.canonicalize() else {
-                continue;
-            };
-            for (j, other) in identifiers.iter().enumerate() {
-                if std::path::Path::new(other) == canonical {
-                    return Some(j);
-                }
+    // Relative paths traversing parent directories need anchoring. Delegate to
+    // the resolver so custom AR backends override path handling without any
+    // filesystem access here.
+    if needle.starts_with("../") || needle.starts_with("..\\") {
+        for anchor_id in identifiers {
+            let anchor = ResolvedPath::new(PathBuf::from(anchor_id));
+            let resolved = resolver.create_identifier(asset_path, Some(&anchor));
+            if let Some(pos) = identifiers.iter().position(|id| *id == resolved) {
+                return Some(pos);
             }
         }
     }
@@ -1440,7 +1438,12 @@ mod tests {
     /// Helper: loads layers and creates a [`LayerStack`].
     fn load_stack(path: &str) -> anyhow::Result<LayerStack> {
         let (layers, identifiers) = load_layers(path)?;
-        Ok(LayerStack::new(layers, identifiers, 0))
+        Ok(LayerStack::new(
+            layers,
+            identifiers,
+            0,
+            Box::new(DefaultResolver::new()),
+        ))
     }
 
     #[test]
@@ -1540,41 +1543,42 @@ mod tests {
 
     #[test]
     fn find_layer_exact_match() -> Result<()> {
+        let resolver = DefaultResolver::new();
         let (_, ids) = load_layers(&fixture_path("ref_external.usda"))?;
-        assert!(find_layer(&ids[0], &ids).is_some());
+        assert!(find_layer(&ids[0], &ids, &resolver).is_some());
         Ok(())
     }
 
     #[test]
     fn find_layer_suffix_match() -> Result<()> {
+        let resolver = DefaultResolver::new();
         let (_, ids) = load_layers(&fixture_path("ref_external.usda"))?;
-        assert!(find_layer("ref_target.usda", &ids).is_some());
+        assert!(find_layer("ref_target.usda", &ids, &resolver).is_some());
         Ok(())
     }
 
     #[test]
     fn find_layer_no_partial_name_match() -> Result<()> {
+        let resolver = DefaultResolver::new();
         let (_, ids) = load_layers(&fixture_path("ref_external.usda"))?;
-        assert!(find_layer("target.usda", &ids).is_none());
+        assert!(find_layer("target.usda", &ids, &resolver).is_none());
         Ok(())
     }
 
     #[test]
     fn find_layer_not_found() -> Result<()> {
+        let resolver = DefaultResolver::new();
         let (_, ids) = load_layers(&fixture_path("ref_external.usda"))?;
-        assert!(find_layer("nonexistent.usda", &ids).is_none());
+        assert!(find_layer("nonexistent.usda", &ids, &resolver).is_none());
         Ok(())
     }
 
-    /// Relative paths (`./foo`, `../foo`) must anchor against each
-    /// candidate identifier's parent directory. Without this, a
-    /// reference authored inside one sub-USD cannot be matched
-    /// against the loaded sibling layer's canonical identifier.
+    /// Relative `../` paths must be anchored against each candidate
+    /// identifier's location via the resolver. Without this, a reference
+    /// like `../Materials/Materials.usd` authored inside a prop USD silently
+    /// fails every composition lookup with `UnresolvedLayer`.
     #[test]
     fn find_layer_relative_parent_anchored() -> Result<()> {
-        // Fixture: two real files in different sibling dirs of the
-        // crate's `fixtures/` tree. We want a `../<other dir>/<file>`
-        // reference written from one to the other to resolve.
         let tmp = tempfile::tempdir()?;
         let a_dir = tmp.path().join("Props");
         let b_dir = tmp.path().join("Materials");
@@ -1588,9 +1592,13 @@ mod tests {
             a.canonicalize()?.to_string_lossy().into_owned(),
             b.canonicalize()?.to_string_lossy().into_owned(),
         ];
+        let resolver = DefaultResolver::new();
         // `../Materials/Materials.usd` written inside `Props/link.usd`
         // should resolve to identifier index 1 (the Materials.usd).
-        assert_eq!(find_layer("../Materials/Materials.usd", &identifiers), Some(1));
+        assert_eq!(
+            find_layer("../Materials/Materials.usd", &identifiers, &resolver),
+            Some(1)
+        );
         Ok(())
     }
 
@@ -1627,7 +1635,7 @@ mod tests {
             "should have node from C.usd via nested reference"
         );
 
-        let a_idx = find_layer("A.usd", &stack.identifiers).unwrap();
+        let a_idx = find_layer("A.usd", &stack.identifiers, &*stack.resolver).unwrap();
         let a_attr_path = Path::new("/A.A_attr").unwrap();
         assert!(
             stack.layer(a_idx).has_spec(&a_attr_path),
@@ -1673,7 +1681,7 @@ mod tests {
         let stack = load_stack(&path)?;
 
         assert!(
-            find_layer("camera_perspective.usd", &stack.identifiers).is_some(),
+            find_layer("camera_perspective.usd", &stack.identifiers, &*stack.resolver).is_some(),
             "camera_perspective.usd should be collected from variant reference"
         );
 
@@ -1745,7 +1753,7 @@ def "Root" (
         );
         let layers = vec![a, b];
         let ids = vec!["a.usd".to_string(), "b.usd".to_string()];
-        let stack = LayerStack::new(layers, ids, 0);
+        let stack = LayerStack::new(layers, ids, 0, Box::new(DefaultResolver::new()));
 
         let result = PrimIndex::build_with_context(&Path::from("/Root"), &stack, &CompositionContext::default());
         assert!(
@@ -1769,7 +1777,7 @@ def "Prim" (
         );
         let layers = vec![layer];
         let ids = vec!["test.usda".to_string()];
-        let stack = LayerStack::new(layers, ids, 0);
+        let stack = LayerStack::new(layers, ids, 0, Box::new(DefaultResolver::new()));
 
         let result = PrimIndex::build_with_context(&Path::from("/Prim"), &stack, &CompositionContext::default());
         assert!(
@@ -1795,7 +1803,7 @@ def "Prim" (
         let target = parse_usda("#usda 1.0\ndef \"Foo\" {}\n");
         let layers = vec![root, target];
         let ids = vec!["root.usda".to_string(), "target.usda".to_string()];
-        let stack = LayerStack::new(layers, ids, 0);
+        let stack = LayerStack::new(layers, ids, 0, Box::new(DefaultResolver::new()));
 
         let result = PrimIndex::build_with_context(&Path::from("/Prim"), &stack, &CompositionContext::default());
         assert!(

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -1323,8 +1323,14 @@ fn collect_payloads_in(nodes: &[Node], layers: &[LayerData]) -> Vec<Payload> {
 
 /// Finds a layer index whose identifier matches `asset_path`.
 ///
-/// Tries an exact match first, then falls back to suffix matching at a
-/// path separator boundary. Strips leading `./` before matching.
+/// Tries an exact match first, then suffix-matches at a path-separator
+/// boundary. Relative paths (`./foo`, `../foo`) won't suffix-match a
+/// canonical absolute identifier; for those, anchor the needle against
+/// each candidate identifier's parent directory, canonicalize, and look
+/// the result back up in the layer stack. Without this, multi-file
+/// asset hierarchies whose sub-layers reference siblings via parent-
+/// traversal paths (e.g. `../Materials/Materials.usd` from a prop
+/// USD) fail every composition lookup with `UnresolvedLayer`.
 pub(super) fn find_layer(asset_path: &str, identifiers: &[String]) -> Option<usize> {
     let sep = std::path::MAIN_SEPARATOR as u8;
     let needle = asset_path.strip_prefix("./").unwrap_or(asset_path);
@@ -1338,6 +1344,29 @@ pub(super) fn find_layer(asset_path: &str, identifiers: &[String]) -> Option<usi
             let prefix_len = id.len() - needle.len();
             if prefix_len > 0 && id.as_bytes()[prefix_len - 1] == sep {
                 return Some(i);
+            }
+        }
+    }
+
+    let needs_anchor = needle.starts_with("./")
+        || needle.starts_with("../")
+        || needle.starts_with(".\\")
+        || needle.starts_with("..\\");
+    if needs_anchor {
+        let needle_path = std::path::Path::new(needle);
+        for id in identifiers.iter() {
+            let id_path = std::path::Path::new(id);
+            let Some(parent) = id_path.parent() else {
+                continue;
+            };
+            let candidate = parent.join(needle_path);
+            let Ok(canonical) = candidate.canonicalize() else {
+                continue;
+            };
+            for (j, other) in identifiers.iter().enumerate() {
+                if std::path::Path::new(other) == canonical {
+                    return Some(j);
+                }
             }
         }
     }
@@ -1534,6 +1563,37 @@ mod tests {
     fn find_layer_not_found() -> Result<()> {
         let (_, ids) = load_layers(&fixture_path("ref_external.usda"))?;
         assert!(find_layer("nonexistent.usda", &ids).is_none());
+        Ok(())
+    }
+
+    /// Relative paths (`./foo`, `../foo`) must anchor against each
+    /// candidate identifier's parent directory. Without this, a
+    /// reference authored inside one sub-USD cannot be matched
+    /// against the loaded sibling layer's canonical identifier.
+    #[test]
+    fn find_layer_relative_parent_anchored() -> Result<()> {
+        // Fixture: two real files in different sibling dirs of the
+        // crate's `fixtures/` tree. We want a `../<other dir>/<file>`
+        // reference written from one to the other to resolve.
+        let tmp = tempfile::tempdir()?;
+        let a_dir = tmp.path().join("Props");
+        let b_dir = tmp.path().join("Materials");
+        std::fs::create_dir_all(&a_dir)?;
+        std::fs::create_dir_all(&b_dir)?;
+        let a = a_dir.join("link.usd");
+        let b = b_dir.join("Materials.usd");
+        std::fs::write(&a, b"placeholder")?;
+        std::fs::write(&b, b"placeholder")?;
+        let identifiers = vec![
+            a.canonicalize()?.to_string_lossy().into_owned(),
+            b.canonicalize()?.to_string_lossy().into_owned(),
+        ];
+        // `../Materials/Materials.usd` written inside `Props/link.usd`
+        // should resolve to identifier index 1 (the Materials.usd).
+        assert_eq!(
+            find_layer("../Materials/Materials.usd", &identifiers),
+            Some(1)
+        );
         Ok(())
     }
 

--- a/src/pcp/mod.rs
+++ b/src/pcp/mod.rs
@@ -101,6 +101,7 @@ mod rel;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use crate::ar::Resolver;
 use crate::sdf::schema::FieldKey;
 use crate::sdf::{self, LayerData, Path, Value};
 
@@ -183,13 +184,20 @@ pub(crate) struct LayerStack {
     /// stack that contains it. Precomputed from `sublayer_stacks` to keep
     /// per-prim composition off the linear-scan hot path.
     layer_offsets: HashMap<usize, sdf::LayerOffset>,
+    /// Resolver used to anchor relative asset paths when locating layers.
+    pub(crate) resolver: Box<dyn Resolver>,
 }
 
 impl LayerStack {
     /// Creates a new layer stack, precomputing sublayer ordering.
-    pub fn new(layers: Vec<LayerData>, identifiers: Vec<String>, session_layer_count: usize) -> Self {
+    pub fn new(
+        layers: Vec<LayerData>,
+        identifiers: Vec<String>,
+        session_layer_count: usize,
+        resolver: Box<dyn Resolver>,
+    ) -> Self {
         let sublayer_stacks: SublayerStacks = (0..layers.len())
-            .map(|i| (i, Self::build_sublayer_stack(i, &layers, &identifiers)))
+            .map(|i| (i, Self::build_sublayer_stack(i, &layers, &identifiers, &*resolver)))
             .collect();
         let mut layer_offsets: HashMap<usize, sdf::LayerOffset> = HashMap::new();
         for stack in sublayer_stacks.values() {
@@ -203,6 +211,7 @@ impl LayerStack {
             sublayer_stacks,
             session_layer_count,
             layer_offsets,
+            resolver,
         }
     }
 
@@ -248,6 +257,7 @@ impl LayerStack {
         root_layer: usize,
         layers: &[LayerData],
         identifiers: &[String],
+        resolver: &dyn Resolver,
     ) -> Vec<(usize, sdf::LayerOffset)> {
         let mut stack: Vec<(usize, sdf::LayerOffset)> = vec![(root_layer, sdf::LayerOffset::IDENTITY)];
         let mut seen: HashSet<usize> = HashSet::new();
@@ -277,7 +287,7 @@ impl LayerStack {
                 .unwrap_or_default();
 
             for (i, sub_path) in sub_paths.into_iter().enumerate() {
-                let Some(sub_idx) = index::find_layer(&sub_path, identifiers) else {
+                let Some(sub_idx) = index::find_layer(&sub_path, identifiers, resolver) else {
                     continue;
                 };
                 if !seen.insert(sub_idx) {

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -87,7 +87,8 @@ impl Stage {
     ///
     /// `session_layers` are prepended at the front of the layer stack so they
     /// hold the strongest opinions (stronger than the root layer).
-    fn from_layers(
+    fn from_layers<R: Resolver + 'static>(
+        resolver: R,
         session_layers: Vec<layer::Layer>,
         root_layers: Vec<layer::Layer>,
         on_composition_error: Box<dyn Fn(pcp::Error) -> Result<()>>,
@@ -103,7 +104,7 @@ impl Stage {
             layers.push(layer.data);
         }
 
-        let stack = pcp::LayerStack::new(layers, identifiers, session_layer_count);
+        let stack = pcp::LayerStack::new(layers, identifiers, session_layer_count, Box::new(resolver));
         Self {
             graph: RefCell::new(pcp::Cache::new(stack, variant_fallbacks)),
             on_composition_error,
@@ -362,6 +363,7 @@ impl<R: Resolver, E: Fn(CompositionError) -> Result<()>> StageBuilder<R, E> {
     /// Opens a stage from a root layer file.
     pub fn open(self, root_path: &str) -> Result<Stage>
     where
+        R: 'static,
         E: 'static,
     {
         let on_error = self.on_error;
@@ -379,6 +381,7 @@ impl<R: Resolver, E: Fn(CompositionError) -> Result<()>> StageBuilder<R, E> {
 
         let pcp_handler = Box::new(move |e: pcp::Error| on_error(CompositionError::Pcp(e)));
         Ok(Stage::from_layers(
+            self.resolver,
             session_layers,
             root_layers,
             pcp_handler,


### PR DESCRIPTION
Fixes #66.

## Problem

`pcp::index::find_layer` resolves an incoming `asset_path` against the layer stack using only:

1. exact equality with a canonical identifier, and
2. suffix match preceded by `MAIN_SEPARATOR`.

A relative needle like `../Materials/Materials.usd` never matches the canonical absolute identifier `/abs/path/.../Robot/Materials/Materials.usd`, even though `layer::collect_layers` did register the resolved sub-layer correctly. The lookup returns `None`, the arc surfaces as `UnresolvedLayer`, and the entire referenced sub-graph is silently dropped from the composed stage.

This affects any multi-file asset hierarchy that organises shared content (materials, physics, lights) in sibling directories and references it via parent-traversal paths.

## Fix

When the needle is parent-relative (`./` / `../` / Windows variants), additionally try anchoring it against each existing identifier's parent directory, canonicalize, and look the result back up in the layer stack. The existing exact / suffix comparison stays as the fast first attempt; the anchored fallback only fires when:

- the needle is parent-relative, and
- the cheap match already failed.

Behaviour for absolute paths and already-resolved canonical identifiers is unchanged. New unit test (`find_layer_relative_parent_anchored`) uses `tempfile` to set up real on-disk parent dirs and verifies a `../sibling.usd` needle resolves to the matching absolute identifier.

## Impact (downstream Bevy viewer rendering `franka.usd`)

**Before** — 134 prims, no `Looks` subtree, every Mesh falls back to the engine default material:

<img width="1392" height="933" alt="image" src="https://github.com/user-attachments/assets/a6b851e0-f7e3-4012-a897-afc5be2fb4c9" />

**After** — 409 prims, full `Looks` subtree resolved (`Aluminum`, `PlasticBlack`, `PlasticGray`, `PlasticWhite`, `RubberGray`, `RubberGreen`, …), bound materials drive correct shading:

<img width="1394" height="932" alt="image" src="https://github.com/user-attachments/assets/f39fb563-922e-4aa6-a660-1e5d868a9855" />

## Tests

- `cargo test` — all 347 lib tests pass, including the new `find_layer_relative_parent_anchored`.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean on the diff. (One pre-existing lint in `pcp/cache.rs:303` originates from upstream commit `37e6cba4`, unrelated to this change.)
