### PR TITLE
feat(skel): SkelAnimQuery + array interp

### DIFF
--- a/src/interp.rs
+++ b/src/interp.rs
@@ -67,6 +67,28 @@ pub fn is_linear_supported(v: &Value) -> bool {
             | Value::Quath(_)
             | Value::Quatf(_)
             | Value::Quatd(_)
+            // Array (VtArray) variants follow C++ `USD_LINEAR_INTERPOLATION_TYPES`.
+            // Bracketing samples must agree on length; when they don't,
+            // the evaluator falls back to held.
+            | Value::HalfVec(_)
+            | Value::FloatVec(_)
+            | Value::DoubleVec(_)
+            | Value::TimeCodeVec(_)
+            | Value::Matrix2dVec(_)
+            | Value::Matrix3dVec(_)
+            | Value::Matrix4dVec(_)
+            | Value::Vec2hVec(_)
+            | Value::Vec2fVec(_)
+            | Value::Vec2dVec(_)
+            | Value::Vec3hVec(_)
+            | Value::Vec3fVec(_)
+            | Value::Vec3dVec(_)
+            | Value::Vec4hVec(_)
+            | Value::Vec4fVec(_)
+            | Value::Vec4dVec(_)
+            | Value::QuathVec(_)
+            | Value::QuatfVec(_)
+            | Value::QuatdVec(_)
     )
 }
 
@@ -158,6 +180,72 @@ fn lerp_value(a: &Value, b: &Value, t: f32) -> Option<Value> {
         (V::Quath(x), V::Quath(y)) => V::Quath(slerp_half(x, y, t)),
         (V::Quatf(x), V::Quatf(y)) => V::Quatf(slerp_quatf(x, y, t)),
         (V::Quatd(x), V::Quatd(y)) => V::Quatd(slerp_quatd(x, y, t64)),
+
+        // Array (VtArray) variants. Per C++: bracketing samples must
+        // agree on length, otherwise fall back to held.
+        (V::HalfVec(x), V::HalfVec(y)) if x.len() == y.len() => V::HalfVec(
+            x.iter()
+                .zip(y)
+                .map(|(a, b)| half::f16::from_f32(lerp_f32(a.to_f32(), b.to_f32(), t)))
+                .collect(),
+        ),
+        (V::FloatVec(x), V::FloatVec(y)) if x.len() == y.len() => {
+            V::FloatVec(x.iter().zip(y).map(|(a, b)| lerp_f32(*a, *b, t)).collect())
+        }
+        (V::DoubleVec(x), V::DoubleVec(y)) if x.len() == y.len() => {
+            V::DoubleVec(x.iter().zip(y).map(|(a, b)| lerp_f64(*a, *b, t64)).collect())
+        }
+        (V::TimeCodeVec(x), V::TimeCodeVec(y)) if x.len() == y.len() => {
+            V::TimeCodeVec(x.iter().zip(y).map(|(a, b)| lerp_f64(*a, *b, t64)).collect())
+        }
+
+        (V::Matrix2dVec(x), V::Matrix2dVec(y)) if x.len() == y.len() => {
+            V::Matrix2dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<4>(a, b, t64)).collect())
+        }
+        (V::Matrix3dVec(x), V::Matrix3dVec(y)) if x.len() == y.len() => {
+            V::Matrix3dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<9>(a, b, t64)).collect())
+        }
+        (V::Matrix4dVec(x), V::Matrix4dVec(y)) if x.len() == y.len() => {
+            V::Matrix4dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<16>(a, b, t64)).collect())
+        }
+
+        (V::Vec2hVec(x), V::Vec2hVec(y)) if x.len() == y.len() => {
+            V::Vec2hVec(x.iter().zip(y).map(|(a, b)| lerp_half_array::<2>(a, b, t)).collect())
+        }
+        (V::Vec2fVec(x), V::Vec2fVec(y)) if x.len() == y.len() => {
+            V::Vec2fVec(x.iter().zip(y).map(|(a, b)| lerp_array_f32::<2>(a, b, t)).collect())
+        }
+        (V::Vec2dVec(x), V::Vec2dVec(y)) if x.len() == y.len() => {
+            V::Vec2dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<2>(a, b, t64)).collect())
+        }
+        (V::Vec3hVec(x), V::Vec3hVec(y)) if x.len() == y.len() => {
+            V::Vec3hVec(x.iter().zip(y).map(|(a, b)| lerp_half_array::<3>(a, b, t)).collect())
+        }
+        (V::Vec3fVec(x), V::Vec3fVec(y)) if x.len() == y.len() => {
+            V::Vec3fVec(x.iter().zip(y).map(|(a, b)| lerp_array_f32::<3>(a, b, t)).collect())
+        }
+        (V::Vec3dVec(x), V::Vec3dVec(y)) if x.len() == y.len() => {
+            V::Vec3dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<3>(a, b, t64)).collect())
+        }
+        (V::Vec4hVec(x), V::Vec4hVec(y)) if x.len() == y.len() => {
+            V::Vec4hVec(x.iter().zip(y).map(|(a, b)| lerp_half_array::<4>(a, b, t)).collect())
+        }
+        (V::Vec4fVec(x), V::Vec4fVec(y)) if x.len() == y.len() => {
+            V::Vec4fVec(x.iter().zip(y).map(|(a, b)| lerp_array_f32::<4>(a, b, t)).collect())
+        }
+        (V::Vec4dVec(x), V::Vec4dVec(y)) if x.len() == y.len() => {
+            V::Vec4dVec(x.iter().zip(y).map(|(a, b)| lerp_array_f64::<4>(a, b, t64)).collect())
+        }
+
+        (V::QuathVec(x), V::QuathVec(y)) if x.len() == y.len() => {
+            V::QuathVec(x.iter().zip(y).map(|(a, b)| slerp_half(a, b, t)).collect())
+        }
+        (V::QuatfVec(x), V::QuatfVec(y)) if x.len() == y.len() => {
+            V::QuatfVec(x.iter().zip(y).map(|(a, b)| slerp_quatf(a, b, t)).collect())
+        }
+        (V::QuatdVec(x), V::QuatdVec(y)) if x.len() == y.len() => {
+            V::QuatdVec(x.iter().zip(y).map(|(a, b)| slerp_quatd(a, b, t64)).collect())
+        }
 
         _ => return None,
     })
