### PR TITLE
feat(skel): UsdSkel reader + skinning toolkit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["usd", "usda", "usdc", "usdz", "pxr"]
 
 [features]
 physics = []
+skel = []
 serde = ["dep:serde", "half/serde"]
 
 [dependencies]
@@ -51,3 +52,7 @@ required-features = ["serde"]
 [[test]]
 name = "physics_reader"
 required-features = ["physics"]
+
+[[test]]
+name = "skel_reader"
+required-features = ["skel"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,7 +178,7 @@ Features from the C++ reference implementation not covered by the core specifica
 | [UsdGeom](https://openusd.org/release/api/usd_geom_page_front.html) (geometry, transforms, cameras) | :construction: | | |
 | [UsdShade](https://openusd.org/release/api/usd_shade_page_front.html) (materials, shaders) | :construction: | | |
 | [UsdLux](https://openusd.org/release/api/usd_lux_page_front.html) (lighting) | :construction: | | |
-| [UsdSkel](https://openusd.org/release/api/usd_skel_page_front.html) (skeletons, skinning) | :construction: | | |
+| [UsdSkel](https://openusd.org/release/api/usd_skel_page_front.html) (skeletons, skinning) | :white_check_mark: | `main` | Schema reader behind `skel` feature. Covers `SkelRoot`, `Skeleton`, `SkelAnimation`, `BlendShape` (incl. inbetween shapes), and `SkelBindingAPI` with namespace-inherited `skel:skeleton` / `skel:animationSource`. No authoring helpers; stage-level interpolation of SkelAnimation time samples is left to the consumer. |
 | [UsdVol](https://openusd.org/release/api/usd_vol_page_front.html) (volumes) | :construction: | | |
 | [UsdPhysics](https://openusd.org/release/api/usd_physics_page_front.html) | :white_check_mark: | `main` | Schema reader behind `physics` feature. Covers all 8 prim types, 7 single-apply APIs, `LimitAPI` + `DriveAPI` multi-apply. No authoring helpers; `CollisionGroup` returns raw collection targets only. |
 | [UsdRender](https://openusd.org/release/api/usd_render_page_front.html) | :construction: | | |

--- a/fixtures/usdSkel_scene.usda
+++ b/fixtures/usdSkel_scene.usda
@@ -1,0 +1,86 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Y"
+    metersPerUnit = 1.0
+    doc = "UsdSkel reader integration test fixture: covers SkelRoot, Skeleton, SkelAnimation, BlendShape (with inbetweens), and SkelBindingAPI on a skinned Mesh."
+)
+
+def Xform "World"
+{
+    def SkelRoot "Character" (
+        prepend apiSchemas = ["SkelBindingAPI"]
+    )
+    {
+        float3[] extent = [(-1, 0, -1), (1, 2, 1)]
+        rel skel:skeleton = </World/Character/Rig>
+        rel skel:animationSource = </World/Character/Anim>
+
+        def Skeleton "Rig"
+        {
+            uniform token[] joints = ["Root", "Root/Hip", "Root/Hip/Knee"]
+            uniform matrix4d[] bindTransforms = [
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) ),
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 1, 0, 1) ),
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 2, 0, 1) ),
+            ]
+            uniform matrix4d[] restTransforms = [
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) ),
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 1, 0, 1) ),
+                ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 1, 0, 1) ),
+            ]
+        }
+
+        def SkelAnimation "Anim"
+        {
+            uniform token[] joints = ["Root", "Root/Hip", "Root/Hip/Knee"]
+            uniform token[] blendShapes = ["smile"]
+            float3[] translations.timeSamples = {
+                0: [(0, 0, 0), (0, 1, 0), (0, 1, 0)],
+                10: [(0, 0, 0), (0, 1.5, 0), (0, 1, 0)],
+            }
+            quatf[] rotations.timeSamples = {
+                0: [(1, 0, 0, 0), (1, 0, 0, 0), (1, 0, 0, 0)],
+                10: [(1, 0, 0, 0), (0.707, 0, 0, 0.707), (1, 0, 0, 0)],
+            }
+            float[] blendShapeWeights.timeSamples = {
+                0: [0.0],
+                10: [1.0],
+            }
+        }
+
+        def Mesh "Body" (
+            prepend apiSchemas = ["SkelBindingAPI"]
+        )
+        {
+            point3f[] points = [(-0.5, 0, -0.5), (0.5, 0, -0.5), (0.5, 0, 0.5), (-0.5, 0, 0.5)]
+            int[] faceVertexCounts = [4]
+            int[] faceVertexIndices = [0, 1, 2, 3]
+
+            uniform token[] skel:joints = ["Root/Hip", "Root/Hip/Knee"]
+            uniform token[] skel:blendShapes = ["smile"]
+            rel skel:blendShapeTargets = </World/Character/Smile>
+
+            int[] primvars:skel:jointIndices = [0, 0, 1, 1] (
+                interpolation = "vertex"
+                elementSize = 1
+            )
+            float[] primvars:skel:jointWeights = [1.0, 1.0, 1.0, 1.0] (
+                interpolation = "vertex"
+                elementSize = 1
+            )
+            matrix4d primvars:skel:geomBindTransform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+            uniform token primvars:skel:skinningMethod = "classicLinear"
+        }
+
+        def BlendShape "Smile"
+        {
+            uniform vector3f[] offsets = [(0, 0.1, 0), (0, 0.1, 0)]
+            uniform vector3f[] normalOffsets = [(0, 0, 0), (0, 0, 0)]
+            uniform int[] pointIndices = [0, 1]
+            uniform vector3f[] inbetweens:half (
+                weight = 0.5
+            ) = [(0, 0.04, 0), (0, 0.04, 0)]
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod pcp;
 #[cfg(feature = "physics")]
 pub mod physics;
 pub mod sdf;
+#[cfg(feature = "skel")]
+pub mod skel;
 pub mod stage;
 pub mod usda;
 pub mod usdc;

--- a/src/skel/anim_mapper.rs
+++ b/src/skel/anim_mapper.rs
@@ -26,6 +26,11 @@ pub struct AnimMapper {
     /// `indices[t]` = the source index that should land at target `t`,
     /// or [`MISSING`] if the target joint isn't in the source.
     indices: Vec<i32>,
+    /// Number of joints the mapper was constructed for on the source
+    /// side. [`remap`] / [`remap_with_stride`] assert that incoming
+    /// arrays match this length so callers fail fast on a mismatch
+    /// rather than picking up garbage.
+    source_len: usize,
     /// `true` iff `indices == [0, 1, 2, …, n-1]` AND `source.len() ==
     /// target.len()`. When set, [`remap`] is a straight clone.
     identity: bool,
@@ -48,6 +53,7 @@ impl AnimMapper {
         let identity = source.len() == target.len() && indices.iter().enumerate().all(|(i, &j)| j == i as i32);
         Self {
             indices,
+            source_len: source.len(),
             identity,
             full,
         }
@@ -58,9 +64,25 @@ impl AnimMapper {
         &self.indices
     }
 
+    /// Number of joints the mapper expects on the source side.
+    pub fn source_len(&self) -> usize {
+        self.source_len
+    }
+
     /// Number of joints in the target ordering.
     pub fn target_len(&self) -> usize {
         self.indices.len()
+    }
+
+    /// Source index that lands at target slot `target`, or [`None`]
+    /// when the target joint isn't present in the source. Hides the
+    /// internal sentinel encoding from callers — prefer this over
+    /// inspecting [`indices`] directly.
+    pub fn source_index(&self, target: usize) -> Option<usize> {
+        match self.indices.get(target).copied()? {
+            MISSING => None,
+            i => Some(i as usize),
+        }
     }
 
     /// `true` when the mapper is a no-op (source order equals target
@@ -84,9 +106,16 @@ impl AnimMapper {
 
     /// Remap a per-joint array `source` (one element per source
     /// joint) into target order. Missing entries get `default`.
-    /// Panics if `source.len()` doesn't match the source length the
-    /// mapper was built with.
+    ///
+    /// Panics when `source.len() != self.source_len()`.
     pub fn remap<T: Clone>(&self, source: &[T], default: T) -> Vec<T> {
+        assert_eq!(
+            source.len(),
+            self.source_len,
+            "AnimMapper::remap: source length {} != mapper source length {}",
+            source.len(),
+            self.source_len
+        );
         if self.identity {
             return source.to_vec();
         }
@@ -106,7 +135,19 @@ impl AnimMapper {
     /// matrix data stored as a flat `Vec<f64>` (stride = 16) or any
     /// other strided per-joint buffer. `default` is the value to copy
     /// into each entry of a missing slot.
+    ///
+    /// Panics when `source.len() != self.source_len() * stride`.
     pub fn remap_with_stride<T: Copy>(&self, source: &[T], stride: usize, default: T) -> Vec<T> {
+        let expected = self.source_len * stride;
+        assert_eq!(
+            source.len(),
+            expected,
+            "AnimMapper::remap_with_stride: source length {} != source_len {} * stride {} = {}",
+            source.len(),
+            self.source_len,
+            stride,
+            expected
+        );
         let mut out = Vec::with_capacity(self.indices.len() * stride);
         for &i in &self.indices {
             if i == MISSING {
@@ -152,6 +193,20 @@ mod tests {
         assert!(m.is_sparse());
         assert_eq!(m.indices(), &[0, MISSING]);
         assert_eq!(m.remap(&[42], 0), vec![42, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "source length")]
+    fn remap_rejects_wrong_source_length() {
+        let m = AnimMapper::new(&s(&["A", "B"]), &s(&["A", "B"]));
+        let _ = m.remap(&[1], 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "source length")]
+    fn remap_with_stride_rejects_wrong_source_length() {
+        let m = AnimMapper::new(&s(&["A", "B"]), &s(&["A"]));
+        let _ = m.remap_with_stride(&[0.0_f32; 7], 4, 0.0);
     }
 
     #[test]

--- a/src/skel/anim_mapper.rs
+++ b/src/skel/anim_mapper.rs
@@ -1,0 +1,168 @@
+//! Per-joint array remapping between two joint orderings.
+//!
+//! Mirrors Pixar's `UsdSkelAnimMapper`. Built from a *source* joint
+//! order (e.g. a SkelAnimation's `joints`) and a *target* joint order
+//! (e.g. a bound Skeleton's `joints`, or a per-mesh `skel:joints`
+//! subset). The resulting mapper can then transfer arrays whose
+//! per-joint stride is known — translations (`[f32; 3]`), rotations
+//! (`[f32; 4]`), scales, etc. — from source into target order
+//! efficiently.
+//!
+//! Joints present in the target but not in the source are filled with
+//! a caller-supplied default value. Joints present in the source but
+//! not in the target are dropped.
+
+/// Index `i` in [`AnimMapper::indices`] is the position in the source
+/// array of the joint that should land at target index `i`, or
+/// [`MISSING`] when the target joint isn't present in the source.
+pub const MISSING: i32 = -1;
+
+/// Pre-computed source→target remap. Build with
+/// [`AnimMapper::new`]; apply with [`AnimMapper::remap`] (or
+/// [`AnimMapper::remap_with_stride`] when each joint slot is a flat
+/// sub-array — useful for matrix data laid out as `[f64; 16]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnimMapper {
+    /// `indices[t]` = the source index that should land at target `t`,
+    /// or [`MISSING`] if the target joint isn't in the source.
+    indices: Vec<i32>,
+    /// `true` iff `indices == [0, 1, 2, …, n-1]` AND `source.len() ==
+    /// target.len()`. When set, [`remap`] is a straight clone.
+    identity: bool,
+    /// `true` iff every target joint resolved to a source slot — i.e.
+    /// no [`MISSING`] entries. When set the fill value is unused.
+    full: bool,
+}
+
+impl AnimMapper {
+    /// Build a mapper that translates per-joint arrays in `source`
+    /// order into `target` order.
+    pub fn new(source: &[String], target: &[String]) -> Self {
+        use std::collections::HashMap;
+        let by_name: HashMap<&str, i32> = source.iter().enumerate().map(|(i, n)| (n.as_str(), i as i32)).collect();
+        let indices: Vec<i32> = target
+            .iter()
+            .map(|n| by_name.get(n.as_str()).copied().unwrap_or(MISSING))
+            .collect();
+        let full = indices.iter().all(|&i| i != MISSING);
+        let identity = source.len() == target.len() && indices.iter().enumerate().all(|(i, &j)| j == i as i32);
+        Self {
+            indices,
+            identity,
+            full,
+        }
+    }
+
+    /// Borrow the underlying source-index array.
+    pub fn indices(&self) -> &[i32] {
+        &self.indices
+    }
+
+    /// Number of joints in the target ordering.
+    pub fn target_len(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// `true` when the mapper is a no-op (source order equals target
+    /// order). [`remap`] still works but skipping it entirely is
+    /// cheaper.
+    pub fn is_identity(&self) -> bool {
+        self.identity
+    }
+
+    /// `true` when every target joint resolved to a source slot.
+    pub fn is_full(&self) -> bool {
+        self.full
+    }
+
+    /// `true` when at least one target joint is missing from the
+    /// source — i.e. [`remap`] will fall back to the caller's
+    /// `default` for some entries.
+    pub fn is_sparse(&self) -> bool {
+        !self.full
+    }
+
+    /// Remap a per-joint array `source` (one element per source
+    /// joint) into target order. Missing entries get `default`.
+    /// Panics if `source.len()` doesn't match the source length the
+    /// mapper was built with.
+    pub fn remap<T: Clone>(&self, source: &[T], default: T) -> Vec<T> {
+        if self.identity {
+            return source.to_vec();
+        }
+        self.indices
+            .iter()
+            .map(|&i| {
+                if i == MISSING {
+                    default.clone()
+                } else {
+                    source[i as usize].clone()
+                }
+            })
+            .collect()
+    }
+
+    /// Remap a flat array of `stride`-sized slots — useful for
+    /// matrix data stored as a flat `Vec<f64>` (stride = 16) or any
+    /// other strided per-joint buffer. `default` is the value to copy
+    /// into each entry of a missing slot.
+    pub fn remap_with_stride<T: Copy>(&self, source: &[T], stride: usize, default: T) -> Vec<T> {
+        let mut out = Vec::with_capacity(self.indices.len() * stride);
+        for &i in &self.indices {
+            if i == MISSING {
+                for _ in 0..stride {
+                    out.push(default);
+                }
+            } else {
+                let start = (i as usize) * stride;
+                out.extend_from_slice(&source[start..start + stride]);
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn identity_when_orders_match() {
+        let m = AnimMapper::new(&s(&["A", "B", "C"]), &s(&["A", "B", "C"]));
+        assert!(m.is_identity());
+        assert!(m.is_full());
+        assert_eq!(m.remap(&[10, 20, 30], 0), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn reorders_when_target_permutes() {
+        let m = AnimMapper::new(&s(&["A", "B", "C"]), &s(&["C", "A", "B"]));
+        assert!(!m.is_identity());
+        assert!(m.is_full());
+        assert_eq!(m.remap(&[1.0, 2.0, 3.0], 0.0), vec![3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn fills_missing_with_default() {
+        let m = AnimMapper::new(&s(&["A"]), &s(&["A", "B"]));
+        assert!(m.is_sparse());
+        assert_eq!(m.indices(), &[0, MISSING]);
+        assert_eq!(m.remap(&[42], 0), vec![42, 0]);
+    }
+
+    #[test]
+    fn remap_with_stride_handles_flat_matrices() {
+        // Two source joints, each a stride-4 row.
+        let src = [
+            1.0, 2.0, 3.0, 4.0, // joint A
+            5.0, 6.0, 7.0, 8.0, // joint B
+        ];
+        let m = AnimMapper::new(&s(&["A", "B"]), &s(&["B", "missing", "A"]));
+        let out = m.remap_with_stride(&src, 4, 0.0);
+        assert_eq!(out, vec![5.0, 6.0, 7.0, 8.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+}

--- a/src/skel/binding.rs
+++ b/src/skel/binding.rs
@@ -1,0 +1,129 @@
+//! Aggregate binding discovery: walk a SkelRoot subtree once and
+//! return every `(skeleton, skinned_prim, animation_source)` tuple.
+//!
+//! Covers the "Discovering Bindings On Skinnable Primitives" entry
+//! point from the UsdSkel API intro. The C++ implementation hangs
+//! this off a stateful `UsdSkelCache` populated against a SkelRoot;
+//! the Rust port keeps it stateless — one walk, one allocation, plain
+//! returned data.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::Stage;
+
+use super::read::{read_inherited_animation_source, read_inherited_skeleton, read_skel_binding};
+use super::tokens::{API_SKEL_BINDING, T_SKELETON, T_SKEL_ROOT};
+use super::types::ReadSkelBinding;
+
+/// One discovered skinned-prim binding under a SkelRoot.
+///
+/// All paths are the prim paths as they appear on the composed stage.
+/// `binding` carries the per-mesh `SkelBindingAPI` data verbatim;
+/// `skeleton` / `animation_source` are the *resolved* paths, walking
+/// up the namespace to find the nearest authored binding (per Pixar's
+/// inheritance rule).
+#[derive(Debug, Clone)]
+pub struct SkelBinding {
+    /// Path of the skinned prim (typically a Mesh) carrying
+    /// `SkelBindingAPI`.
+    pub prim: String,
+    /// Resolved `skel:skeleton` target. `None` when no ancestor
+    /// (including the prim itself) authors one.
+    pub skeleton: Option<String>,
+    /// Resolved `skel:animationSource` target. `None` when no
+    /// ancestor authors one.
+    pub animation_source: Option<String>,
+    /// The raw `SkelBindingAPI` data authored on `prim`.
+    pub binding: ReadSkelBinding,
+}
+
+/// Discover every skinnable prim under `skel_root` and resolve each
+/// one's inherited skeleton + animation source.
+///
+/// Mirrors Pixar's `UsdSkelCache::ComputeSkelBindings`, but stateless:
+/// the cache pattern doesn't carry its weight in a non-thread-pool
+/// single-shot reader. Callers that need to cache results can hold
+/// the returned `Vec` for as long as they want.
+///
+/// `skel_root` is expected to be the path of a `SkelRoot` prim; this
+/// function does NOT walk outside its subtree (per the UsdSkel rule
+/// that SkelRoot is the enclosing scope for skeletal processing).
+pub fn discover_bindings(stage: &Stage, skel_root: &Path) -> Result<Vec<SkelBinding>> {
+    let prefix = skel_root.as_str().to_string();
+    let mut out = Vec::new();
+    stage.traverse(|path| {
+        let p = path.as_str();
+        // Restrict to the SkelRoot's subtree. Pixar's UsdSkel allows
+        // SkelRoot to be the root itself (path = "/"), in which case
+        // the prefix check trivially holds.
+        if !is_under(p, &prefix) {
+            return;
+        }
+        let api = match stage.api_schemas(path) {
+            Ok(api) => api,
+            Err(_) => return,
+        };
+        if !api.iter().any(|s| s == API_SKEL_BINDING) {
+            return;
+        }
+        let binding = match read_skel_binding(stage, path) {
+            Ok(Some(b)) => b,
+            _ => return,
+        };
+        let skeleton = read_inherited_skeleton(stage, path).ok().flatten();
+        let animation_source = read_inherited_animation_source(stage, path).ok().flatten();
+        out.push(SkelBinding {
+            prim: p.to_string(),
+            skeleton,
+            animation_source,
+            binding,
+        });
+    })?;
+    Ok(out)
+}
+
+/// Discover every `Skeleton` prim under `skel_root`. Useful when a
+/// SkelRoot encloses multiple skeletons (the spec permits this; the
+/// AnimationSource binding then has to be authored carefully to
+/// disambiguate which skeleton each animation drives).
+pub fn discover_skeletons(stage: &Stage, skel_root: &Path) -> Result<Vec<String>> {
+    let prefix = skel_root.as_str().to_string();
+    let mut out = Vec::new();
+    stage.traverse(|path| {
+        let p = path.as_str();
+        if !is_under(p, &prefix) {
+            return;
+        }
+        if let Ok(Some(t)) = stage.type_name(path) {
+            if t == T_SKELETON {
+                out.push(p.to_string());
+            }
+        }
+    })?;
+    Ok(out)
+}
+
+/// Find every `SkelRoot` prim on a stage. Convenience entry point
+/// for tools that don't know upfront where the SkelRoots live.
+pub fn find_skel_roots(stage: &Stage) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    stage.traverse(|path| {
+        if let Ok(Some(t)) = stage.type_name(path) {
+            if t == T_SKEL_ROOT {
+                out.push(path.as_str().to_string());
+            }
+        }
+    })?;
+    Ok(out)
+}
+
+fn is_under(path: &str, prefix: &str) -> bool {
+    if prefix == "/" {
+        return true;
+    }
+    if path == prefix {
+        return true;
+    }
+    path.starts_with(prefix) && path.as_bytes().get(prefix.len()) == Some(&b'/')
+}

--- a/src/skel/mod.rs
+++ b/src/skel/mod.rs
@@ -1,0 +1,89 @@
+//! UsdSkel schema reader and skinning toolkit.
+//!
+//! Decodes Pixar's `UsdSkel` schema family from a composed
+//! [`crate::Stage`], plus the time-independent half of Pixar's
+//! UsdSkel object model: topology, animation-to-skeleton mappers,
+//! per-mesh skinning resolvers, and pure-math helpers for linear
+//! blend skinning and blend-shape application.
+//!
+//! Time-dependent evaluation (interpolating SkelAnimation samples at
+//! a stage time, computing per-frame skinning transforms) is the job
+//! of the upcoming `anim` layer. The resolvers here are designed to
+//! plug straight into that work — every API that would need a
+//! `UsdTimeCode` instead takes the already-evaluated joint poses.
+//!
+//! # Schemas
+//!
+//! Concrete prim types:
+//! - [`tokens::T_SKEL_ROOT`] — encapsulating scope for skeletal
+//!   processing; carries an authored `extent`.
+//! - [`tokens::T_SKELETON`] — joint topology + bind / rest poses.
+//! - [`tokens::T_SKEL_ANIMATION`] — time-sampled joint transforms and
+//!   blend-shape weights.
+//! - [`tokens::T_BLEND_SHAPE`] — per-vertex position / normal offsets
+//!   with optional inbetween shapes.
+//!
+//! API schemas:
+//! - [`tokens::API_SKEL_BINDING`] — applied to skinnable prims
+//!   (typically Meshes) to wire joint influences, blend shapes,
+//!   `skel:skeleton`, and `skel:animationSource`.
+//!
+//! # Conventions
+//!
+//! Reader functions return values in the scene's authored units:
+//! - Matrices are row-major flattened 4×4 (`[f64; 16]`).
+//! - Quaternions stay in USD's textual `(w, x, y, z)` order.
+//! - Half-precision storage (`half3[] scales`, `quath[] rotations`) is
+//!   widened to `f32` so callers don't need to depend on the `half`
+//!   crate transitively.
+//! - `bindTransforms` are world-space; `restTransforms` are joint-local
+//!   space (parent-relative).
+//!
+//! # Inheritance
+//!
+//! `skel:skeleton` and `skel:animationSource` are inheritable down
+//! namespace. [`read_skel_binding`] reports only the values authored
+//! directly on the queried prim; use [`read_inherited_skeleton`] /
+//! [`read_inherited_animation_source`] to resolve the nearest-ancestor
+//! binding. [`discover_bindings`] does that walk for every skinnable
+//! prim under a SkelRoot in one pass.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use openusd::{skel, sdf, Stage};
+//!
+//! let stage = Stage::open("character.usda")?;
+//! for root in skel::find_skel_roots(&stage)? {
+//!     let root = sdf::path(&root)?;
+//!     for b in skel::discover_bindings(&stage, &root)? {
+//!         println!("{} bound to {:?}", b.prim, b.skeleton);
+//!     }
+//! }
+//! # anyhow::Ok(())
+//! ```
+
+pub mod tokens;
+
+mod anim_mapper;
+mod binding;
+mod read;
+mod skeleton_query;
+pub mod skinning;
+mod skinning_query;
+mod topology;
+mod types;
+
+pub use anim_mapper::{AnimMapper, MISSING};
+pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
+pub use read::{
+    find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,
+    read_skel_binding, read_skel_root, read_skeleton,
+};
+pub use skeleton_query::SkeletonResolver;
+pub use skinning_query::SkinningResolver;
+pub use topology::{Topology, TopologyError, NO_PARENT};
+pub use types::{
+    InfluenceInterpolation, ReadBlendShape, ReadInbetween, ReadSkelAnimation, ReadSkelBinding, ReadSkelRoot,
+    ReadSkeleton, SkelPrims, SkinningMethod,
+};

--- a/src/skel/read.rs
+++ b/src/skel/read.rs
@@ -120,6 +120,10 @@ fn read_inbetweens(stage: &Stage, prim: &Path) -> Result<Vec<ReadInbetween>> {
         let offsets = match stage.field::<Value>(attr_path.clone(), "default")? {
             Some(Value::Vec3fVec(v)) => v,
             Some(Value::Vec3dVec(v)) => v.into_iter().map(|a| [a[0] as f32, a[1] as f32, a[2] as f32]).collect(),
+            Some(Value::Vec3hVec(v)) => v
+                .into_iter()
+                .map(|a| [a[0].to_f32(), a[1].to_f32(), a[2].to_f32()])
+                .collect(),
             _ => Vec::new(),
         };
         let weight = match stage.field::<Value>(attr_path, META_WEIGHT)? {

--- a/src/skel/read.rs
+++ b/src/skel/read.rs
@@ -1,0 +1,437 @@
+//! Reader functions for the [UsdSkel](super) schema family.
+//!
+//! Each `read_*` helper takes a composed [`Stage`] plus the prim
+//! [`Path`] to inspect, returns the decoded struct (or [`None`] when
+//! the schema isn't applied / the prim isn't of the expected type),
+//! or surfaces a `Result` for IO / decode errors.
+//!
+//! Numeric conventions follow USD's authored form:
+//! - Matrices are row-major flattened (16 doubles for 4×4).
+//! - Quaternions are USD's `(w, x, y, z)` order.
+//! - Half-precision storage (`half3[] scales`, `quath[] rotations`) is
+//!   widened to `f32` so callers don't need the `half` crate.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value};
+use crate::Stage;
+
+use super::tokens::*;
+use super::types::*;
+
+/// Read a `SkelRoot` prim. Returns `None` when the prim isn't typed
+/// `SkelRoot`.
+pub fn read_skel_root(stage: &Stage, prim: &Path) -> Result<Option<ReadSkelRoot>> {
+    if stage.type_name(prim)?.as_deref() != Some(T_SKEL_ROOT) {
+        return Ok(None);
+    }
+    let extent = read_extent(stage, prim)?;
+    Ok(Some(ReadSkelRoot {
+        path: prim.as_str().to_string(),
+        extent,
+    }))
+}
+
+/// Read a `Skeleton` prim. Returns `None` when the prim isn't typed
+/// `Skeleton`.
+pub fn read_skeleton(stage: &Stage, prim: &Path) -> Result<Option<ReadSkeleton>> {
+    if stage.type_name(prim)?.as_deref() != Some(T_SKELETON) {
+        return Ok(None);
+    }
+    let joints = read_token_vec(stage, prim, A_JOINTS)?;
+    let bind_transforms = read_mat4_vec(stage, prim, A_BIND_TRANSFORMS)?;
+    let rest_transforms = read_mat4_vec(stage, prim, A_REST_TRANSFORMS)?;
+    Ok(Some(ReadSkeleton {
+        path: prim.as_str().to_string(),
+        joints,
+        bind_transforms,
+        rest_transforms,
+    }))
+}
+
+/// Read a `SkelAnimation` prim. Returns `None` when the prim isn't
+/// typed `SkelAnimation`.
+///
+/// Attributes that author only a `default` (no `timeSamples`) are
+/// surfaced as a single entry at time `0.0`, so the caller can treat
+/// static and animated SkelAnimations uniformly.
+pub fn read_skel_animation(stage: &Stage, prim: &Path) -> Result<Option<ReadSkelAnimation>> {
+    if stage.type_name(prim)?.as_deref() != Some(T_SKEL_ANIMATION) {
+        return Ok(None);
+    }
+    let joints = read_token_vec(stage, prim, A_JOINTS)?;
+    let blend_shapes = read_token_vec(stage, prim, A_BLEND_SHAPES)?;
+    let translations = read_vec3f_timed(stage, prim, A_TRANSLATIONS)?;
+    let rotations = read_quatf_timed(stage, prim, A_ROTATIONS)?;
+    let scales = read_vec3f_timed(stage, prim, A_SCALES)?;
+    let blend_shape_weights = read_float_timed(stage, prim, A_BLEND_SHAPE_WEIGHTS)?;
+    Ok(Some(ReadSkelAnimation {
+        path: prim.as_str().to_string(),
+        joints,
+        blend_shapes,
+        translations,
+        rotations,
+        scales,
+        blend_shape_weights,
+    }))
+}
+
+/// Read a `BlendShape` prim. Returns `None` when the prim isn't typed
+/// `BlendShape` or has no `offsets` authored.
+pub fn read_blend_shape(stage: &Stage, prim: &Path) -> Result<Option<ReadBlendShape>> {
+    if stage.type_name(prim)?.as_deref() != Some(T_BLEND_SHAPE) {
+        return Ok(None);
+    }
+    let offsets = read_vec3f_vec(stage, prim, A_OFFSETS)?;
+    if offsets.is_empty() {
+        return Ok(None);
+    }
+    let normal_offsets = read_vec3f_vec(stage, prim, A_NORMAL_OFFSETS)?;
+    let point_indices = read_int_vec(stage, prim, A_POINT_INDICES)?.unwrap_or_default();
+    let inbetweens = read_inbetweens(stage, prim)?;
+    Ok(Some(ReadBlendShape {
+        path: prim.as_str().to_string(),
+        offsets,
+        normal_offsets,
+        point_indices,
+        inbetweens,
+    }))
+}
+
+/// Read every `inbetweens:<name>` attribute authored on `prim`.
+///
+/// Walks the prim's property list looking for the `inbetweens:`
+/// namespace, then reads each one's `weight` metadata,
+/// `offsets`-style default value, and the matching
+/// `inbetweens:<name>:normalOffsets` sibling.
+fn read_inbetweens(stage: &Stage, prim: &Path) -> Result<Vec<ReadInbetween>> {
+    let mut out = Vec::new();
+    let props = stage.prim_properties(prim.clone())?;
+    for name in &props {
+        let Some(rest) = name.strip_prefix(NS_INBETWEENS) else {
+            continue;
+        };
+        // Skip the per-inbetween `normalOffsets` siblings — they're
+        // folded into the inbetween that names them.
+        if rest.contains(':') {
+            continue;
+        }
+        let attr_path = prim.append_property(name)?;
+        let offsets = match stage.field::<Value>(attr_path.clone(), "default")? {
+            Some(Value::Vec3fVec(v)) => v,
+            Some(Value::Vec3dVec(v)) => v.into_iter().map(|a| [a[0] as f32, a[1] as f32, a[2] as f32]).collect(),
+            _ => Vec::new(),
+        };
+        let weight = match stage.field::<Value>(attr_path, META_WEIGHT)? {
+            Some(Value::Float(f)) => Some(f),
+            Some(Value::Double(d)) => Some(d as f32),
+            _ => None,
+        };
+        let normal_offsets_name = format!("{NS_INBETWEENS}{rest}:{A_NORMAL_OFFSETS}");
+        let normal_offsets = if props.iter().any(|n| n == &normal_offsets_name) {
+            read_vec3f_vec(stage, prim, &normal_offsets_name)?
+        } else {
+            Vec::new()
+        };
+        out.push(ReadInbetween {
+            name: rest.to_string(),
+            weight,
+            offsets,
+            normal_offsets,
+        });
+    }
+    Ok(out)
+}
+
+/// Read `SkelBindingAPI` state from a prim. Returns `None` when the
+/// API isn't applied.
+///
+/// Note that `skel:skeleton` and `skel:animationSource` are inheritable
+/// down namespace — this function reports only the values authored
+/// *directly* on `prim`. Use [`read_inherited_skeleton`] /
+/// [`read_inherited_animation_source`] to walk ancestors.
+pub fn read_skel_binding(stage: &Stage, prim: &Path) -> Result<Option<ReadSkelBinding>> {
+    if !stage.has_api_schema(prim, API_SKEL_BINDING)? {
+        return Ok(None);
+    }
+    let skeleton = read_rel_first_target(stage, prim, REL_SKEL_SKELETON)?;
+    let animation_source = read_rel_first_target(stage, prim, REL_SKEL_ANIMATION_SOURCE)?;
+    let joint_indices = read_int_vec(stage, prim, A_JOINT_INDICES)?.unwrap_or_default();
+    let joint_weights = read_float_vec(stage, prim, A_JOINT_WEIGHTS)?.unwrap_or_default();
+    let elements_per_element = read_attr_field(stage, prim, A_JOINT_INDICES, META_ELEMENT_SIZE)?
+        .and_then(|v| match v {
+            Value::Int(n) => Some(n),
+            Value::Int64(n) => Some(n as i32),
+            _ => None,
+        })
+        .unwrap_or(1);
+    let interpolation = read_attr_field(stage, prim, A_JOINT_INDICES, META_INTERPOLATION)?
+        .and_then(|v| match v {
+            Value::Token(s) | Value::String(s) => InfluenceInterpolation::from_token(&s),
+            _ => None,
+        })
+        .unwrap_or(InfluenceInterpolation::Vertex);
+    let joint_subset = read_token_vec(stage, prim, A_SKEL_JOINTS)?;
+    let blend_shapes = read_token_vec(stage, prim, A_SKEL_BLEND_SHAPES)?;
+    let blend_shape_targets = read_rel_all_targets(stage, prim, REL_SKEL_BLEND_SHAPE_TARGETS)?;
+    let geom_bind_transform = read_mat4(stage, prim, A_GEOM_BIND_TRANSFORM)?;
+    let skinning_method = read_token(stage, prim, A_SKINNING_METHOD)?
+        .and_then(|s| SkinningMethod::from_token(&s))
+        .unwrap_or_default();
+    Ok(Some(ReadSkelBinding {
+        path: prim.as_str().to_string(),
+        skeleton,
+        animation_source,
+        joint_indices,
+        joint_weights,
+        elements_per_element,
+        interpolation,
+        joint_subset,
+        blend_shapes,
+        blend_shape_targets,
+        geom_bind_transform,
+        skinning_method,
+    }))
+}
+
+/// Resolve the inherited `skel:skeleton` binding for `prim` by walking
+/// up its ancestors. Returns the rel target authored on the nearest
+/// ancestor (inclusive of `prim` itself) that has `SkelBindingAPI`
+/// applied and authors the rel, or `None` if no such ancestor exists.
+pub fn read_inherited_skeleton(stage: &Stage, prim: &Path) -> Result<Option<String>> {
+    read_inherited_rel(stage, prim, REL_SKEL_SKELETON)
+}
+
+/// Resolve the inherited `skel:animationSource` binding for `prim` by
+/// walking up its ancestors.
+pub fn read_inherited_animation_source(stage: &Stage, prim: &Path) -> Result<Option<String>> {
+    read_inherited_rel(stage, prim, REL_SKEL_ANIMATION_SOURCE)
+}
+
+fn read_inherited_rel(stage: &Stage, prim: &Path, rel_name: &str) -> Result<Option<String>> {
+    let mut cur = prim.clone();
+    loop {
+        if let Some(target) = read_rel_first_target(stage, &cur, rel_name)? {
+            return Ok(Some(target));
+        }
+        if cur.as_str() == "/" {
+            return Ok(None);
+        }
+        match cur.parent() {
+            Some(p) => cur = p,
+            None => return Ok(None),
+        }
+    }
+}
+
+/// Walk the entire stage once and return categorised path lists.
+/// Saves callers from re-walking for each schema family.
+pub fn find_skel_prims(stage: &Stage) -> Result<SkelPrims> {
+    let mut out = SkelPrims::default();
+    stage.traverse(|path| {
+        if let Ok(Some(type_name)) = stage.type_name(path) {
+            match type_name.as_str() {
+                T_SKEL_ROOT => out.skel_roots.push(path.as_str().to_string()),
+                T_SKELETON => out.skeletons.push(path.as_str().to_string()),
+                T_SKEL_ANIMATION => out.animations.push(path.as_str().to_string()),
+                T_BLEND_SHAPE => out.blend_shapes.push(path.as_str().to_string()),
+                _ => {}
+            }
+        }
+        if let Ok(api) = stage.api_schemas(path) {
+            if api.iter().any(|s| s == API_SKEL_BINDING) {
+                out.bindings.push(path.as_str().to_string());
+            }
+        }
+    })?;
+    Ok(out)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// internal value helpers
+// ────────────────────────────────────────────────────────────────────────
+
+fn read_attr_default(stage: &Stage, prim: &Path, name: &str) -> Result<Option<Value>> {
+    let attr_path = prim.append_property(name)?;
+    stage.field::<Value>(attr_path, "default")
+}
+
+fn read_attr_field(stage: &Stage, prim: &Path, attr_name: &str, field: &str) -> Result<Option<Value>> {
+    let attr_path = prim.append_property(attr_name)?;
+    stage.field::<Value>(attr_path, field)
+}
+
+fn read_token(stage: &Stage, prim: &Path, name: &str) -> Result<Option<String>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::Token(s)) | Some(Value::String(s)) => Some(s),
+        _ => None,
+    })
+}
+
+fn read_token_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<String>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::TokenVec(v)) | Some(Value::StringVec(v)) => v,
+        _ => Vec::new(),
+    })
+}
+
+fn read_int_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Option<Vec<i32>>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::IntVec(v)) => Some(v),
+        _ => None,
+    })
+}
+
+fn read_float_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Option<Vec<f32>>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::FloatVec(v)) => Some(v),
+        Some(Value::DoubleVec(v)) => Some(v.into_iter().map(|d| d as f32).collect()),
+        _ => None,
+    })
+}
+
+fn read_vec3f_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<[f32; 3]>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::Vec3fVec(v)) => v,
+        Some(Value::Vec3dVec(v)) => v.into_iter().map(|a| [a[0] as f32, a[1] as f32, a[2] as f32]).collect(),
+        Some(Value::Vec3hVec(v)) => v
+            .into_iter()
+            .map(|a| [a[0].to_f32(), a[1].to_f32(), a[2].to_f32()])
+            .collect(),
+        _ => Vec::new(),
+    })
+}
+
+fn read_mat4(stage: &Stage, prim: &Path, name: &str) -> Result<Option<[f64; 16]>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::Matrix4d(m)) => Some(m),
+        _ => None,
+    })
+}
+
+fn read_mat4_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<[f64; 16]>> {
+    Ok(match read_attr_default(stage, prim, name)? {
+        Some(Value::Matrix4dVec(v)) => v,
+        _ => Vec::new(),
+    })
+}
+
+fn read_extent(stage: &Stage, prim: &Path) -> Result<Option<[[f32; 3]; 2]>> {
+    let arr = read_vec3f_vec(stage, prim, A_EXTENT)?;
+    Ok(if arr.len() >= 2 { Some([arr[0], arr[1]]) } else { None })
+}
+
+fn read_rel_first_target(stage: &Stage, prim: &Path, rel_name: &str) -> Result<Option<String>> {
+    Ok(read_rel_all_targets(stage, prim, rel_name)?.into_iter().next())
+}
+
+fn read_rel_all_targets(stage: &Stage, prim: &Path, rel_name: &str) -> Result<Vec<String>> {
+    let rel_path = prim.append_property(rel_name)?;
+    let raw = stage.field::<Value>(rel_path, "targetPaths")?;
+    let paths = match raw {
+        Some(Value::PathListOp(op)) => op.flatten(),
+        Some(Value::PathVec(v)) => v,
+        _ => Vec::new(),
+    };
+    Ok(paths.into_iter().map(|p| p.as_str().to_string()).collect())
+}
+
+// ── time-sample readers ─────────────────────────────────────────────
+//
+// Each `read_*_timed` helper returns `Vec<(time, payload)>`.
+// `default`-only attributes are surfaced as a single sample at `t = 0.0`.
+// `timeSamples` are returned in authored order (the parser sorts
+// ascending by timecode).
+
+fn read_vec3f_timed(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<(f64, Vec<[f32; 3]>)>> {
+    let attr_path = prim.append_property(name)?;
+    if let Some(Value::TimeSamples(samples)) = stage.field::<Value>(attr_path.clone(), "timeSamples")? {
+        let mut out = Vec::with_capacity(samples.len());
+        for (t, v) in samples {
+            if let Some(arr) = value_to_vec3f_array(v) {
+                out.push((t, arr));
+            }
+        }
+        return Ok(out);
+    }
+    if let Some(arr) = stage
+        .field::<Value>(attr_path, "default")?
+        .and_then(value_to_vec3f_array)
+    {
+        return Ok(vec![(0.0, arr)]);
+    }
+    Ok(Vec::new())
+}
+
+fn read_quatf_timed(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<(f64, Vec<[f32; 4]>)>> {
+    let attr_path = prim.append_property(name)?;
+    if let Some(Value::TimeSamples(samples)) = stage.field::<Value>(attr_path.clone(), "timeSamples")? {
+        let mut out = Vec::with_capacity(samples.len());
+        for (t, v) in samples {
+            if let Some(arr) = value_to_quatf_array(v) {
+                out.push((t, arr));
+            }
+        }
+        return Ok(out);
+    }
+    if let Some(arr) = stage
+        .field::<Value>(attr_path, "default")?
+        .and_then(value_to_quatf_array)
+    {
+        return Ok(vec![(0.0, arr)]);
+    }
+    Ok(Vec::new())
+}
+
+fn read_float_timed(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<(f64, Vec<f32>)>> {
+    let attr_path = prim.append_property(name)?;
+    if let Some(Value::TimeSamples(samples)) = stage.field::<Value>(attr_path.clone(), "timeSamples")? {
+        let mut out = Vec::with_capacity(samples.len());
+        for (t, v) in samples {
+            if let Some(arr) = value_to_f32_array(v) {
+                out.push((t, arr));
+            }
+        }
+        return Ok(out);
+    }
+    if let Some(arr) = stage.field::<Value>(attr_path, "default")?.and_then(value_to_f32_array) {
+        return Ok(vec![(0.0, arr)]);
+    }
+    Ok(Vec::new())
+}
+
+fn value_to_vec3f_array(v: Value) -> Option<Vec<[f32; 3]>> {
+    Some(match v {
+        Value::Vec3fVec(v) => v,
+        Value::Vec3dVec(v) => v.into_iter().map(|a| [a[0] as f32, a[1] as f32, a[2] as f32]).collect(),
+        Value::Vec3hVec(v) => v
+            .into_iter()
+            .map(|a| [a[0].to_f32(), a[1].to_f32(), a[2].to_f32()])
+            .collect(),
+        _ => return None,
+    })
+}
+
+fn value_to_quatf_array(v: Value) -> Option<Vec<[f32; 4]>> {
+    Some(match v {
+        Value::QuatfVec(v) => v,
+        Value::QuatdVec(v) => v
+            .into_iter()
+            .map(|q| [q[0] as f32, q[1] as f32, q[2] as f32, q[3] as f32])
+            .collect(),
+        Value::QuathVec(v) => v
+            .into_iter()
+            .map(|q| [q[0].to_f32(), q[1].to_f32(), q[2].to_f32(), q[3].to_f32()])
+            .collect(),
+        _ => return None,
+    })
+}
+
+fn value_to_f32_array(v: Value) -> Option<Vec<f32>> {
+    Some(match v {
+        Value::FloatVec(v) => v,
+        Value::DoubleVec(v) => v.into_iter().map(|d| d as f32).collect(),
+        Value::HalfVec(v) => v.into_iter().map(f32::from).collect(),
+        _ => return None,
+    })
+}

--- a/src/skel/skeleton_query.rs
+++ b/src/skel/skeleton_query.rs
@@ -1,0 +1,124 @@
+//! Static (time-independent) resolver bundle for a `Skeleton`.
+//!
+//! Mirrors the *static* surface of Pixar's `UsdSkelSkeletonQuery`:
+//! topology, joint order, world-space bind transforms (per spec
+//! `bindTransforms` is already world-space), pre-computed inverse-bind
+//! matrices, and the helpers that compose joint-local transforms into
+//! skel-space and combine them with current poses to produce skinning
+//! matrices.
+//!
+//! Time-dependent methods (`ComputeJointLocalTransforms(time)`,
+//! `ComputeSkinningTransforms(time)`, etc.) require evaluating a
+//! bound `SkelAnimation` at a specific stage time. That belongs to
+//! the anim layer and is intentionally NOT provided here — once
+//! anim lands, callers will feed its pre-evaluated local transforms
+//! into [`SkeletonResolver::compute_skinning_transforms_from_local`]
+//! below.
+
+use super::skinning::{
+    compute_inverse_bind_transforms, compute_skinning_transforms as math_skin_xforms, joint_local_to_skel_space,
+    joint_skel_to_world,
+};
+use super::topology::Topology;
+use super::types::ReadSkeleton;
+
+/// Resolved, time-independent view of one `Skeleton` prim.
+///
+/// Build with [`SkeletonResolver::new`]; the constructor pre-computes
+/// the topology and the inverse-bind matrices that every skinning
+/// pipeline reuses every frame.
+#[derive(Debug, Clone)]
+pub struct SkeletonResolver {
+    skeleton: ReadSkeleton,
+    topology: Topology,
+    inverse_bind_transforms: Vec<[f64; 16]>,
+}
+
+impl SkeletonResolver {
+    /// Pre-compute topology + inverse-bind matrices for `skeleton`.
+    /// Joints with a singular bind transform fall back to the identity
+    /// inverse — same as Pixar's reference implementation.
+    pub fn new(skeleton: ReadSkeleton) -> Self {
+        let topology = Topology::from_joint_paths(&skeleton.joints);
+        let inverse_bind_transforms = compute_inverse_bind_transforms(&skeleton.bind_transforms);
+        Self {
+            skeleton,
+            topology,
+            inverse_bind_transforms,
+        }
+    }
+
+    /// Borrow the decoded `Skeleton` data.
+    pub fn skeleton(&self) -> &ReadSkeleton {
+        &self.skeleton
+    }
+
+    /// Borrow the skeleton's path-encoded joint order.
+    pub fn joint_order(&self) -> &[String] {
+        &self.skeleton.joints
+    }
+
+    /// Borrow the topology — handy for callers that want to do their
+    /// own walks (e.g. when computing a name→index mapping).
+    pub fn topology(&self) -> &Topology {
+        &self.topology
+    }
+
+    /// World-space joint bind transforms — verbatim from
+    /// `Skeleton.bindTransforms`.
+    pub fn joint_world_bind_transforms(&self) -> &[[f64; 16]] {
+        &self.skeleton.bind_transforms
+    }
+
+    /// Pre-computed `inverse(bindTransform)` per joint. Used by
+    /// [`compute_skinning_transforms_from_world`] /
+    /// [`compute_skinning_transforms_from_local`].
+    pub fn inverse_bind_transforms(&self) -> &[[f64; 16]] {
+        &self.inverse_bind_transforms
+    }
+
+    /// Compose joint-local transforms into skel-space transforms.
+    pub fn joint_local_to_skel_space(&self, local: &[[f64; 16]]) -> Vec<[f64; 16]> {
+        joint_local_to_skel_space(local, &self.topology)
+    }
+
+    /// Lift skel-space joint transforms into world space using the
+    /// supplied SkelRoot local-to-world matrix.
+    pub fn joint_skel_to_world(&self, skel: &[[f64; 16]], skel_local_to_world: &[f64; 16]) -> Vec<[f64; 16]> {
+        joint_skel_to_world(skel, skel_local_to_world)
+    }
+
+    /// Compute skinning transforms (`inverse(bind) · joint_world`)
+    /// from world-space joint transforms.
+    pub fn compute_skinning_transforms_from_world(&self, joint_world: &[[f64; 16]]) -> Vec<[f64; 16]> {
+        math_skin_xforms(joint_world, &self.inverse_bind_transforms)
+    }
+
+    /// Compute skinning transforms from joint-local transforms in one
+    /// step: compose to skel-space, lift to world, then multiply by
+    /// the inverse-bind. Use when you have only local poses (typical
+    /// case after evaluating a SkelAnimation).
+    pub fn compute_skinning_transforms_from_local(
+        &self,
+        joint_local: &[[f64; 16]],
+        skel_local_to_world: &[f64; 16],
+    ) -> Vec<[f64; 16]> {
+        let skel = self.joint_local_to_skel_space(joint_local);
+        let world = self.joint_skel_to_world(&skel, skel_local_to_world);
+        math_skin_xforms(&world, &self.inverse_bind_transforms)
+    }
+
+    /// Convenience: the rest-pose joint-local transforms a caller
+    /// can hand to [`compute_skinning_transforms_from_local`] when
+    /// no SkelAnimation is bound (or the consumer wants the rest
+    /// pose for preview / fallback).
+    pub fn rest_pose_local(&self) -> &[[f64; 16]] {
+        &self.skeleton.rest_transforms
+    }
+
+    /// Rest pose composed into skel-space — equivalent to feeding
+    /// `rest_pose_local()` into [`joint_local_to_skel_space`].
+    pub fn rest_pose_skel_space(&self) -> Vec<[f64; 16]> {
+        joint_local_to_skel_space(&self.skeleton.rest_transforms, &self.topology)
+    }
+}

--- a/src/skel/skinning.rs
+++ b/src/skel/skinning.rs
@@ -63,8 +63,15 @@ pub fn mat4_transform_vec(m: &[f64; 16], v: [f32; 3]) -> [f32; 3] {
     [nx as f32, ny as f32, nz as f32]
 }
 
+/// Singularity threshold for [`mat4_inverse`]. `f64::EPSILON` (≈ 2.2e-16)
+/// is tight enough that ill-conditioned real-world bind matrices slip
+/// through and produce numerically-unstable inverses; `1e-12` matches
+/// the tolerance Pixar's reference inverter uses for skel data.
+const MAT4_SINGULAR_DETERMINANT: f64 = 1e-12;
+
 /// Invert a 4×4 row-major matrix using cofactor expansion.
-/// Returns [`None`] when the matrix is singular (determinant ≈ 0).
+/// Returns [`None`] when the matrix is singular or near-singular
+/// (`|det| < `[`MAT4_SINGULAR_DETERMINANT`]).
 pub fn mat4_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
     let mut inv = [0.0f64; 16];
 
@@ -115,7 +122,7 @@ pub fn mat4_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
         - m[8] * m[2] * m[5];
 
     let det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
-    if det.abs() < f64::EPSILON {
+    if det.abs() < MAT4_SINGULAR_DETERMINANT {
         return None;
     }
     let inv_det = 1.0 / det;
@@ -518,6 +525,23 @@ mod tests {
         for i in 0..16 {
             assert!((id[i] - IDENTITY_MAT4[i]).abs() < 1e-10, "row-col {i}: {id:?}");
         }
+    }
+
+    #[test]
+    fn inverse_rejects_near_singular() {
+        // A 4x4 with two identical rows is singular (det = 0); a
+        // matrix scaled by ~1e-7 across the board is well above
+        // f64::EPSILON but well below the 1e-12 skel threshold.
+        let mut near_singular = [0.0f64; 16];
+        // Diagonal scale of 1e-4 means det = 1e-16 — under 1e-12.
+        for i in 0..4 {
+            near_singular[i * 4 + i] = 1e-4;
+        }
+        assert!(mat4_inverse(&near_singular).is_none(), "should reject near-singular");
+
+        // Plain singular (row of zeros).
+        let singular = [0.0f64; 16];
+        assert!(mat4_inverse(&singular).is_none(), "should reject zero matrix");
     }
 
     #[test]

--- a/src/skel/skinning.rs
+++ b/src/skel/skinning.rs
@@ -1,0 +1,632 @@
+//! Pure-math skinning helpers — linear blend skinning, transform
+//! composition, blend-shape application.
+//!
+//! All matrix data uses USD's textual `matrix4d` layout: a flat
+//! `[f64; 16]` storing the matrix in row-major order (the same order
+//! the USDA writer emits). All operations live in this module so the
+//! `skel` crate doesn't grow a top-level math dependency — callers
+//! can keep using their own math library and only convert at the
+//! interface.
+
+use super::topology::{Topology, NO_PARENT};
+
+/// 4×4 identity in USD's `matrix4d` row-major layout.
+pub const IDENTITY_MAT4: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0, //
+];
+
+/// `out = a · b` for two 4×4 row-major matrices.
+///
+/// USD authors transforms in row-major form and applies them by
+/// pre-multiplying row vectors: `v_out = v_in · M`. Composition is
+/// therefore `(M_parent · M_local)` to chain a child's local
+/// transform under its parent — the same convention every UsdSkel
+/// formula in the spec uses.
+pub fn mat4_mul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
+    let mut out = [0.0f64; 16];
+    for r in 0..4 {
+        for c in 0..4 {
+            let mut v = 0.0;
+            for k in 0..4 {
+                v += a[r * 4 + k] * b[k * 4 + c];
+            }
+            out[r * 4 + c] = v;
+        }
+    }
+    out
+}
+
+/// Apply a 4×4 row-major matrix to a position. Equivalent to
+/// `(p.x, p.y, p.z, 1) · M` and then dropping `w`.
+pub fn mat4_transform_point(m: &[f64; 16], p: [f32; 3]) -> [f32; 3] {
+    let x = p[0] as f64;
+    let y = p[1] as f64;
+    let z = p[2] as f64;
+    let nx = x * m[0] + y * m[4] + z * m[8] + m[12];
+    let ny = x * m[1] + y * m[5] + z * m[9] + m[13];
+    let nz = x * m[2] + y * m[6] + z * m[10] + m[14];
+    [nx as f32, ny as f32, nz as f32]
+}
+
+/// Apply the rotational + scale part of a matrix to a direction
+/// vector (e.g. a normal). Ignores the translation row.
+pub fn mat4_transform_vec(m: &[f64; 16], v: [f32; 3]) -> [f32; 3] {
+    let x = v[0] as f64;
+    let y = v[1] as f64;
+    let z = v[2] as f64;
+    let nx = x * m[0] + y * m[4] + z * m[8];
+    let ny = x * m[1] + y * m[5] + z * m[9];
+    let nz = x * m[2] + y * m[6] + z * m[10];
+    [nx as f32, ny as f32, nz as f32]
+}
+
+/// Invert a 4×4 row-major matrix using cofactor expansion.
+/// Returns [`None`] when the matrix is singular (determinant ≈ 0).
+pub fn mat4_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
+    let mut inv = [0.0f64; 16];
+
+    inv[0] =
+        m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15] + m[9] * m[7] * m[14] + m[13] * m[6] * m[11]
+            - m[13] * m[7] * m[10];
+    inv[4] =
+        -m[4] * m[10] * m[15] + m[4] * m[11] * m[14] + m[8] * m[6] * m[15] - m[8] * m[7] * m[14] - m[12] * m[6] * m[11]
+            + m[12] * m[7] * m[10];
+    inv[8] =
+        m[4] * m[9] * m[15] - m[4] * m[11] * m[13] - m[8] * m[5] * m[15] + m[8] * m[7] * m[13] + m[12] * m[5] * m[11]
+            - m[12] * m[7] * m[9];
+    inv[12] =
+        -m[4] * m[9] * m[14] + m[4] * m[10] * m[13] + m[8] * m[5] * m[14] - m[8] * m[6] * m[13] - m[12] * m[5] * m[10]
+            + m[12] * m[6] * m[9];
+    inv[1] =
+        -m[1] * m[10] * m[15] + m[1] * m[11] * m[14] + m[9] * m[2] * m[15] - m[9] * m[3] * m[14] - m[13] * m[2] * m[11]
+            + m[13] * m[3] * m[10];
+    inv[5] =
+        m[0] * m[10] * m[15] - m[0] * m[11] * m[14] - m[8] * m[2] * m[15] + m[8] * m[3] * m[14] + m[12] * m[2] * m[11]
+            - m[12] * m[3] * m[10];
+    inv[9] =
+        -m[0] * m[9] * m[15] + m[0] * m[11] * m[13] + m[8] * m[1] * m[15] - m[8] * m[3] * m[13] - m[12] * m[1] * m[11]
+            + m[12] * m[3] * m[9];
+    inv[13] =
+        m[0] * m[9] * m[14] - m[0] * m[10] * m[13] - m[8] * m[1] * m[14] + m[8] * m[2] * m[13] + m[12] * m[1] * m[10]
+            - m[12] * m[2] * m[9];
+    inv[2] =
+        m[1] * m[6] * m[15] - m[1] * m[7] * m[14] - m[5] * m[2] * m[15] + m[5] * m[3] * m[14] + m[13] * m[2] * m[7]
+            - m[13] * m[3] * m[6];
+    inv[6] =
+        -m[0] * m[6] * m[15] + m[0] * m[7] * m[14] + m[4] * m[2] * m[15] - m[4] * m[3] * m[14] - m[12] * m[2] * m[7]
+            + m[12] * m[3] * m[6];
+    inv[10] =
+        m[0] * m[5] * m[15] - m[0] * m[7] * m[13] - m[4] * m[1] * m[15] + m[4] * m[3] * m[13] + m[12] * m[1] * m[7]
+            - m[12] * m[3] * m[5];
+    inv[14] =
+        -m[0] * m[5] * m[14] + m[0] * m[6] * m[13] + m[4] * m[1] * m[14] - m[4] * m[2] * m[13] - m[12] * m[1] * m[6]
+            + m[12] * m[2] * m[5];
+    inv[3] =
+        -m[1] * m[6] * m[11] + m[1] * m[7] * m[10] + m[5] * m[2] * m[11] - m[5] * m[3] * m[10] - m[9] * m[2] * m[7]
+            + m[9] * m[3] * m[6];
+    inv[7] = m[0] * m[6] * m[11] - m[0] * m[7] * m[10] - m[4] * m[2] * m[11] + m[4] * m[3] * m[10] + m[8] * m[2] * m[7]
+        - m[8] * m[3] * m[6];
+    inv[11] = -m[0] * m[5] * m[11] + m[0] * m[7] * m[9] + m[4] * m[1] * m[11] - m[4] * m[3] * m[9] - m[8] * m[1] * m[7]
+        + m[8] * m[3] * m[5];
+    inv[15] = m[0] * m[5] * m[10] - m[0] * m[6] * m[9] - m[4] * m[1] * m[10] + m[4] * m[2] * m[9] + m[8] * m[1] * m[6]
+        - m[8] * m[2] * m[5];
+
+    let det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+    if det.abs() < f64::EPSILON {
+        return None;
+    }
+    let inv_det = 1.0 / det;
+    for v in &mut inv {
+        *v *= inv_det;
+    }
+    Some(inv)
+}
+
+/// Compose joint-local transforms into skeleton-space transforms by
+/// concatenating each joint's local transform with its parent's
+/// already-resolved skel-space transform.
+///
+/// Per the UsdSkel spec: `jointSkelSpaceTransform =
+/// jointLocalSpaceTransform * parentJointSkelSpaceTransform`. The
+/// canonical UsdSkel `joints` ordering guarantees parents precede
+/// children, so a single forward pass is enough.
+///
+/// Root joints (parent == [`NO_PARENT`]) keep their local transform
+/// as their skel-space transform.
+pub fn joint_local_to_skel_space(local: &[[f64; 16]], topology: &Topology) -> Vec<[f64; 16]> {
+    assert_eq!(
+        local.len(),
+        topology.num_joints(),
+        "joint_local_to_skel_space: local.len() must equal topology.num_joints()"
+    );
+    let mut out = vec![IDENTITY_MAT4; local.len()];
+    for i in 0..local.len() {
+        let p = topology.parent(i);
+        out[i] = if p == NO_PARENT {
+            local[i]
+        } else {
+            mat4_mul(&local[i], &out[p as usize])
+        };
+    }
+    out
+}
+
+/// Compose skel-space joint transforms with the skel-root's
+/// local-to-world transform to obtain world-space joint transforms.
+/// Per the UsdSkel spec: `jointWorldSpaceTransform =
+/// jointSkelSpaceTransform * skelLocalToWorldTransform`.
+///
+/// Callers supply the skel-root's world transform; this module does
+/// not reach into the Stage for it (UsdSkel intentionally separates
+/// the two so consumers can plug in their own xform cache).
+pub fn joint_skel_to_world(skel: &[[f64; 16]], skel_local_to_world: &[f64; 16]) -> Vec<[f64; 16]> {
+    skel.iter().map(|m| mat4_mul(m, skel_local_to_world)).collect()
+}
+
+/// Compute per-joint skinning transforms from current joint poses and
+/// the bind-pose inverses.
+///
+/// Per Pixar's `UsdSkelSkeletonQuery::ComputeSkinningTransforms`:
+/// `skinningTransform = inverse(bindTransform) · jointTransform`. The
+/// caller decides which space `jointTransform` is in (skel-space when
+/// `geomBindTransform` is the identity, world-space otherwise — they
+/// must match the space of the bind transforms).
+pub fn compute_skinning_transforms(joint: &[[f64; 16]], inverse_bind: &[[f64; 16]]) -> Vec<[f64; 16]> {
+    assert_eq!(
+        joint.len(),
+        inverse_bind.len(),
+        "compute_skinning_transforms: array lengths must match"
+    );
+    joint.iter().zip(inverse_bind).map(|(j, b)| mat4_mul(b, j)).collect()
+}
+
+/// Pre-compute the per-joint inverse-bind transforms used by
+/// [`compute_skinning_transforms`]. Joints whose bind transform is
+/// singular get [`IDENTITY_MAT4`] — same fallback as Pixar's
+/// reference implementation.
+pub fn compute_inverse_bind_transforms(bind: &[[f64; 16]]) -> Vec<[f64; 16]> {
+    bind.iter().map(|m| mat4_inverse(m).unwrap_or(IDENTITY_MAT4)).collect()
+}
+
+/// Linear blend skinning of a point cloud — the canonical UsdSkel
+/// algorithm from the spec's "Skinning a Point" section:
+///
+/// ```text
+/// skelSpacePoint = geomBindTransform.Transform(localSpacePoint)
+/// p = (0, 0, 0)
+/// for (jointIndex, jointWeight) in jointInfluencesForPoint:
+///     p += skinningTransforms[jointIndex].Transform(skelSpacePoint) * jointWeight
+/// ```
+///
+/// `points` are in the mesh's local space at bind time.
+/// `joint_indices` / `joint_weights` are the flattened per-point
+/// influence lists from `SkelBindingAPI`; `num_influences` is the
+/// per-vertex stride (`elementSize` on the primvar).
+/// `skinning_xforms` must be in the *mesh-effective* joint order
+/// (apply [`super::AnimMapper`] first if the mesh uses `skel:joints`
+/// to subset/reorder the skeleton's joints).
+///
+/// Returns one deformed point per input point.
+pub fn skin_points_lbs(
+    points: &[[f32; 3]],
+    joint_indices: &[i32],
+    joint_weights: &[f32],
+    num_influences: usize,
+    geom_bind_transform: &[f64; 16],
+    skinning_xforms: &[[f64; 16]],
+) -> Vec<[f32; 3]> {
+    assert!(num_influences >= 1, "num_influences must be >= 1");
+    assert_eq!(
+        joint_indices.len(),
+        joint_weights.len(),
+        "indices and weights must be the same length"
+    );
+    assert_eq!(
+        joint_indices.len(),
+        points.len() * num_influences,
+        "indices length must equal points * num_influences"
+    );
+
+    let mut out = Vec::with_capacity(points.len());
+    for (vi, p) in points.iter().enumerate() {
+        let skel_p = mat4_transform_point(geom_bind_transform, *p);
+        let mut acc = [0.0f32; 3];
+        for inf in 0..num_influences {
+            let slot = vi * num_influences + inf;
+            let w = joint_weights[slot];
+            if w == 0.0 {
+                continue;
+            }
+            let j = joint_indices[slot] as usize;
+            let warped = mat4_transform_point(&skinning_xforms[j], skel_p);
+            acc[0] += warped[0] * w;
+            acc[1] += warped[1] * w;
+            acc[2] += warped[2] * w;
+        }
+        out.push(acc);
+    }
+    out
+}
+
+/// Linear blend skinning of normals. Same per-vertex influence layout
+/// as [`skin_points_lbs`], but treats vectors as directions (no
+/// translation) and renormalises each result.
+///
+/// Note this uses the same per-joint matrix as [`skin_points_lbs`] —
+/// a strictly correct implementation would use the inverse-transpose
+/// when scale is non-uniform. For typical character rigs (rigid bone
+/// transforms) the two are equivalent and consumers don't notice.
+pub fn skin_normals_lbs(
+    normals: &[[f32; 3]],
+    joint_indices: &[i32],
+    joint_weights: &[f32],
+    num_influences: usize,
+    geom_bind_transform: &[f64; 16],
+    skinning_xforms: &[[f64; 16]],
+) -> Vec<[f32; 3]> {
+    assert!(num_influences >= 1, "num_influences must be >= 1");
+    let mut out = Vec::with_capacity(normals.len());
+    for (vi, n) in normals.iter().enumerate() {
+        let skel_n = mat4_transform_vec(geom_bind_transform, *n);
+        let mut acc = [0.0f32; 3];
+        for inf in 0..num_influences {
+            let slot = vi * num_influences + inf;
+            let w = joint_weights[slot];
+            if w == 0.0 {
+                continue;
+            }
+            let j = joint_indices[slot] as usize;
+            let warped = mat4_transform_vec(&skinning_xforms[j], skel_n);
+            acc[0] += warped[0] * w;
+            acc[1] += warped[1] * w;
+            acc[2] += warped[2] * w;
+        }
+        let len = (acc[0] * acc[0] + acc[1] * acc[1] + acc[2] * acc[2]).sqrt();
+        if len > 0.0 {
+            acc[0] /= len;
+            acc[1] /= len;
+            acc[2] /= len;
+        }
+        out.push(acc);
+    }
+    out
+}
+
+/// Rigid-deformation transform for a constant-interpolation
+/// SkelBindingAPI — when every vertex shares one set of joint
+/// influences, skinning collapses to a single 4×4 to apply to the
+/// whole mesh's local-to-world.
+///
+/// `joint_indices` / `joint_weights` are the (single-element-per-vertex
+/// or constant) influences. `num_influences` is the influence count;
+/// it doesn't have to be 1 — a constant-interpolation primvar can
+/// still carry multiple influences applied to the mesh as a whole.
+///
+/// Returns `geomBindTransform · Σ(weight_i · skinning_xform_i)`.
+pub fn rigid_skinning_transform(
+    joint_indices: &[i32],
+    joint_weights: &[f32],
+    num_influences: usize,
+    geom_bind_transform: &[f64; 16],
+    skinning_xforms: &[[f64; 16]],
+) -> [f64; 16] {
+    assert!(num_influences >= 1, "num_influences must be >= 1");
+    assert_eq!(joint_indices.len(), num_influences);
+    assert_eq!(joint_weights.len(), num_influences);
+    let mut weighted = [0.0f64; 16];
+    for inf in 0..num_influences {
+        let w = joint_weights[inf] as f64;
+        if w == 0.0 {
+            continue;
+        }
+        let j = joint_indices[inf] as usize;
+        let m = &skinning_xforms[j];
+        for k in 0..16 {
+            weighted[k] += m[k] * w;
+        }
+    }
+    mat4_mul(geom_bind_transform, &weighted)
+}
+
+/// One blend-shape contribution ready to apply to mesh points.
+/// `point_indices` may be empty to indicate a dense shape (entry `i`
+/// affects vertex `i`).
+#[derive(Debug, Clone)]
+pub struct BlendShapeWeighted<'a> {
+    /// Blended weight after inbetween resolution (typically `[0, 1]`).
+    pub weight: f32,
+    /// Per-affected-vertex position offsets, parallel to
+    /// `point_indices` when sparse.
+    pub offsets: &'a [[f32; 3]],
+    /// Optional sparse-vertex remap. Empty = dense.
+    pub point_indices: &'a [i32],
+}
+
+/// Apply a stack of blend shapes to a mesh's points.
+///
+/// Per the canonical UsdSkel pipeline blend shapes are evaluated
+/// *before* skinning; the deformed mesh is then skinned through
+/// [`skin_points_lbs`]. This helper does only the morph step:
+///
+/// `p_morphed[i] = p[i] + Σ_s (weight_s * offset_s[i])`
+///
+/// Caller supplies the per-shape weight already resolved through
+/// any inbetween interpolation — see [`resolve_inbetween_weight`].
+pub fn apply_blend_shapes(points: &[[f32; 3]], shapes: &[BlendShapeWeighted<'_>]) -> Vec<[f32; 3]> {
+    let mut out = points.to_vec();
+    for s in shapes {
+        if s.weight == 0.0 {
+            continue;
+        }
+        if s.point_indices.is_empty() {
+            // Dense: offsets[i] applies to vertex i.
+            for (i, off) in s.offsets.iter().enumerate() {
+                if i >= out.len() {
+                    break;
+                }
+                out[i][0] += off[0] * s.weight;
+                out[i][1] += off[1] * s.weight;
+                out[i][2] += off[2] * s.weight;
+            }
+        } else {
+            for (slot, &vi) in s.point_indices.iter().enumerate() {
+                let i = vi as usize;
+                if i >= out.len() || slot >= s.offsets.len() {
+                    continue;
+                }
+                let off = s.offsets[slot];
+                out[i][0] += off[0] * s.weight;
+                out[i][1] += off[1] * s.weight;
+                out[i][2] += off[2] * s.weight;
+            }
+        }
+    }
+    out
+}
+
+/// Resolve the effective offset contribution at a given weight for a
+/// blend shape that has inbetween shapes.
+///
+/// Implements UsdSkel's piecewise-linear interpolation along the
+/// `[0, 1]` weight axis: breakpoints are at `0` (rest, zero offset),
+/// each inbetween at its authored weight, and `1` (the primary
+/// `BlendShape.offsets`). Caller passes `(inbetween_weight,
+/// inbetween_offsets)` pairs **sorted ascending by weight** (this
+/// helper sorts internally so authoring order doesn't matter).
+///
+/// Returns `(effective_weight_on_segment, segment_offsets)` for the
+/// segment containing `w`, where `effective_weight_on_segment` is the
+/// `[0, 1]` interpolation parameter to apply to `segment_offsets` via
+/// `out[i] = lower + t * (segment_offsets[i] - lower[i])`. Since we
+/// don't have negative-weight semantics in the spec the result is
+/// clamped to `[0, 1]`.
+///
+/// For consumers that just want a single blended offset array
+/// directly, [`resolve_blend_shape_offsets`] does that in one shot.
+pub fn resolve_inbetween_weight<'a>(
+    w: f32,
+    inbetweens: &'a [(f32, &'a [[f32; 3]])],
+    primary: &'a [[f32; 3]],
+) -> (f32, &'a [[f32; 3]]) {
+    let w = w.clamp(0.0, 1.0);
+    // Sort by weight ascending. Small-N (typical: 1-3 inbetweens)
+    // so a copy + sort is fine.
+    let mut breakpoints: Vec<(f32, &[[f32; 3]])> = inbetweens.iter().map(|(w, o)| (*w, *o)).collect();
+    breakpoints.push((1.0, primary));
+    breakpoints.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let mut prev_w = 0.0f32;
+    for (bw, off) in breakpoints {
+        if w <= bw {
+            let span = bw - prev_w;
+            let t = if span > 0.0 { (w - prev_w) / span } else { 0.0 };
+            return (t, off);
+        }
+        prev_w = bw;
+    }
+    // Past the last breakpoint (which is the primary at 1.0):
+    // saturate to full primary.
+    (1.0, primary)
+}
+
+/// One inbetween shape — its authored weight and its offsets.
+/// Inputs to [`resolve_blend_shape_offsets`].
+pub type InbetweenRef<'a> = (f32, &'a [[f32; 3]]);
+
+/// Resolve a single blend shape (primary + optional inbetweens) at
+/// weight `w` into the effective per-vertex offset array. Returns a
+/// fresh `Vec` whose length matches whichever array is in play for
+/// the resolved segment (segments don't span shapes with different
+/// vertex counts in well-formed UsdSkel data).
+pub fn resolve_blend_shape_offsets(w: f32, inbetweens: &[InbetweenRef<'_>], primary: &[[f32; 3]]) -> Vec<[f32; 3]> {
+    let w = w.clamp(0.0, 1.0);
+    // Find the segment as above, but this time return the actual
+    // interpolated offsets between (lower_offsets, upper_offsets).
+    let mut bps: Vec<(f32, &[[f32; 3]])> = inbetweens.iter().map(|(w, o)| (*w, *o)).collect();
+    bps.push((1.0, primary));
+    bps.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut lower_w = 0.0f32;
+    let lower_offsets: Vec<[f32; 3]> = Vec::new();
+    let mut lower_offsets_slice: &[[f32; 3]] = &lower_offsets;
+    for (bw, off) in &bps {
+        if w <= *bw {
+            let span = bw - lower_w;
+            let t = if span > 0.0 { (w - lower_w) / span } else { 0.0 };
+            return lerp_offsets(lower_offsets_slice, off, t, off.len());
+        }
+        lower_w = *bw;
+        lower_offsets_slice = off;
+    }
+    primary.to_vec()
+}
+
+fn lerp_offsets(a: &[[f32; 3]], b: &[[f32; 3]], t: f32, len: usize) -> Vec<[f32; 3]> {
+    (0..len)
+        .map(|i| {
+            let av = if a.is_empty() { [0.0; 3] } else { a[i.min(a.len() - 1)] };
+            let bv = if b.is_empty() { [0.0; 3] } else { b[i.min(b.len() - 1)] };
+            [
+                av[0] + (bv[0] - av[0]) * t,
+                av[1] + (bv[1] - av[1]) * t,
+                av[2] + (bv[2] - av[2]) * t,
+            ]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn translation(x: f64, y: f64, z: f64) -> [f64; 16] {
+        let mut m = IDENTITY_MAT4;
+        m[12] = x;
+        m[13] = y;
+        m[14] = z;
+        m
+    }
+
+    #[test]
+    fn mat4_mul_identity_is_noop() {
+        let m = translation(1.0, 2.0, 3.0);
+        assert_eq!(mat4_mul(&IDENTITY_MAT4, &m), m);
+        assert_eq!(mat4_mul(&m, &IDENTITY_MAT4), m);
+    }
+
+    #[test]
+    fn point_transform_applies_translation() {
+        let m = translation(10.0, 20.0, 30.0);
+        let p = mat4_transform_point(&m, [1.0, 2.0, 3.0]);
+        assert_eq!(p, [11.0, 22.0, 33.0]);
+    }
+
+    #[test]
+    fn vec_transform_ignores_translation() {
+        let m = translation(10.0, 20.0, 30.0);
+        let v = mat4_transform_vec(&m, [1.0, 2.0, 3.0]);
+        assert_eq!(v, [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn inverse_round_trips() {
+        let m = translation(5.0, -2.0, 7.0);
+        let inv = mat4_inverse(&m).unwrap();
+        let id = mat4_mul(&m, &inv);
+        for i in 0..16 {
+            assert!((id[i] - IDENTITY_MAT4[i]).abs() < 1e-10, "row-col {i}: {id:?}");
+        }
+    }
+
+    #[test]
+    fn joint_local_to_skel_chains_translations() {
+        // Two joints in a chain. Root is at (1, 0, 0); child is
+        // (0, 1, 0) relative to root. Expected: root at (1, 0, 0),
+        // child at (1, 1, 0).
+        let topo = Topology::from_parents(vec![NO_PARENT, 0]);
+        let local = vec![translation(1.0, 0.0, 0.0), translation(0.0, 1.0, 0.0)];
+        let skel = joint_local_to_skel_space(&local, &topo);
+        assert_eq!(skel[0][12..16], [1.0, 0.0, 0.0, 1.0]);
+        assert_eq!(skel[1][12..16], [1.0, 1.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn skinning_transform_is_inverse_bind_times_current() {
+        // Joint bound at (1, 0, 0), now at (1, 2, 0). Skinning xform
+        // for a point at (1, 0, 0) should produce (1, 2, 0).
+        let bind = vec![translation(1.0, 0.0, 0.0)];
+        let inv_bind = compute_inverse_bind_transforms(&bind);
+        let current = vec![translation(1.0, 2.0, 0.0)];
+        let skin = compute_skinning_transforms(&current, &inv_bind);
+        let p = mat4_transform_point(&skin[0], [1.0, 0.0, 0.0]);
+        assert_eq!(p, [1.0, 2.0, 0.0]);
+    }
+
+    #[test]
+    fn skin_points_with_single_full_weight_translates_mesh() {
+        // One joint that translates by (0, 1, 0). Identity geom-bind.
+        // Two points, each fully influenced by joint 0.
+        let skin = vec![translation(0.0, 1.0, 0.0)];
+        let pts = [[0.0_f32, 0.0, 0.0], [1.0, 0.0, 0.0]];
+        let out = skin_points_lbs(&pts, &[0, 0], &[1.0, 1.0], 1, &IDENTITY_MAT4, &skin);
+        assert_eq!(out, vec![[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]);
+    }
+
+    #[test]
+    fn skin_points_blends_two_joints_50_50() {
+        // Two joints: one translates +x, one translates +y. Weight
+        // 0.5/0.5 → point at (0,0,0) goes to (0.5, 0.5, 0).
+        let skin = vec![translation(1.0, 0.0, 0.0), translation(0.0, 1.0, 0.0)];
+        let pts = [[0.0_f32, 0.0, 0.0]];
+        let out = skin_points_lbs(&pts, &[0, 1], &[0.5, 0.5], 2, &IDENTITY_MAT4, &skin);
+        assert_eq!(out, vec![[0.5, 0.5, 0.0]]);
+    }
+
+    #[test]
+    fn apply_blend_shape_dense_adds_offsets() {
+        let pts = vec![[1.0_f32, 0.0, 0.0], [0.0, 0.0, 0.0]];
+        let shape = BlendShapeWeighted {
+            weight: 0.5,
+            offsets: &[[0.0, 1.0, 0.0], [0.0, 2.0, 0.0]],
+            point_indices: &[],
+        };
+        let out = apply_blend_shapes(&pts, &[shape]);
+        assert_eq!(out, vec![[1.0, 0.5, 0.0], [0.0, 1.0, 0.0]]);
+    }
+
+    #[test]
+    fn apply_blend_shape_sparse_remaps_via_indices() {
+        let pts = vec![[0.0_f32; 3]; 4];
+        let shape = BlendShapeWeighted {
+            weight: 1.0,
+            offsets: &[[1.0, 0.0, 0.0], [0.0, 0.0, 5.0]],
+            point_indices: &[1, 3],
+        };
+        let out = apply_blend_shapes(&pts, &[shape]);
+        assert_eq!(out, vec![[0.0; 3], [1.0, 0.0, 0.0], [0.0; 3], [0.0, 0.0, 5.0]]);
+    }
+
+    #[test]
+    fn resolve_inbetween_weight_lands_on_segment() {
+        let inb_off = [[0.0_f32, 0.5, 0.0]];
+        let prim = [[0.0_f32, 1.0, 0.0]];
+        let inbetweens = [(0.5_f32, &inb_off[..])];
+
+        // At w=0.25 we're 50% across the (0 → 0.5) segment.
+        let (t, segment) = resolve_inbetween_weight(0.25, &inbetweens, &prim);
+        assert!((t - 0.5).abs() < 1e-6);
+        assert_eq!(segment, &inb_off[..]);
+
+        // At w=0.75 we're 50% across the (0.5 → 1.0) segment.
+        let (t, segment) = resolve_inbetween_weight(0.75, &inbetweens, &prim);
+        assert!((t - 0.5).abs() < 1e-6);
+        assert_eq!(segment, &prim[..]);
+    }
+
+    #[test]
+    fn resolve_blend_shape_offsets_interpolates_through_inbetween() {
+        // Inbetween at 0.5 with offset (0, 1, 0); primary at 1.0 with (0, 2, 0).
+        let inb_off = [[0.0_f32, 1.0, 0.0]];
+        let prim = [[0.0_f32, 2.0, 0.0]];
+        let inbetweens = [(0.5_f32, &inb_off[..])];
+
+        // At w=0.5: exactly the inbetween shape.
+        let out = resolve_blend_shape_offsets(0.5, &inbetweens, &prim);
+        assert_eq!(out, vec![[0.0, 1.0, 0.0]]);
+
+        // At w=0.75: halfway between inbetween (0, 1, 0) and primary (0, 2, 0).
+        let out = resolve_blend_shape_offsets(0.75, &inbetweens, &prim);
+        assert_eq!(out, vec![[0.0, 1.5, 0.0]]);
+    }
+
+    #[test]
+    fn rigid_skinning_combines_weighted_joints_then_geom_bind() {
+        let skin = vec![translation(1.0, 0.0, 0.0), translation(0.0, 1.0, 0.0)];
+        let m = rigid_skinning_transform(&[0, 1], &[0.5, 0.5], 2, &IDENTITY_MAT4, &skin);
+        // Apply to (0, 0, 0): should land at (0.5, 0.5, 0).
+        let p = mat4_transform_point(&m, [0.0, 0.0, 0.0]);
+        assert_eq!(p, [0.5, 0.5, 0.0]);
+    }
+}

--- a/src/skel/skinning_query.rs
+++ b/src/skel/skinning_query.rs
@@ -119,27 +119,21 @@ impl SkinningResolver {
     /// Remap skinning transforms from the bound skeleton's joint
     /// order into the mesh's effective order. No-op when no
     /// `skel:joints` subset was authored.
+    ///
+    /// Walks the pre-computed mapper indices once with no
+    /// intermediate buffers, so this is cheap to call per frame.
+    /// Missing joints (a target joint that isn't in the bound
+    /// skeleton — rare but legal) get [`IDENTITY_MAT4`].
     pub fn remap_skinning_xforms(&self, skel_skinning_xforms: &[[f64; 16]]) -> Vec<[f64; 16]> {
         if self.mapper.is_identity() {
             return skel_skinning_xforms.to_vec();
         }
-        // Flatten through the strided helper. Missing joints land as
-        // identity (fill value = 1 on the diagonal).
-        let flat: Vec<f64> = skel_skinning_xforms.iter().flat_map(|m| m.iter().copied()).collect();
-        let strided = self.mapper.remap_with_stride(&flat, 16, 0.0);
-        let mut out = Vec::with_capacity(self.num_mesh_joints);
-        for chunk in strided.chunks_exact(16) {
-            let mut m = [0.0f64; 16];
-            m.copy_from_slice(chunk);
-            // Fill-with-zeros leaves missing joints as the all-zeros
-            // matrix; promote to identity so the downstream skin
-            // routine doesn't collapse points to the origin.
-            if m == [0.0f64; 16] {
-                m = IDENTITY_MAT4;
-            }
-            out.push(m);
-        }
-        out
+        (0..self.mapper.target_len())
+            .map(|t| match self.mapper.source_index(t) {
+                Some(i) => skel_skinning_xforms[i],
+                None => IDENTITY_MAT4,
+            })
+            .collect()
     }
 
     /// Skin `points` through this binding's per-vertex influences,

--- a/src/skel/skinning_query.rs
+++ b/src/skel/skinning_query.rs
@@ -1,0 +1,206 @@
+//! Per-mesh skinning resolver — the static (time-independent) data
+//! every skinning pipeline needs for one prim carrying
+//! `SkelBindingAPI`.
+//!
+//! Mirrors the static surface of Pixar's `UsdSkelSkinningQuery`. The
+//! caller still owns the per-frame joint pose (in the bound
+//! skeleton's joint order); this object handles the per-mesh details:
+//!
+//! - Remapping the skeleton-order skinning transforms through the
+//!   mesh's `skel:joints` subset (when authored) via
+//!   [`super::AnimMapper`].
+//! - Telling skinning code whether the binding is rigid or per-vertex.
+//! - Holding the `geomBindTransform` and `skinningMethod` so the
+//!   caller doesn't have to re-read them per frame.
+//! - Driving the [`super::skinning`] math against the right inputs.
+
+use super::anim_mapper::AnimMapper;
+use super::skinning::{rigid_skinning_transform, skin_normals_lbs, skin_points_lbs, IDENTITY_MAT4};
+use super::types::{InfluenceInterpolation, ReadSkelBinding, SkinningMethod};
+
+/// Resolver bundle for one skinnable prim.
+///
+/// Build with [`SkinningResolver::new`], passing the bound skeleton's
+/// joint order so the joint-subset remapping ([`AnimMapper`]) can be
+/// pre-computed. After construction the resolver is read-only and
+/// can be reused across frames.
+#[derive(Debug, Clone)]
+pub struct SkinningResolver {
+    binding: ReadSkelBinding,
+    /// Mapper from the bound skeleton's joint order into the mesh's
+    /// effective joint order. Identity (with `is_identity() == true`)
+    /// when `skel:joints` isn't authored.
+    mapper: AnimMapper,
+    /// Effective mesh-side joint count — `binding.joint_subset.len()`
+    /// when a subset was authored, otherwise the skeleton's joint
+    /// count.
+    num_mesh_joints: usize,
+    /// Cached `geomBindTransform`. Spec default = identity.
+    geom_bind_transform: [f64; 16],
+}
+
+impl SkinningResolver {
+    /// Build a resolver for `binding`. `skeleton_joint_order` is the
+    /// bound `Skeleton.joints` array, used to derive the
+    /// skeleton→mesh joint remap when `skel:joints` is authored.
+    pub fn new(binding: ReadSkelBinding, skeleton_joint_order: &[String]) -> Self {
+        let mapper = if binding.joint_subset.is_empty() {
+            // No subset authored — skinning transforms feed straight
+            // through. Pre-build an identity mapper so callers always
+            // hit the same code path.
+            AnimMapper::new(skeleton_joint_order, skeleton_joint_order)
+        } else {
+            AnimMapper::new(skeleton_joint_order, &binding.joint_subset)
+        };
+        let num_mesh_joints = if binding.joint_subset.is_empty() {
+            skeleton_joint_order.len()
+        } else {
+            binding.joint_subset.len()
+        };
+        let geom_bind_transform = binding.geom_bind_transform.unwrap_or(IDENTITY_MAT4);
+        Self {
+            binding,
+            mapper,
+            num_mesh_joints,
+            geom_bind_transform,
+        }
+    }
+
+    /// Borrow the underlying `SkelBindingAPI` data.
+    pub fn binding(&self) -> &ReadSkelBinding {
+        &self.binding
+    }
+
+    /// Borrow the prim path the binding came from.
+    pub fn prim(&self) -> &str {
+        &self.binding.path
+    }
+
+    /// `true` when this prim is authored with `constant` interpolation
+    /// — every vertex shares the same joint influences and the mesh
+    /// can be skinned by a single 4×4 (see [`compute_rigid_transform`]).
+    pub fn is_rigidly_deformed(&self) -> bool {
+        self.binding.interpolation == InfluenceInterpolation::Constant
+    }
+
+    /// Number of `(joint, weight)` pairs per skinned element. For
+    /// per-vertex bindings, "element" is a vertex; for rigid bindings,
+    /// the count applies to the mesh as a whole.
+    pub fn num_influences_per_component(&self) -> usize {
+        self.binding.elements_per_element.max(1) as usize
+    }
+
+    /// `true` if joint influences and weights were authored (i.e.
+    /// skinning is actually meaningful for this prim).
+    pub fn has_joint_influences(&self) -> bool {
+        !self.binding.joint_indices.is_empty() && !self.binding.joint_weights.is_empty()
+    }
+
+    /// Effective joint order on the mesh side. Equal to the bound
+    /// `Skeleton.joints` when `skel:joints` isn't authored; otherwise
+    /// equal to `skel:joints`.
+    pub fn joint_order_len(&self) -> usize {
+        self.num_mesh_joints
+    }
+
+    /// Cached `geomBindTransform` — identity when unauthored.
+    pub fn geom_bind_transform(&self) -> &[f64; 16] {
+        &self.geom_bind_transform
+    }
+
+    /// Authored skinning method. Spec default is
+    /// [`SkinningMethod::ClassicLinear`]; consumers without dual-
+    /// quaternion support typically fall back to classic LBS even
+    /// when the prim authors `dualQuaternion`.
+    pub fn skinning_method(&self) -> SkinningMethod {
+        self.binding.skinning_method
+    }
+
+    /// Remap skinning transforms from the bound skeleton's joint
+    /// order into the mesh's effective order. No-op when no
+    /// `skel:joints` subset was authored.
+    pub fn remap_skinning_xforms(&self, skel_skinning_xforms: &[[f64; 16]]) -> Vec<[f64; 16]> {
+        if self.mapper.is_identity() {
+            return skel_skinning_xforms.to_vec();
+        }
+        // Flatten through the strided helper. Missing joints land as
+        // identity (fill value = 1 on the diagonal).
+        let flat: Vec<f64> = skel_skinning_xforms.iter().flat_map(|m| m.iter().copied()).collect();
+        let strided = self.mapper.remap_with_stride(&flat, 16, 0.0);
+        let mut out = Vec::with_capacity(self.num_mesh_joints);
+        for chunk in strided.chunks_exact(16) {
+            let mut m = [0.0f64; 16];
+            m.copy_from_slice(chunk);
+            // Fill-with-zeros leaves missing joints as the all-zeros
+            // matrix; promote to identity so the downstream skin
+            // routine doesn't collapse points to the origin.
+            if m == [0.0f64; 16] {
+                m = IDENTITY_MAT4;
+            }
+            out.push(m);
+        }
+        out
+    }
+
+    /// Skin `points` through this binding's per-vertex influences,
+    /// using `skel_skinning_xforms` (in the bound skeleton's joint
+    /// order; this method handles the remap to mesh order).
+    ///
+    /// Panics when called on a rigidly-deformed binding — use
+    /// [`compute_rigid_transform`] for that case.
+    pub fn compute_skinned_points(&self, points: &[[f32; 3]], skel_skinning_xforms: &[[f64; 16]]) -> Vec<[f32; 3]> {
+        assert!(
+            !self.is_rigidly_deformed(),
+            "compute_skinned_points called on rigidly-deformed binding"
+        );
+        let mesh_xforms = self.remap_skinning_xforms(skel_skinning_xforms);
+        skin_points_lbs(
+            points,
+            &self.binding.joint_indices,
+            &self.binding.joint_weights,
+            self.num_influences_per_component(),
+            &self.geom_bind_transform,
+            &mesh_xforms,
+        )
+    }
+
+    /// Skin normals through the same per-vertex influences as
+    /// [`compute_skinned_points`]. Normalises each result; see
+    /// [`super::skinning::skin_normals_lbs`] for the caveat about
+    /// inverse-transpose under non-uniform scale.
+    pub fn compute_skinned_normals(&self, normals: &[[f32; 3]], skel_skinning_xforms: &[[f64; 16]]) -> Vec<[f32; 3]> {
+        assert!(
+            !self.is_rigidly_deformed(),
+            "compute_skinned_normals called on rigidly-deformed binding"
+        );
+        let mesh_xforms = self.remap_skinning_xforms(skel_skinning_xforms);
+        skin_normals_lbs(
+            normals,
+            &self.binding.joint_indices,
+            &self.binding.joint_weights,
+            self.num_influences_per_component(),
+            &self.geom_bind_transform,
+            &mesh_xforms,
+        )
+    }
+
+    /// Compute the single 4×4 that should be applied to a
+    /// rigidly-deformed mesh's local-to-world transform.
+    ///
+    /// Panics when called on a per-vertex binding — use
+    /// [`compute_skinned_points`] / [`compute_skinned_normals`] there.
+    pub fn compute_rigid_transform(&self, skel_skinning_xforms: &[[f64; 16]]) -> [f64; 16] {
+        assert!(
+            self.is_rigidly_deformed(),
+            "compute_rigid_transform called on per-vertex binding"
+        );
+        let mesh_xforms = self.remap_skinning_xforms(skel_skinning_xforms);
+        rigid_skinning_transform(
+            &self.binding.joint_indices,
+            &self.binding.joint_weights,
+            self.num_influences_per_component(),
+            &self.geom_bind_transform,
+            &mesh_xforms,
+        )
+    }
+}

--- a/src/skel/tokens.rs
+++ b/src/skel/tokens.rs
@@ -1,0 +1,62 @@
+//! Token constants for the [UsdSkel](super) schema family.
+//!
+//! Centralised so consumers can match against canonical strings instead of
+//! retyping literals. Mirrors the grouping in Pixar's
+//! `pxr/usd/usdSkel/tokens.h`.
+
+// Concrete prim type names.
+pub const T_SKEL_ROOT: &str = "SkelRoot";
+pub const T_SKELETON: &str = "Skeleton";
+pub const T_SKEL_ANIMATION: &str = "SkelAnimation";
+pub const T_BLEND_SHAPE: &str = "BlendShape";
+
+// API schemas.
+pub const API_SKEL_BINDING: &str = "SkelBindingAPI";
+
+// Boundable attribute (shared with UsdGeom; mirrored here for the
+// `SkelRoot` reader that decodes it).
+pub const A_EXTENT: &str = "extent";
+
+// Skeleton attribute names.
+pub const A_JOINTS: &str = "joints";
+pub const A_BIND_TRANSFORMS: &str = "bindTransforms";
+pub const A_REST_TRANSFORMS: &str = "restTransforms";
+
+// SkelAnimation attribute names.
+pub const A_TRANSLATIONS: &str = "translations";
+pub const A_ROTATIONS: &str = "rotations";
+pub const A_SCALES: &str = "scales";
+pub const A_BLEND_SHAPES: &str = "blendShapes";
+pub const A_BLEND_SHAPE_WEIGHTS: &str = "blendShapeWeights";
+
+// BlendShape attribute names.
+pub const A_OFFSETS: &str = "offsets";
+pub const A_NORMAL_OFFSETS: &str = "normalOffsets";
+pub const A_POINT_INDICES: &str = "pointIndices";
+
+// Inbetween-shape namespace + weight metadata.
+pub const NS_INBETWEENS: &str = "inbetweens:";
+pub const META_WEIGHT: &str = "weight";
+
+// SkelBindingAPI properties.
+pub const A_SKEL_JOINTS: &str = "skel:joints";
+pub const A_SKEL_BLEND_SHAPES: &str = "skel:blendShapes";
+pub const REL_SKEL_BLEND_SHAPE_TARGETS: &str = "skel:blendShapeTargets";
+pub const REL_SKEL_SKELETON: &str = "skel:skeleton";
+pub const REL_SKEL_ANIMATION_SOURCE: &str = "skel:animationSource";
+pub const A_JOINT_INDICES: &str = "primvars:skel:jointIndices";
+pub const A_JOINT_WEIGHTS: &str = "primvars:skel:jointWeights";
+pub const A_GEOM_BIND_TRANSFORM: &str = "primvars:skel:geomBindTransform";
+pub const A_SKINNING_METHOD: &str = "primvars:skel:skinningMethod";
+
+// Primvar metadata field names.
+pub const META_INTERPOLATION: &str = "interpolation";
+pub const META_ELEMENT_SIZE: &str = "elementSize";
+
+// Skinning-method tokens (`primvars:skel:skinningMethod`).
+pub const SKINNING_METHOD_CLASSIC_LINEAR: &str = "classicLinear";
+pub const SKINNING_METHOD_DUAL_QUATERNION: &str = "dualQuaternion";
+
+// Primvar interpolation tokens recognised on the joint-influences primvars.
+pub const INTERP_CONSTANT: &str = "constant";
+pub const INTERP_VERTEX: &str = "vertex";

--- a/src/skel/topology.rs
+++ b/src/skel/topology.rs
@@ -1,0 +1,155 @@
+//! Joint topology — the static parent/child structure of a skeleton.
+//!
+//! Mirrors Pixar's `UsdSkelTopology`. Holds one `parent` index per
+//! joint, with `-1` denoting a root. Built either from a slice of
+//! path-encoded joint names (Pixar's standard `joints` token array
+//! format — `"Shoulder/Elbow"` ⇒ parent is `"Shoulder"`) or from a
+//! pre-computed parent-index array.
+
+/// Sentinel value meaning "this joint has no parent" in
+/// [`Topology::parents`] / [`Topology::parent`].
+pub const NO_PARENT: i32 = -1;
+
+/// Joint topology — parent indices, validation, root tests.
+///
+/// Indices line up 1:1 with the originating `joints` token array.
+/// `parents[i]` is either the index of joint `i`'s parent or
+/// [`NO_PARENT`] for root joints.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Topology {
+    parents: Vec<i32>,
+}
+
+impl Topology {
+    /// Empty topology — no joints.
+    pub fn new() -> Self {
+        Self { parents: Vec::new() }
+    }
+
+    /// Build a topology from a slice of joint path tokens — Pixar's
+    /// `joints` token array convention. The path encoding
+    /// (`"A/B"` ⇒ parent of `"A/B"` is `"A"`) implies the parent
+    /// link. Joints without a `/` (or whose prefix isn't present in
+    /// the array) are roots.
+    ///
+    /// Order is preserved: `parents[i]` corresponds to `paths[i]`.
+    pub fn from_joint_paths(paths: &[String]) -> Self {
+        use std::collections::HashMap;
+        let by_path: HashMap<&str, i32> = paths.iter().enumerate().map(|(i, p)| (p.as_str(), i as i32)).collect();
+        let parents = paths
+            .iter()
+            .map(|p| {
+                p.rsplit_once('/')
+                    .and_then(|(parent, _)| by_path.get(parent).copied())
+                    .unwrap_or(NO_PARENT)
+            })
+            .collect();
+        Self { parents }
+    }
+
+    /// Build a topology directly from a parent-index array — same
+    /// semantics as Pixar's `UsdSkelTopology(VtIntArray)` constructor.
+    pub fn from_parents(parents: Vec<i32>) -> Self {
+        Self { parents }
+    }
+
+    /// Borrow the parent-index array.
+    pub fn parents(&self) -> &[i32] {
+        &self.parents
+    }
+
+    /// Number of joints in this topology.
+    pub fn num_joints(&self) -> usize {
+        self.parents.len()
+    }
+
+    /// Parent of joint `i`, or [`NO_PARENT`] when `i` is a root.
+    /// Returns [`NO_PARENT`] if `i` is out of range — callers that
+    /// need to distinguish should range-check separately.
+    pub fn parent(&self, i: usize) -> i32 {
+        self.parents.get(i).copied().unwrap_or(NO_PARENT)
+    }
+
+    /// True when joint `i` has no parent.
+    pub fn is_root(&self, i: usize) -> bool {
+        self.parent(i) == NO_PARENT
+    }
+
+    /// Validate that every parent index either equals [`NO_PARENT`]
+    /// or refers to a *prior* joint (parent-before-child ordering —
+    /// the canonical UsdSkel invariant). Returns the offending joint
+    /// index on failure.
+    pub fn validate(&self) -> Result<(), TopologyError> {
+        for (i, &p) in self.parents.iter().enumerate() {
+            if p == NO_PARENT {
+                continue;
+            }
+            if p < 0 || (p as usize) >= self.parents.len() {
+                return Err(TopologyError::ParentOutOfRange { joint: i, parent: p });
+            }
+            if (p as usize) >= i {
+                return Err(TopologyError::ParentNotBeforeChild { joint: i, parent: p });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Reasons [`Topology::validate`] can fail.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TopologyError {
+    /// A parent index doesn't refer to a joint in this topology.
+    #[error("joint {joint}: parent index {parent} is out of range")]
+    ParentOutOfRange { joint: usize, parent: i32 },
+    /// UsdSkel requires parents to come before children in the
+    /// `joints` array. This entry violates that ordering.
+    #[error("joint {joint}: parent index {parent} must be less than the joint's own index")]
+    ParentNotBeforeChild { joint: usize, parent: i32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn derives_parents_from_path_encoding() {
+        let t = Topology::from_joint_paths(&paths(&["Root", "Root/Hip", "Root/Hip/Knee", "Root/Hip/Other"]));
+        assert_eq!(t.parents(), &[NO_PARENT, 0, 1, 1]);
+        assert!(t.is_root(0));
+        assert!(!t.is_root(1));
+        assert_eq!(t.num_joints(), 4);
+        t.validate().unwrap();
+    }
+
+    #[test]
+    fn joints_with_missing_prefix_become_roots() {
+        // "Foo/Bar" has no preceding "Foo" entry — it's still a valid
+        // joint but with no parent in the topology.
+        let t = Topology::from_joint_paths(&paths(&["A", "Foo/Bar"]));
+        assert_eq!(t.parents(), &[NO_PARENT, NO_PARENT]);
+    }
+
+    #[test]
+    fn validate_rejects_forward_parent_reference() {
+        // parents[0] = 1 → joint 0 says its parent is joint 1, which
+        // comes after it. Spec requires parent < child.
+        let t = Topology::from_parents(vec![1, NO_PARENT]);
+        assert!(matches!(
+            t.validate(),
+            Err(TopologyError::ParentNotBeforeChild { joint: 0, parent: 1 })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_parent() {
+        let t = Topology::from_parents(vec![NO_PARENT, 7]);
+        assert!(matches!(
+            t.validate(),
+            Err(TopologyError::ParentOutOfRange { joint: 1, parent: 7 })
+        ));
+    }
+}

--- a/src/skel/types.rs
+++ b/src/skel/types.rs
@@ -1,0 +1,286 @@
+//! Decoded structs and enums returned by [`super::read`] functions.
+
+use super::tokens::*;
+
+/// `primvars:skel:skinningMethod` token values from `UsdSkelBindingAPI`.
+///
+/// The default when unauthored is [`SkinningMethod::ClassicLinear`] —
+/// standard linear blend skinning. [`SkinningMethod::DualQuaternion`]
+/// is the only other Pixar-defined value; consumers without DQ support
+/// typically fall back to classic LBS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkinningMethod {
+    #[default]
+    ClassicLinear,
+    DualQuaternion,
+}
+
+impl SkinningMethod {
+    pub fn as_token(self) -> &'static str {
+        match self {
+            SkinningMethod::ClassicLinear => SKINNING_METHOD_CLASSIC_LINEAR,
+            SkinningMethod::DualQuaternion => SKINNING_METHOD_DUAL_QUATERNION,
+        }
+    }
+
+    pub fn from_token(s: &str) -> Option<Self> {
+        Some(match s {
+            SKINNING_METHOD_CLASSIC_LINEAR => SkinningMethod::ClassicLinear,
+            SKINNING_METHOD_DUAL_QUATERNION => SkinningMethod::DualQuaternion,
+            _ => return None,
+        })
+    }
+}
+
+/// Authored interpolation on the joint-influence primvars.
+///
+/// `Constant` encodes rigid skinning (one set of weights for the whole
+/// prim). `Vertex` is per-point weights, the normal skinned case.
+/// `Vertex` is the unauthored default — the only interpolation that
+/// generally makes sense for per-vertex influence lists, and what
+/// every UsdSkel example uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InfluenceInterpolation {
+    Constant,
+    #[default]
+    Vertex,
+}
+
+impl InfluenceInterpolation {
+    pub fn as_token(self) -> &'static str {
+        match self {
+            InfluenceInterpolation::Constant => INTERP_CONSTANT,
+            InfluenceInterpolation::Vertex => INTERP_VERTEX,
+        }
+    }
+
+    pub fn from_token(s: &str) -> Option<Self> {
+        Some(match s {
+            INTERP_CONSTANT => InfluenceInterpolation::Constant,
+            INTERP_VERTEX => InfluenceInterpolation::Vertex,
+            _ => return None,
+        })
+    }
+}
+
+/// Decoded `UsdSkelRoot` prim — the scope marker beneath which
+/// skeletal processing applies.
+///
+/// `extent` is the authored bounding box on the SkelRoot (a `Boundable`).
+/// USD recommends authoring it explicitly so consumers can avoid
+/// computing skinned bounds at runtime; this reader does not synthesise
+/// one when missing.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReadSkelRoot {
+    pub path: String,
+    /// `extent` — `[min, max]` corners in the SkelRoot's local space.
+    /// `None` when unauthored.
+    pub extent: Option<[[f32; 3]; 2]>,
+}
+
+/// Decoded `UsdSkelSkeleton` prim.
+///
+/// `joints[i]` is the SdfPath-encoded name of joint `i`; parent links
+/// are derived from the path encoding (see
+/// [`ReadSkeleton::joint_parent_indices`]).
+///
+/// Index alignment is strict: `bind_transforms[i]` and
+/// `rest_transforms[i]` correspond to `joints[i]`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReadSkeleton {
+    pub path: String,
+    /// `joints` token array — path-encoded joint hierarchy.
+    /// Example: `["Root", "Root/Hip", "Root/Hip/Knee"]`.
+    pub joints: Vec<String>,
+    /// `bindTransforms` — per-joint bind pose in *world space*.
+    /// Row-major flattened 4×4. Empty when unauthored.
+    pub bind_transforms: Vec<[f64; 16]>,
+    /// `restTransforms` — per-joint rest pose in *joint-local space*
+    /// (parent-relative). Row-major flattened 4×4. Empty when
+    /// unauthored.
+    pub rest_transforms: Vec<[f64; 16]>,
+}
+
+impl ReadSkeleton {
+    /// Recover the parent index of each joint from the path encoding.
+    /// `joints[i] = "A/B"` ⇒ parent is the index of `"A"`; a joint with
+    /// no `/` is a root and gets `None`.
+    pub fn joint_parent_indices(&self) -> Vec<Option<usize>> {
+        let by_path: std::collections::HashMap<&str, usize> =
+            self.joints.iter().enumerate().map(|(i, p)| (p.as_str(), i)).collect();
+        self.joints
+            .iter()
+            .map(|p| {
+                p.rsplit_once('/')
+                    .map(|(parent, _)| parent)
+                    .and_then(|parent_path| by_path.get(parent_path).copied())
+            })
+            .collect()
+    }
+
+    /// Last segment of each joint path — the bone's display name.
+    /// Returns the full path verbatim if the joint has no `/`.
+    pub fn joint_short_names(&self) -> Vec<&str> {
+        self.joints
+            .iter()
+            .map(|p| p.rsplit_once('/').map(|(_, n)| n).unwrap_or(p.as_str()))
+            .collect()
+    }
+
+    /// Map an animation's `joints` list to indices in this Skeleton's
+    /// `joints` (by exact path match). Used to remap SkelAnimation data
+    /// onto skeleton joint indices — the animation's ordering need not
+    /// match the skeleton's.
+    pub fn map_anim_joints(&self, anim_joints: &[String]) -> Vec<Option<usize>> {
+        let by_path: std::collections::HashMap<&str, usize> =
+            self.joints.iter().enumerate().map(|(i, p)| (p.as_str(), i)).collect();
+        anim_joints.iter().map(|p| by_path.get(p.as_str()).copied()).collect()
+    }
+}
+
+/// Decoded `UsdSkelAnimation` prim. Per-frame arrays live on
+/// [`ReadSkelAnimation::translations`] / `rotations` / `scales` and
+/// must each be the same length as `joints` (uniform sized rows).
+///
+/// `blend_shape_weights[t]` is parallel to `blend_shapes`.
+///
+/// Time samples are returned in their authored ordering (ascending
+/// time-code). When an attribute carries only a `default` value
+/// instead of `timeSamples`, the reader synthesises a single entry at
+/// `t = 0.0` so consumers can treat both shapes uniformly.
+#[derive(Debug, Clone, Default)]
+pub struct ReadSkelAnimation {
+    pub path: String,
+    /// `joints` — the animation's own joint ordering. Does NOT have
+    /// to match the bound Skeleton's `joints`; consumers remap by
+    /// name via [`ReadSkeleton::map_anim_joints`].
+    pub joints: Vec<String>,
+    /// `blendShapes` — names of the blend shapes whose weights are
+    /// animated.
+    pub blend_shapes: Vec<String>,
+    /// Per-time `translations` — flat per-joint `(x, y, z)` rows.
+    /// Inner Vec length matches `joints.len()`.
+    pub translations: Vec<(f64, Vec<[f32; 3]>)>,
+    /// Per-time `rotations` — quaternions in USD's `(w, x, y, z)`
+    /// order. Inner Vec length matches `joints.len()`.
+    pub rotations: Vec<(f64, Vec<[f32; 4]>)>,
+    /// Per-time `scales` — Pixar's schema authors `half3[]`; the
+    /// reader widens to `f32` so consumers don't need the half crate.
+    /// Inner Vec length matches `joints.len()`.
+    pub scales: Vec<(f64, Vec<[f32; 3]>)>,
+    /// Per-time `blendShapeWeights` — inner Vec length matches
+    /// `blend_shapes.len()`.
+    pub blend_shape_weights: Vec<(f64, Vec<f32>)>,
+}
+
+/// One in-between authored on a [`ReadBlendShape`].
+///
+/// Spec: `0 < weight < 1`. Endpoint weights are implicit — rest pose
+/// at 0 and the primary BlendShape at 1, neither of which can be
+/// authored as an inbetween. The reader surfaces whatever was authored
+/// without enforcing the bound; callers that want strict spec
+/// behaviour should filter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReadInbetween {
+    /// Inbetween name — last segment of the `inbetweens:<name>`
+    /// attribute path.
+    pub name: String,
+    /// `weight` metadata authored on the attribute. Required by spec;
+    /// `None` indicates malformed authoring (we still return the entry
+    /// so callers can warn).
+    pub weight: Option<f32>,
+    /// Inbetween position offsets. Parallel to the parent
+    /// `BlendShape.pointIndices` layout.
+    pub offsets: Vec<[f32; 3]>,
+    /// Optional `normalOffsets`-style sibling, authored on the
+    /// inbetween via `inbetweens:<name>:normalOffsets`. Empty when
+    /// unauthored.
+    pub normal_offsets: Vec<[f32; 3]>,
+}
+
+/// Decoded `UsdSkelBlendShape` prim.
+///
+/// Sparse via `point_indices` — `offsets[i]` applies to the mesh
+/// vertex at `point_indices[i]`. Dense when `point_indices` is empty
+/// (offsets[i] applies to vertex i).
+#[derive(Debug, Clone, Default)]
+pub struct ReadBlendShape {
+    pub path: String,
+    /// Required `offsets` (`vector3f[]`). One entry per affected
+    /// vertex.
+    pub offsets: Vec<[f32; 3]>,
+    /// Optional `normalOffsets` (`vector3f[]`). Same length as
+    /// `offsets`. Empty when unauthored.
+    pub normal_offsets: Vec<[f32; 3]>,
+    /// Optional `pointIndices` (`int[]`). Maps `offsets[i]` to the
+    /// vertex it deforms. Empty for dense blend shapes.
+    pub point_indices: Vec<i32>,
+    /// Authored inbetween shapes (`inbetweens:<name>`). Empty when
+    /// none. The reader does not sort by weight — preserve authoring
+    /// order so the caller can mirror the source layer's spelling.
+    pub inbetweens: Vec<ReadInbetween>,
+}
+
+/// Decoded `SkelBindingAPI` on a skinnable prim (typically a Mesh).
+///
+/// `skel:skeleton` and `skel:animationSource` are inheritable down
+/// namespace — see [`super::read::read_inherited_skeleton`] and
+/// [`super::read::read_inherited_animation_source`] for ancestor-walk
+/// resolution.
+#[derive(Debug, Clone, Default)]
+pub struct ReadSkelBinding {
+    /// Prim path of the skinned geometry.
+    pub path: String,
+    /// `skel:skeleton` rel target authored directly on this prim.
+    /// `None` when the binding is inherited from an ancestor.
+    pub skeleton: Option<String>,
+    /// `skel:animationSource` rel target authored directly on this
+    /// prim. `None` when inherited.
+    pub animation_source: Option<String>,
+    /// `primvars:skel:jointIndices` values.
+    pub joint_indices: Vec<i32>,
+    /// `primvars:skel:jointWeights` values. Parallel to
+    /// `joint_indices`.
+    pub joint_weights: Vec<f32>,
+    /// `elementSize` on the joint-influence primvars — number of
+    /// `(joint, weight)` pairs per element. Defaults to 1 when
+    /// unauthored.
+    pub elements_per_element: i32,
+    /// Authored interpolation on the joint-influence primvars
+    /// (`vertex` / `constant`). Defaults to `Vertex` when unauthored,
+    /// which is the only interpolation that makes sense for a
+    /// per-vertex influence list — UsdSkel restricts authored values
+    /// to `vertex` or `constant`.
+    pub interpolation: InfluenceInterpolation,
+    /// `skel:joints` — optional per-mesh subset / reordering of the
+    /// bound Skeleton's joints. When present, `joint_indices` index
+    /// into this list, NOT into the Skeleton's `joints`.
+    pub joint_subset: Vec<String>,
+    /// `skel:blendShapes` — names of the blend shapes this mesh uses.
+    /// Parallel-indexed to [`Self::blend_shape_targets`].
+    pub blend_shapes: Vec<String>,
+    /// `skel:blendShapeTargets` (rel) — absolute prim paths of the
+    /// BlendShape prims, one per [`Self::blend_shapes`] entry.
+    pub blend_shape_targets: Vec<String>,
+    /// `primvars:skel:geomBindTransform` — bind-time world-space
+    /// transform of the skinned primitive. Row-major flattened 4×4.
+    /// `None` when unauthored — the spec default is the identity
+    /// matrix.
+    pub geom_bind_transform: Option<[f64; 16]>,
+    /// `primvars:skel:skinningMethod`. Default is
+    /// [`SkinningMethod::ClassicLinear`].
+    pub skinning_method: SkinningMethod,
+}
+
+/// Result of [`super::read::find_skel_prims`] — a single-pass stage
+/// walk that returns categorised path lists. Saves callers from
+/// re-walking the stage for each schema family.
+#[derive(Debug, Clone, Default)]
+pub struct SkelPrims {
+    pub skel_roots: Vec<String>,
+    pub skeletons: Vec<String>,
+    pub animations: Vec<String>,
+    pub blend_shapes: Vec<String>,
+    /// Prims with `SkelBindingAPI` applied (typically Meshes).
+    pub bindings: Vec<String>,
+}

--- a/tests/skel_reader.rs
+++ b/tests/skel_reader.rs
@@ -1,0 +1,270 @@
+//! Integration tests for the UsdSkel module against a fixture that
+//! exercises every schema family the reader covers, plus the
+//! time-independent object-model layer (topology, AnimMapper,
+//! SkeletonResolver, SkinningResolver, binding discovery).
+
+use anyhow::Result;
+use openusd::sdf;
+use openusd::skel::{
+    self, discover_bindings, find_skel_roots, AnimMapper, InfluenceInterpolation, SkeletonResolver, SkinningMethod,
+    SkinningResolver, Topology, NO_PARENT,
+};
+use openusd::Stage;
+
+const FIXTURE: &str = "fixtures/usdSkel_scene.usda";
+
+fn open() -> Result<Stage> {
+    Stage::open(FIXTURE)
+}
+
+#[test]
+fn finds_every_skel_prim_family() -> Result<()> {
+    let stage = open()?;
+    let prims = skel::find_skel_prims(&stage)?;
+
+    assert_eq!(prims.skel_roots, vec!["/World/Character".to_string()]);
+    assert_eq!(prims.skeletons, vec!["/World/Character/Rig".to_string()]);
+    assert_eq!(prims.animations, vec!["/World/Character/Anim".to_string()]);
+    assert_eq!(prims.blend_shapes, vec!["/World/Character/Smile".to_string()]);
+    assert!(prims.bindings.contains(&"/World/Character".to_string()));
+    assert!(prims.bindings.contains(&"/World/Character/Body".to_string()));
+
+    Ok(())
+}
+
+#[test]
+fn reads_skel_root_extent() -> Result<()> {
+    let stage = open()?;
+    let root = skel::read_skel_root(&stage, &sdf::path("/World/Character")?)?.expect("SkelRoot");
+    assert_eq!(root.path, "/World/Character");
+    let extent = root.extent.expect("extent authored");
+    assert_eq!(extent, [[-1.0, 0.0, -1.0], [1.0, 2.0, 1.0]]);
+    Ok(())
+}
+
+#[test]
+fn reads_skeleton_joints_and_transforms() -> Result<()> {
+    let stage = open()?;
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.expect("Skeleton");
+    assert_eq!(skl.joints, vec!["Root", "Root/Hip", "Root/Hip/Knee"]);
+    assert_eq!(skl.bind_transforms.len(), 3);
+    assert_eq!(skl.rest_transforms.len(), 3);
+
+    // bindTransforms world-space: Hip is at (0, 1, 0), Knee at (0, 2, 0).
+    assert_eq!(skl.bind_transforms[1][12..16], [0.0, 1.0, 0.0, 1.0]);
+    assert_eq!(skl.bind_transforms[2][12..16], [0.0, 2.0, 0.0, 1.0]);
+
+    // Parent indices derive from the path encoding.
+    let parents = skl.joint_parent_indices();
+    assert_eq!(parents, vec![None, Some(0), Some(1)]);
+
+    // Short names strip everything but the leaf segment.
+    assert_eq!(skl.joint_short_names(), vec!["Root", "Hip", "Knee"]);
+    Ok(())
+}
+
+#[test]
+fn reads_skel_animation_time_samples() -> Result<()> {
+    let stage = open()?;
+    let anim = skel::read_skel_animation(&stage, &sdf::path("/World/Character/Anim")?)?.expect("SkelAnimation");
+    assert_eq!(anim.joints, vec!["Root", "Root/Hip", "Root/Hip/Knee"]);
+    assert_eq!(anim.blend_shapes, vec!["smile"]);
+
+    assert_eq!(anim.translations.len(), 2);
+    assert_eq!(anim.translations[0].0, 0.0);
+    assert_eq!(anim.translations[1].0, 10.0);
+    assert_eq!(anim.translations[1].1[1], [0.0, 1.5, 0.0]);
+
+    assert_eq!(anim.rotations.len(), 2);
+    assert_eq!(anim.rotations[1].1[1][0], 0.707);
+
+    assert_eq!(anim.blend_shape_weights.len(), 2);
+    assert_eq!(anim.blend_shape_weights[1].1, vec![1.0]);
+    Ok(())
+}
+
+#[test]
+fn maps_anim_joints_to_skeleton_indices() -> Result<()> {
+    let stage = open()?;
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.unwrap();
+    let anim = skel::read_skel_animation(&stage, &sdf::path("/World/Character/Anim")?)?.unwrap();
+    let map = skl.map_anim_joints(&anim.joints);
+    assert_eq!(map, vec![Some(0), Some(1), Some(2)]);
+    Ok(())
+}
+
+#[test]
+fn reads_blend_shape_with_inbetween() -> Result<()> {
+    let stage = open()?;
+    let bs = skel::read_blend_shape(&stage, &sdf::path("/World/Character/Smile")?)?.expect("BlendShape");
+    assert_eq!(bs.offsets, vec![[0.0, 0.1, 0.0], [0.0, 0.1, 0.0]]);
+    assert_eq!(bs.normal_offsets.len(), 2);
+    assert_eq!(bs.point_indices, vec![0, 1]);
+
+    assert_eq!(bs.inbetweens.len(), 1);
+    let inb = &bs.inbetweens[0];
+    assert_eq!(inb.name, "half");
+    assert_eq!(inb.weight, Some(0.5));
+    assert_eq!(inb.offsets, vec![[0.0, 0.04, 0.0], [0.0, 0.04, 0.0]]);
+    Ok(())
+}
+
+#[test]
+fn reads_skel_binding_on_mesh() -> Result<()> {
+    let stage = open()?;
+    let bind = skel::read_skel_binding(&stage, &sdf::path("/World/Character/Body")?)?.expect("SkelBindingAPI");
+    assert_eq!(bind.path, "/World/Character/Body");
+
+    // skel:skeleton / skel:animationSource are NOT authored on the mesh
+    // itself — they're inherited from the SkelRoot.
+    assert!(bind.skeleton.is_none());
+    assert!(bind.animation_source.is_none());
+
+    assert_eq!(bind.joint_subset, vec!["Root/Hip", "Root/Hip/Knee"]);
+    assert_eq!(bind.joint_indices, vec![0, 0, 1, 1]);
+    assert_eq!(bind.joint_weights, vec![1.0, 1.0, 1.0, 1.0]);
+    assert_eq!(bind.elements_per_element, 1);
+    assert_eq!(bind.interpolation, InfluenceInterpolation::Vertex);
+    assert_eq!(bind.blend_shapes, vec!["smile"]);
+    assert_eq!(bind.blend_shape_targets, vec!["/World/Character/Smile".to_string()]);
+    assert!(bind.geom_bind_transform.is_some());
+    assert_eq!(bind.skinning_method, SkinningMethod::ClassicLinear);
+    Ok(())
+}
+
+#[test]
+fn resolves_inherited_skeleton_and_animation_source() -> Result<()> {
+    let stage = open()?;
+    let mesh = sdf::path("/World/Character/Body")?;
+
+    let skeleton = skel::read_inherited_skeleton(&stage, &mesh)?.expect("inherited skel:skeleton");
+    assert_eq!(skeleton, "/World/Character/Rig");
+
+    let anim = skel::read_inherited_animation_source(&stage, &mesh)?.expect("inherited skel:animationSource");
+    assert_eq!(anim, "/World/Character/Anim");
+    Ok(())
+}
+
+#[test]
+fn finds_skel_roots_on_stage() -> Result<()> {
+    let stage = open()?;
+    let roots = find_skel_roots(&stage)?;
+    assert_eq!(roots, vec!["/World/Character".to_string()]);
+    Ok(())
+}
+
+#[test]
+fn discover_bindings_walks_skel_root_subtree() -> Result<()> {
+    let stage = open()?;
+    let root = sdf::path("/World/Character")?;
+    let bindings = discover_bindings(&stage, &root)?;
+    // The SkelRoot itself + the Body mesh both carry SkelBindingAPI.
+    assert_eq!(bindings.len(), 2);
+
+    let body = bindings
+        .iter()
+        .find(|b| b.prim == "/World/Character/Body")
+        .expect("Body binding");
+    // The Body itself doesn't author skel:skeleton — it's inherited
+    // from the SkelRoot.
+    assert!(body.binding.skeleton.is_none());
+    assert_eq!(body.skeleton.as_deref(), Some("/World/Character/Rig"));
+    assert_eq!(body.animation_source.as_deref(), Some("/World/Character/Anim"));
+    Ok(())
+}
+
+#[test]
+fn skeleton_resolver_pre_computes_inverse_bind() -> Result<()> {
+    let stage = open()?;
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.unwrap();
+    let resolver = SkeletonResolver::new(skl);
+
+    assert_eq!(resolver.topology().num_joints(), 3);
+    assert_eq!(resolver.topology().parents(), &[NO_PARENT, 0, 1]);
+    assert_eq!(resolver.inverse_bind_transforms().len(), 3);
+
+    // rest_pose composed into skel-space: identity rests with the
+    // chain (0, 0, 0) → (0, 1, 0) → (0, 2, 0) should produce
+    // skel-space translations matching the bind transforms.
+    let skel_space = resolver.rest_pose_skel_space();
+    assert_eq!(skel_space[1][12..16], [0.0, 1.0, 0.0, 1.0]);
+    assert_eq!(skel_space[2][12..16], [0.0, 2.0, 0.0, 1.0]);
+    Ok(())
+}
+
+#[test]
+fn skinning_resolver_remaps_through_skel_joints_subset() -> Result<()> {
+    let stage = open()?;
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.unwrap();
+    let binding = skel::read_skel_binding(&stage, &sdf::path("/World/Character/Body")?)?.unwrap();
+    let resolver = SkinningResolver::new(binding, &skl.joints);
+
+    assert!(!resolver.is_rigidly_deformed());
+    assert!(resolver.has_joint_influences());
+    assert_eq!(resolver.num_influences_per_component(), 1);
+    // skel:joints subset = ["Root/Hip", "Root/Hip/Knee"] — two
+    // mesh-effective joints out of the skeleton's three.
+    assert_eq!(resolver.joint_order_len(), 2);
+    assert_eq!(resolver.skinning_method(), SkinningMethod::ClassicLinear);
+
+    // Author identity skinning transforms for every skeleton joint.
+    // After remapping, the mesh-side array should still be length 2
+    // (since the subset selects 2 joints).
+    let identity = openusd::skel::skinning::IDENTITY_MAT4;
+    let skel_xforms = vec![identity; 3];
+    let mesh_xforms = resolver.remap_skinning_xforms(&skel_xforms);
+    assert_eq!(mesh_xforms.len(), 2);
+    assert_eq!(mesh_xforms[0], identity);
+    Ok(())
+}
+
+#[test]
+fn skinning_resolver_with_identity_xforms_returns_bind_pose_points() -> Result<()> {
+    let stage = open()?;
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.unwrap();
+    let binding = skel::read_skel_binding(&stage, &sdf::path("/World/Character/Body")?)?.unwrap();
+    let resolver = SkinningResolver::new(binding, &skl.joints);
+
+    let pts = [
+        [-0.5_f32, 0.0, -0.5],
+        [0.5, 0.0, -0.5],
+        [0.5, 0.0, 0.5],
+        [-0.5, 0.0, 0.5],
+    ];
+    let identity = openusd::skel::skinning::IDENTITY_MAT4;
+    let skel_xforms = vec![identity; 3];
+    let out = resolver.compute_skinned_points(&pts, &skel_xforms);
+    // Identity geom-bind + identity joints + weight 1.0 = no movement.
+    for (i, p) in out.iter().enumerate() {
+        for k in 0..3 {
+            assert!(
+                (p[k] - pts[i][k]).abs() < 1e-6,
+                "point {i}: got {p:?}, want {:?}",
+                pts[i]
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn topology_unit_methods() {
+    let topo = Topology::from_joint_paths(&["Root".to_string(), "Root/Hip".to_string(), "Root/Hip/Knee".to_string()]);
+    assert_eq!(topo.num_joints(), 3);
+    assert!(topo.is_root(0));
+    assert!(!topo.is_root(1));
+    assert_eq!(topo.parent(2), 1);
+    topo.validate().expect("valid");
+}
+
+#[test]
+fn anim_mapper_remap_with_missing_joints() {
+    let m = AnimMapper::new(
+        &["Root".to_string(), "Hip".to_string()],
+        &["Hip".to_string(), "Missing".to_string(), "Root".to_string()],
+    );
+    assert!(m.is_sparse());
+    assert_eq!(m.target_len(), 3);
+    let out = m.remap(&[10, 20], -1);
+    assert_eq!(out, vec![20, -1, 10]);
+}


### PR DESCRIPTION
## Proposal for follow-up reorganisation

Before this lands, a question for @mxpv: if you're open to it, I'd like to move `src/physics/` and `src/skel/` (and the matching `tests/`+ `fixtures/`) under a `src/noncore/` subfolder in a follow-up PR.

The plan is to keep contributing domain schemas — `UsdAnim` is next, then `UsdLux` and `UsdGeom.Camera`. Adding one top-level folder per schema family will get crowded fast, and these schemas aren't part of the AOUSD core spec anyway, so `noncore` (or `schemas`, or whatever you prefer) feels like a natural grouping. Happy to defer to your naming preference.

If you'd rather keep the flat layout, no problem — this PR doesn't depend on the reorg either way.

---

## Summary

Adds the `skel` cargo feature with a complete UsdSkel schema reader plus the time-independent half of Pixar's UsdSkel object model. Covers sections 1, 3, 4, and 6 of the canonical UsdSkel landing page (https://openusd.org/release/api/usd_skel_page_front.html), minus animation evaluation (left for a follow-up `anim` feature).

## What's deliberately out

Time-dependent evaluation (`UsdSkelAnimQuery`, `ComputeSkinningTransforms(time)`, stage-time interpolation of
SkelAnimation samples). Resolvers take pre-evaluated joint poses so the follow-up anim layer can plug in directly.

Instancing-of-bind-state and a stateful `UsdSkelCache` were intentionally skipped — discovery is exposed as plain stateless functions to fit the existing single-shot Stage API surface.

## Tests

All green; no regressions in other test binaries.

## ROADMAP

Flips the UsdSkel row to `:white_check_mark:` / `main`.

## EXAMPLE POSSIBLE BECAUSE OF THIS
<img width="1640" height="1148" alt="image" src="https://github.com/user-attachments/assets/d99d92bd-d654-4f23-87ca-4362712955cf" />