@@ -381,6 +469,45 @@ mod tests {
         );
         assert!(out[2].abs() < 1e-5);
         assert!(out[3].abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_vec3f_array_lerps_per_element() {
+        let s = vec![
+            (0.0, Value::Vec3fVec(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])),
+            (10.0, Value::Vec3fVec(vec![[10.0, 0.0, 0.0], [10.0, 20.0, 0.0]])),
+        ];
+        let out = evaluate(&s, 5.0, InterpolationType::Linear).unwrap();
+        assert_eq!(out, Value::Vec3fVec(vec![[5.0, 0.0, 0.0], [10.0, 10.0, 0.0]]));
+    }
+
+    #[test]
+    fn linear_quatf_array_slerps_per_element() {
+        let s = vec![
+            (0.0, Value::QuatfVec(vec![[1.0, 0.0, 0.0, 0.0]])),
+            (10.0, Value::QuatfVec(vec![[0.0, 1.0, 0.0, 0.0]])),
+        ];
+        let out = evaluate(&s, 5.0, InterpolationType::Linear).unwrap();
+        if let Value::QuatfVec(v) = out {
+            let expected_w = std::f32::consts::FRAC_PI_4.cos();
+            let expected_x = std::f32::consts::FRAC_PI_4.sin();
+            assert!((v[0][0] - expected_w).abs() < 1e-5);
+            assert!((v[0][1] - expected_x).abs() < 1e-5);
+        } else {
+            panic!("expected QuatfVec, got {out:?}");
+        }
+    }
+
+    #[test]
+    fn linear_array_length_mismatch_falls_back_to_held() {
+        // Spec: when bracketing arrays differ in length, linear is
+        // undefined; behaviour matches Held (return the previous sample).
+        let s = vec![
+            (0.0, Value::FloatVec(vec![1.0, 2.0, 3.0])),
+            (10.0, Value::FloatVec(vec![4.0, 5.0])),
+        ];
+        let out = evaluate(&s, 5.0, InterpolationType::Linear).unwrap();
+        assert_eq!(out, Value::FloatVec(vec![1.0, 2.0, 3.0]));
     }
 
     #[test]

--- a/src/schemas/skel/anim_query.rs
+++ b/src/schemas/skel/anim_query.rs
@@ -1,0 +1,310 @@
+//! Time-dependent view of a `SkelAnimation` prim.
+//!
+//! Mirrors Pixar's `UsdSkelAnimQuery`. Thin wrapper: each
+//! `compute_*` method pulls the underlying `timeSamples` through
+//! [`crate::Stage::value_at`], so the values it returns already
+//! honour the stage's interpolation mode (AOUSD §12.5 — linear by
+//! default, with per-joint slerp for the `rotations` array).
+//!
+//! The resolver itself is static — build once, then query at
+//! whatever stage times the consumer needs. Defaults for unauthored
+//! components match Pixar's reference: identity translation, identity
+//! quaternion, unit scale, zero blend-shape weight.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value};
+use crate::Stage;
+
+use super::skinning::{mat4_mul, IDENTITY_MAT4};
+use super::tokens::{
+    A_BLEND_SHAPES, A_BLEND_SHAPE_WEIGHTS, A_JOINTS, A_ROTATIONS, A_SCALES, A_TRANSLATIONS, T_SKEL_ANIMATION,
+};
+
+/// Decomposed joint-local transforms at a stage time: one entry per
+/// joint, holding translation `[x, y, z]`, rotation `[w, x, y, z]`,
+/// and scale `[x, y, z]`. Returned by
+/// [`SkelAnimQuery::compute_joint_local_transform_components`].
+pub type JointTransformComponents = (Vec<[f32; 3]>, Vec<[f32; 4]>, Vec<[f32; 3]>);
+
+/// Pre-resolved description of one `SkelAnimation` prim. Holds the
+/// joint and blend-shape ordering tokens plus flags recording which
+/// time-sampled attributes were actually authored, so the
+/// `*_might_be_time_varying` predicates can answer without going back
+/// to the stage.
+#[derive(Debug, Clone)]
+pub struct SkelAnimQuery {
+    prim: Path,
+    joints: Vec<String>,
+    blend_shapes: Vec<String>,
+    has_translations: bool,
+    has_rotations: bool,
+    has_scales: bool,
+    has_blend_shape_weights: bool,
+}
+
+impl SkelAnimQuery {
+    /// Build a query for a `SkelAnimation` prim. Returns `None` when
+    /// the prim isn't typed `SkelAnimation`, or when neither joints
+    /// nor blend shapes are authored on it.
+    pub fn new(stage: &Stage, prim: Path) -> Result<Option<Self>> {
+        if stage.type_name(&prim)?.as_deref() != Some(T_SKEL_ANIMATION) {
+            return Ok(None);
+        }
+        let joints = read_token_vec(stage, &prim, A_JOINTS)?;
+        let blend_shapes = read_token_vec(stage, &prim, A_BLEND_SHAPES)?;
+        if joints.is_empty() && blend_shapes.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            has_translations: attr_authored(stage, &prim, A_TRANSLATIONS)?,
+            has_rotations: attr_authored(stage, &prim, A_ROTATIONS)?,
+            has_scales: attr_authored(stage, &prim, A_SCALES)?,
+            has_blend_shape_weights: attr_authored(stage, &prim, A_BLEND_SHAPE_WEIGHTS)?,
+            joints,
+            blend_shapes,
+            prim,
+        }))
+    }
+
+    /// Path of the underlying `SkelAnimation` prim.
+    pub fn prim_path(&self) -> &str {
+        self.prim.as_str()
+    }
+
+    /// Joint ordering as authored on the SkelAnimation. Does not
+    /// have to match the bound Skeleton's joint order — callers
+    /// remap by name when needed.
+    pub fn joint_order(&self) -> &[String] {
+        &self.joints
+    }
+
+    /// Blend-shape ordering as authored on the SkelAnimation.
+    pub fn blend_shape_order(&self) -> &[String] {
+        &self.blend_shapes
+    }
+
+    /// `true` when any of `translations` / `rotations` / `scales`
+    /// is authored on the prim. Mirrors Pixar's
+    /// `JointTransformsMightBeTimeVarying` — a `false` lets callers
+    /// skip per-frame work when the animation is static.
+    pub fn joint_transforms_might_be_time_varying(&self) -> bool {
+        self.has_translations || self.has_rotations || self.has_scales
+    }
+
+    /// `true` when `blendShapeWeights` is authored on the prim.
+    pub fn blend_shape_weights_might_be_time_varying(&self) -> bool {
+        self.has_blend_shape_weights
+    }
+
+    /// Returns `(translations, rotations, scales)` at `time`. Each
+    /// vector has `joints.len()` entries. Components fall back to
+    /// the spec's identity values when not authored: zero translation,
+    /// identity quaternion `(w=1, x=y=z=0)`, unit scale.
+    pub fn compute_joint_local_transform_components(
+        &self,
+        stage: &Stage,
+        time: f64,
+    ) -> Result<JointTransformComponents> {
+        let n = self.joints.len();
+        let translations = self.read_vec3f_attr_at(stage, A_TRANSLATIONS, time, n, [0.0, 0.0, 0.0])?;
+        let rotations = self.read_quatf_attr_at(stage, A_ROTATIONS, time, n, [1.0, 0.0, 0.0, 0.0])?;
+        let scales = self.read_vec3f_attr_at(stage, A_SCALES, time, n, [1.0, 1.0, 1.0])?;
+        Ok((translations, rotations, scales))
+    }
+
+    /// Returns the joint-local 4×4 transform per joint at `time`,
+    /// composed `scale · rotation · translation` in USD's row-major
+    /// convention. Callers feeding the result into
+    /// [`super::SkeletonResolver::compute_skinning_transforms_from_local`]
+    /// get full skinning transforms out the other side.
+    pub fn compute_joint_local_transforms(&self, stage: &Stage, time: f64) -> Result<Vec<[f64; 16]>> {
+        let (translations, rotations, scales) = self.compute_joint_local_transform_components(stage, time)?;
+        Ok(translations
+            .iter()
+            .zip(rotations.iter())
+            .zip(scales.iter())
+            .map(|((t, r), s)| compose_trs(*t, *r, *s))
+            .collect())
+    }
+
+    /// Blend-shape weight per entry in [`blend_shape_order`] at
+    /// `time`. Unauthored weights default to zero (no contribution).
+    pub fn compute_blend_shape_weights(&self, stage: &Stage, time: f64) -> Result<Vec<f32>> {
+        let n = self.blend_shapes.len();
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+        let attr = self.prim.append_property(A_BLEND_SHAPE_WEIGHTS)?;
+        let v = stage.value_at(attr, time)?;
+        Ok(match v {
+            Some(Value::FloatVec(w)) if w.len() == n => w,
+            Some(Value::DoubleVec(w)) if w.len() == n => w.into_iter().map(|d| d as f32).collect(),
+            Some(Value::HalfVec(w)) if w.len() == n => w.into_iter().map(f32::from).collect(),
+            _ => vec![0.0; n],
+        })
+    }
+
+    fn read_vec3f_attr_at(
+        &self,
+        stage: &Stage,
+        name: &str,
+        time: f64,
+        n: usize,
+        default: [f32; 3],
+    ) -> Result<Vec<[f32; 3]>> {
+        let attr = self.prim.append_property(name)?;
+        let v = stage.value_at(attr, time)?;
+        Ok(match v {
+            Some(Value::Vec3fVec(a)) if a.len() == n => a,
+            Some(Value::Vec3dVec(a)) if a.len() == n => {
+                a.into_iter().map(|x| [x[0] as f32, x[1] as f32, x[2] as f32]).collect()
+            }
+            Some(Value::Vec3hVec(a)) if a.len() == n => a
+                .into_iter()
+                .map(|x| [x[0].to_f32(), x[1].to_f32(), x[2].to_f32()])
+                .collect(),
+            _ => vec![default; n],
+        })
+    }
+
+    fn read_quatf_attr_at(
+        &self,
+        stage: &Stage,
+        name: &str,
+        time: f64,
+        n: usize,
+        default: [f32; 4],
+    ) -> Result<Vec<[f32; 4]>> {
+        let attr = self.prim.append_property(name)?;
+        let v = stage.value_at(attr, time)?;
+        Ok(match v {
+            Some(Value::QuatfVec(a)) if a.len() == n => a,
+            Some(Value::QuatdVec(a)) if a.len() == n => a
+                .into_iter()
+                .map(|q| [q[0] as f32, q[1] as f32, q[2] as f32, q[3] as f32])
+                .collect(),
+            Some(Value::QuathVec(a)) if a.len() == n => a
+                .into_iter()
+                .map(|q| [q[0].to_f32(), q[1].to_f32(), q[2].to_f32(), q[3].to_f32()])
+                .collect(),
+            _ => vec![default; n],
+        })
+    }
+}
+
+fn read_token_vec(stage: &Stage, prim: &Path, name: &str) -> Result<Vec<String>> {
+    let attr = prim.append_property(name)?;
+    Ok(match stage.field::<Value>(attr, "default")? {
+        Some(Value::TokenVec(v)) | Some(Value::StringVec(v)) => v,
+        _ => Vec::new(),
+    })
+}
+
+fn attr_authored(stage: &Stage, prim: &Path, name: &str) -> Result<bool> {
+    let attr = prim.append_property(name)?;
+    let default = stage.field::<Value>(attr.clone(), "default")?;
+    if default.is_some() {
+        return Ok(true);
+    }
+    let samples = stage.field::<Value>(attr, "timeSamples")?;
+    Ok(matches!(samples, Some(Value::TimeSamples(_))))
+}
+
+/// Compose translation + rotation + scale into a 4×4 in USD's
+/// row-major form, where `v_out = v_in · M`. Component order is
+/// `M = scale · rotation · translation`, matching every other matrix
+/// helper in this crate.
+fn compose_trs(t: [f32; 3], r: [f32; 4], s: [f32; 3]) -> [f64; 16] {
+    let scale = scale_matrix(s);
+    let rotation = quat_to_matrix(r);
+    let translation = translation_matrix(t);
+    mat4_mul(&mat4_mul(&scale, &rotation), &translation)
+}
+
+fn translation_matrix(t: [f32; 3]) -> [f64; 16] {
+    let mut m = IDENTITY_MAT4;
+    m[12] = t[0] as f64;
+    m[13] = t[1] as f64;
+    m[14] = t[2] as f64;
+    m
+}
+
+fn scale_matrix(s: [f32; 3]) -> [f64; 16] {
+    let mut m = IDENTITY_MAT4;
+    m[0] = s[0] as f64;
+    m[5] = s[1] as f64;
+    m[10] = s[2] as f64;
+    m
+}
+
+/// Convert a `(w, x, y, z)` quaternion to the row-major rotation
+/// matrix used elsewhere in this crate. The translation row is
+/// identity.
+fn quat_to_matrix(q: [f32; 4]) -> [f64; 16] {
+    let w = q[0] as f64;
+    let x = q[1] as f64;
+    let y = q[2] as f64;
+    let z = q[3] as f64;
+    let xx = x * x;
+    let yy = y * y;
+    let zz = z * z;
+    let xy = x * y;
+    let xz = x * z;
+    let yz = y * z;
+    let wx = w * x;
+    let wy = w * y;
+    let wz = w * z;
+    [
+        1.0 - 2.0 * (yy + zz),
+        2.0 * (xy + wz),
+        2.0 * (xz - wy),
+        0.0,
+        2.0 * (xy - wz),
+        1.0 - 2.0 * (xx + zz),
+        2.0 * (yz + wx),
+        0.0,
+        2.0 * (xz + wy),
+        2.0 * (yz - wx),
+        1.0 - 2.0 * (xx + yy),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_quat_to_matrix_is_identity() {
+        let m = quat_to_matrix([1.0, 0.0, 0.0, 0.0]);
+        assert_eq!(m, IDENTITY_MAT4);
+    }
+
+    #[test]
+    fn compose_trs_with_identity_rotation_and_unit_scale() {
+        let m = compose_trs([1.0, 2.0, 3.0], [1.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0]);
+        // Translation lives in the last row (row-major).
+        assert_eq!(m[12..16], [1.0, 2.0, 3.0, 1.0]);
+        // Upper-left 3x3 is identity.
+        assert_eq!(m[0], 1.0);
+        assert_eq!(m[5], 1.0);
+        assert_eq!(m[10], 1.0);
+    }
+
+    #[test]
+    fn compose_trs_with_scale_then_translation() {
+        let m = compose_trs([10.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [2.0, 3.0, 4.0]);
+        // Scale on diagonal.
+        assert_eq!(m[0], 2.0);
+        assert_eq!(m[5], 3.0);
+        assert_eq!(m[10], 4.0);
+        // Translation unchanged by scale (translation row is last
+        // and scale applies to the linear part).
+        assert_eq!(m[12], 10.0);
+    }
+}

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -6,11 +6,12 @@
 //! per-mesh skinning resolvers, and pure-math helpers for linear
 //! blend skinning and blend-shape application.
 //!
-//! Time-dependent evaluation (interpolating SkelAnimation samples at
-//! a stage time, computing per-frame skinning transforms) is the job
-//! of the upcoming `anim` layer. The resolvers here are designed to
-//! plug straight into that work — every API that would need a
-//! `UsdTimeCode` instead takes the already-evaluated joint poses.
+//! Time-sampled SkelAnimation evaluation is handled by
+//! [`SkelAnimQuery`], which delegates to [`crate::Stage::value_at`]
+//! and inherits the stage's interpolation mode (AOUSD §12.5 — linear
+//! by default, with per-joint slerp for `rotations`). The static
+//! resolvers below take pre-evaluated joint poses, so callers
+//! typically wire `SkelAnimQuery` into them at each frame.
 //!
 //! # Schemas
 //!
@@ -66,6 +67,7 @@
 pub mod tokens;
 
 mod anim_mapper;
+mod anim_query;
 mod binding;
 mod read;
 mod skeleton_query;
@@ -75,6 +77,7 @@ mod topology;
 mod types;
 
 pub use anim_mapper::{AnimMapper, MISSING};
+pub use anim_query::{JointTransformComponents, SkelAnimQuery};
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{
     find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,

--- a/tests/skel_reader.rs
+++ b/tests/skel_reader.rs
@@ -5,8 +5,8 @@
 
 use anyhow::Result;
 use openusd::schemas::skel::{
-    self, discover_bindings, find_skel_roots, AnimMapper, InfluenceInterpolation, SkeletonResolver, SkinningMethod,
-    SkinningResolver, Topology, NO_PARENT,
+    self, discover_bindings, find_skel_roots, AnimMapper, InfluenceInterpolation, SkelAnimQuery, SkeletonResolver,
+    SkinningMethod, SkinningResolver, Topology, NO_PARENT,
 };
 use openusd::sdf;
 use openusd::Stage;
@@ -267,4 +267,91 @@ fn anim_mapper_remap_with_missing_joints() {
     assert_eq!(m.target_len(), 3);
     let out = m.remap(&[10, 20], -1);
     assert_eq!(out, vec![20, -1, 10]);
+}
+
+#[test]
+fn skel_anim_query_orderings() -> Result<()> {
+    let stage = open()?;
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World/Character/Anim")?)?.expect("SkelAnimation");
+    assert_eq!(q.prim_path(), "/World/Character/Anim");
+    assert_eq!(q.joint_order(), &["Root", "Root/Hip", "Root/Hip/Knee"]);
+    assert_eq!(q.blend_shape_order(), &["smile"]);
+    assert!(q.joint_transforms_might_be_time_varying());
+    assert!(q.blend_shape_weights_might_be_time_varying());
+    Ok(())
+}
+
+#[test]
+fn skel_anim_query_components_at_start_frame() -> Result<()> {
+    let stage = open()?;
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World/Character/Anim")?)?.unwrap();
+    let (t, r, s) = q.compute_joint_local_transform_components(&stage, 0.0)?;
+    // Authored at t=0: hip is at (0, 1, 0), all rotations are identity,
+    // scales aren't authored so they default to unit.
+    assert_eq!(t[1], [0.0, 1.0, 0.0]);
+    assert_eq!(r[1], [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(s[1], [1.0, 1.0, 1.0]);
+    Ok(())
+}
+
+#[test]
+fn skel_anim_query_components_lerp_at_midframe() -> Result<()> {
+    let stage = open()?;
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World/Character/Anim")?)?.unwrap();
+    let (t, r, _) = q.compute_joint_local_transform_components(&stage, 5.0)?;
+    // Hip translation lerps from (0,1,0) at t=0 to (0,1.5,0) at t=10.
+    // At t=5 we expect (0, 1.25, 0).
+    assert!((t[1][1] - 1.25).abs() < 1e-5, "hip y at t=5: got {}", t[1][1]);
+    // Hip rotation slerps from identity to ~45° about +Z. At t=5 it
+    // should be a ~22.5° rotation about +Z.
+    let w_expected = (std::f32::consts::PI / 8.0).cos();
+    let z_expected = (std::f32::consts::PI / 8.0).sin();
+    assert!((r[1][0] - w_expected).abs() < 1e-3, "w: {}", r[1][0]);
+    assert!((r[1][3] - z_expected).abs() < 1e-3, "z: {}", r[1][3]);
+    Ok(())
+}
+
+#[test]
+fn skel_anim_query_blend_shape_weights_lerp() -> Result<()> {
+    let stage = open()?;
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World/Character/Anim")?)?.unwrap();
+    let w0 = q.compute_blend_shape_weights(&stage, 0.0)?;
+    assert_eq!(w0, vec![0.0]);
+    let w_mid = q.compute_blend_shape_weights(&stage, 5.0)?;
+    assert!((w_mid[0] - 0.5).abs() < 1e-5, "midpoint weight: {}", w_mid[0]);
+    let w_end = q.compute_blend_shape_weights(&stage, 10.0)?;
+    assert_eq!(w_end, vec![1.0]);
+    Ok(())
+}
+
+#[test]
+fn skel_anim_query_joint_local_matrices_drive_skeleton_resolver() -> Result<()> {
+    let stage = open()?;
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World/Character/Anim")?)?.unwrap();
+    let skl = skel::read_skeleton(&stage, &sdf::path("/World/Character/Rig")?)?.unwrap();
+    let resolver = SkeletonResolver::new(skl);
+
+    let locals = q.compute_joint_local_transforms(&stage, 0.0)?;
+    assert_eq!(locals.len(), 3);
+    // Hip's local at t=0 should carry the (0,1,0) translation in
+    // USD's row-major form (translation lives in elements [12..15]).
+    assert_eq!(&locals[1][12..15], &[0.0, 1.0, 0.0]);
+
+    // Feed into the SkeletonResolver to confirm the wiring works end
+    // to end. With identity rotations everywhere, the resulting
+    // skinning xforms should be well-formed (non-zero translation row
+    // on the moved joints).
+    let identity_world = openusd::schemas::skel::skinning::IDENTITY_MAT4;
+    let skinning = resolver.compute_skinning_transforms_from_local(&locals, &identity_world);
+    assert_eq!(skinning.len(), 3);
+    Ok(())
+}
+
+#[test]
+fn skel_anim_query_returns_none_on_non_skel_animation() -> Result<()> {
+    let stage = open()?;
+    // /World is an Xform, not a SkelAnimation.
+    let q = SkelAnimQuery::new(&stage, sdf::path("/World")?)?;
+    assert!(q.is_none());
+    Ok(())
 }


### PR DESCRIPTION
Follow-up to #71. Adds the time-sampled animation evaluator the heads-up there mentioned. With this, the existing skel resolvers can be driven at a stage time.

```
src/schemas/skel/
└── anim_query.rs       # SkelAnimQuery
```

```
src/
└── interp.rs           # extended with array variants
```

```
tests/
└── skel_reader.rs      # 6 new tests for SkelAnimQuery
```

The query wraps a SkelAnimation prim and exposes translations, rotations, scales, and blend-shape weights at a given time. It delegates to `Stage::value_at` so values inherit the stage's interpolation mode, including per-joint slerp on rotations. A separate helper composes the T/R/S triples into per-joint 4×4 matrices ready to feed the SkeletonResolver.

For rotations to actually slerp frame to frame, the interp module needed to handle array values. It now covers every VtArray variant in C++'s USD_LINEAR_INTERPOLATION_TYPES — component-wise lerp for vector and matrix arrays, per-element slerp for quaternion arrays. Length mismatches fall back to held, same as C++.

14 unit + 21 integration tests, all green.