### PR TITLE
feat: schema authoring across UsdSkel + UsdLux + UsdPhysics + UsdGeom

### DIFF
--- a/src/schemas/common.rs
+++ b/src/schemas/common.rs
@@ -1,0 +1,87 @@
+//! Low-level authoring building blocks shared across the schema families.
+//!
+//! Each helper wraps [`crate::usd::Stage`]'s public authoring entry points
+//! (`create_attribute` / `create_relationship` + the `Attribute` /
+//! `Relationship` fluent setters) with default choices that recur across
+//! `usdGeom`, `usdLux`, `usdPhysics`, and `usdSkel` (`custom = false`,
+//! `variability = Varying` unless overridden).
+//!
+//! Family-specific authoring (typed-value helpers, primvar metadata,
+//! applied-API tokens) stays in each family's `author/common.rs`; this
+//! module only holds the helpers that would otherwise be duplicated
+//! verbatim across all four.
+
+// Each helper is used by at least one schema feature, but typically not
+// all four — silence the dead-code warning on per-feature builds.
+#![allow(dead_code)]
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::{Attribute, Prim, Stage};
+
+/// Author a `varying float` attribute on `prim` with the given default value.
+pub(crate) fn author_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float")?
+        .set_custom(false)?
+        .set(Value::Float(value))?;
+    Ok(())
+}
+
+/// Author a `varying bool` attribute on `prim` with the given default value.
+pub(crate) fn author_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
+    Ok(())
+}
+
+/// Author a `uniform token` attribute on `prim` with the given default value.
+pub(crate) fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Token(value.into()))?;
+    Ok(())
+}
+
+/// Author a `uniform token[]` attribute on `prim` with the given default value.
+pub(crate) fn author_uniform_token_vec(stage: &Stage, prim: &Path, name: &str, tokens: Vec<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::TokenVec(tokens))?;
+    Ok(())
+}
+
+/// Author a relationship on `prim` with the given target paths. Thin path-based
+/// wrapper around [`Prim::author_relationship_targets`] for schema modules that
+/// still pass `(stage, prim_path)` rather than a [`Prim`] handle.
+pub(crate) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
+where
+    I: IntoIterator<Item = P>,
+    P: Into<Path>,
+{
+    Prim::new(stage, prim.clone()).author_relationship_targets(name, targets)?;
+    Ok(())
+}
+
+/// Get-or-create a varying attribute of the given `type_name` on `prim`, with
+/// `custom = false`. Callers write the value via the returned [`Attribute`]
+/// fluent setters.
+pub(crate) fn varying_attribute<'s>(
+    stage: &'s Stage,
+    prim: &Path,
+    name: &str,
+    type_name: &str,
+) -> Result<Attribute<'s>> {
+    Ok(Prim::new(stage, prim.clone()).create_attribute(name, type_name)?.set_custom(false)?)
+}

--- a/src/schemas/common.rs
+++ b/src/schemas/common.rs
@@ -83,5 +83,7 @@ pub(crate) fn varying_attribute<'s>(
     name: &str,
     type_name: &str,
 ) -> Result<Attribute<'s>> {
-    Ok(Prim::new(stage, prim.clone()).create_attribute(name, type_name)?.set_custom(false)?)
+    Ok(Prim::new(stage, prim.clone())
+        .create_attribute(name, type_name)?
+        .set_custom(false)?)
 }

--- a/src/schemas/geom/author/camera.rs
+++ b/src/schemas/geom/author/camera.rs
@@ -1,0 +1,185 @@
+//! `UsdGeomCamera` authoring.
+//!
+//! Mirrors the reader in [`super::super::camera`]: all schema attrs
+//! (focal length / aperture / fStop / focus distance / clipping range,
+//! plus shutter + exposure controls) are exposed as chainable setters.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::geom::tokens::{
+    A_CLIPPING_PLANES, A_CLIPPING_RANGE, A_EXPOSURE, A_EXPOSURE_F_STOP, A_EXPOSURE_ISO, A_EXPOSURE_RESPONSIVITY,
+    A_EXPOSURE_TIME, A_FOCAL_LENGTH, A_FOCUS_DISTANCE, A_F_STOP, A_HORIZONTAL_APERTURE, A_HORIZONTAL_APERTURE_OFFSET,
+    A_PROJECTION, A_SHUTTER_CLOSE, A_SHUTTER_OPEN, A_STEREO_ROLE, A_VERTICAL_APERTURE, A_VERTICAL_APERTURE_OFFSET,
+    T_CAMERA,
+};
+use crate::schemas::geom::types::{Projection, StereoRole};
+
+use super::common::{author_double, author_float, author_uniform_token};
+
+/// Author a `def Camera` prim and return a chainable [`CameraAuthor`].
+pub fn define_camera<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<CameraAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_CAMERA)?;
+    Ok(CameraAuthor { prim })
+}
+
+pub struct CameraAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> CameraAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `projection` (uniform token, `perspective` / `orthographic`).
+    pub fn set_projection(self, projection: Projection) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_PROJECTION, projection.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `focalLength` (float, mm).
+    pub fn set_focal_length(self, mm: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_FOCAL_LENGTH, mm)?;
+        Ok(self)
+    }
+
+    /// Set `horizontalAperture` (float, mm).
+    pub fn set_horizontal_aperture(self, mm: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_HORIZONTAL_APERTURE, mm)?;
+        Ok(self)
+    }
+
+    /// Set `verticalAperture` (float, mm).
+    pub fn set_vertical_aperture(self, mm: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_VERTICAL_APERTURE, mm)?;
+        Ok(self)
+    }
+
+    /// Set `horizontalApertureOffset` (float, mm).
+    pub fn set_horizontal_aperture_offset(self, mm: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_HORIZONTAL_APERTURE_OFFSET, mm)?;
+        Ok(self)
+    }
+
+    /// Set `verticalApertureOffset` (float, mm).
+    pub fn set_vertical_aperture_offset(self, mm: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_VERTICAL_APERTURE_OFFSET, mm)?;
+        Ok(self)
+    }
+
+    /// Set `fStop` (float, spec default 0.0 — pinhole). Pixar's
+    /// schema uses 0.0 by default per the per-attribute fallback.
+    pub fn set_f_stop(self, f_stop: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_F_STOP, f_stop)?;
+        Ok(self)
+    }
+
+    /// Set `focusDistance` (float, scene units).
+    pub fn set_focus_distance(self, distance: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_FOCUS_DISTANCE, distance)?;
+        Ok(self)
+    }
+
+    /// Set `clippingRange` (float2, `(near, far)`).
+    pub fn set_clipping_range(self, range: [f32; 2]) -> Result<Self> {
+        let attr = self.prim.path().append_property(A_CLIPPING_RANGE)?;
+        self.prim
+            .stage()
+            .create_attribute(attr, "float2")?
+            .set_custom(false)?
+            .set(Value::Vec2f(range))?;
+        Ok(self)
+    }
+
+    /// Set `clippingPlanes` (float4[] — plane equations in camera space).
+    pub fn set_clipping_planes(self, planes: Vec<[f32; 4]>) -> Result<Self> {
+        let attr = self.prim.path().append_property(A_CLIPPING_PLANES)?;
+        self.prim
+            .stage()
+            .create_attribute(attr, "float4[]")?
+            .set_custom(false)?
+            .set(Value::Vec4fVec(planes))?;
+        Ok(self)
+    }
+
+    /// Set `shutter:open` (double, frame-relative seconds before frame).
+    pub fn set_shutter_open(self, value: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_SHUTTER_OPEN, value)?;
+        Ok(self)
+    }
+
+    /// Set `shutter:close` (double, frame-relative seconds after frame).
+    pub fn set_shutter_close(self, value: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_SHUTTER_CLOSE, value)?;
+        Ok(self)
+    }
+
+    /// Set `exposure` (float, stops).
+    pub fn set_exposure(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_EXPOSURE, value)?;
+        Ok(self)
+    }
+
+    /// Set `exposure:iso` (float).
+    pub fn set_exposure_iso(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_EXPOSURE_ISO, value)?;
+        Ok(self)
+    }
+
+    /// Set `exposure:time` (float, seconds).
+    pub fn set_exposure_time(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_EXPOSURE_TIME, value)?;
+        Ok(self)
+    }
+
+    /// Set `exposure:fStop` (float).
+    pub fn set_exposure_f_stop(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_EXPOSURE_F_STOP, value)?;
+        Ok(self)
+    }
+
+    /// Set `exposure:responsivity` (float).
+    pub fn set_exposure_responsivity(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_EXPOSURE_RESPONSIVITY, value)?;
+        Ok(self)
+    }
+
+    /// Set `stereoRole` (uniform token, `mono` / `left` / `right`).
+    pub fn set_stereo_role(self, role: StereoRole) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_STEREO_ROLE, role.as_token())?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn camera_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_camera(&stage, sdf::path("/Cam")?)?
+            .set_projection(Projection::Perspective)?
+            .set_focal_length(50.0)?
+            .set_horizontal_aperture(36.0)?
+            .set_vertical_aperture(24.0)?
+            .set_f_stop(2.8)?
+            .set_focus_distance(3.0)?
+            .set_clipping_range([0.1, 1000.0])?
+            .set_shutter_open(-0.25)?
+            .set_shutter_close(0.25)?;
+
+        let cam = crate::schemas::geom::read_camera(&stage, &sdf::path("/Cam")?)?.expect("Camera");
+        assert!((cam.focal_length - 50.0).abs() < 1e-3);
+        assert!((cam.horizontal_aperture - 36.0).abs() < 1e-3);
+        assert_eq!(cam.projection, Projection::Perspective);
+        assert!((cam.f_stop - 2.8).abs() < 1e-3);
+        assert_eq!(cam.clipping_range, [0.1, 1000.0]);
+        assert!((cam.shutter_open - -0.25).abs() < 1e-6);
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/common.rs
+++ b/src/schemas/geom/author/common.rs
@@ -10,6 +10,9 @@ use anyhow::Result;
 use crate::sdf::{Path, Value, Variability};
 use crate::usd::Stage;
 
+use crate::schemas::geom::tokens::META_INTERPOLATION;
+use crate::schemas::geom::types::Interpolation;
+
 pub(super) fn author_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
     let attr_path = prim.append_property(name)?;
     stage
@@ -108,6 +111,30 @@ pub(super) fn author_float_array(stage: &Stage, prim: &Path, name: &str, value: 
         .create_attribute(attr_path, "float[]")?
         .set_custom(false)?
         .set(Value::FloatVec(value))?;
+    Ok(())
+}
+
+/// Author a primvar-style attribute with its `interpolation` metadata.
+///
+/// UsdGeom primvars (and the primvar-like `normals` / `widths` attributes on
+/// PointBased) encode per-element vs. per-prim semantics via an
+/// `interpolation` metadata field. Authoring the value without the metadata
+/// silently inherits Pixar's `constant` default, which truncates multi-element
+/// arrays to `values[0]` for any consumer that respects the field.
+pub(super) fn author_primvar(
+    stage: &Stage,
+    prim: &Path,
+    name: &str,
+    type_name: &str,
+    value: Value,
+    interpolation: Interpolation,
+) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, type_name)?
+        .set_custom(false)?
+        .set_metadata(META_INTERPOLATION, Value::Token(interpolation.as_token().to_string()))?
+        .set(value)?;
     Ok(())
 }
 

--- a/src/schemas/geom/author/common.rs
+++ b/src/schemas/geom/author/common.rs
@@ -132,7 +132,7 @@ pub(super) fn author_vec3f_pair_array(stage: &Stage, prim: &Path, name: &str, va
     stage
         .create_attribute(attr_path, "float3[]")?
         .set_custom(false)?
-        .set(Value::Vec3fVec(vec![value[0], value[1]]))?;
+        .set(Value::Vec3fVec(value.to_vec()))?;
     Ok(())
 }
 

--- a/src/schemas/geom/author/common.rs
+++ b/src/schemas/geom/author/common.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 
-use crate::sdf::{Path, Value, Variability};
+use crate::sdf::{Path, Value};
 use crate::usd::Stage;
 
 use crate::schemas::geom::tokens::META_INTERPOLATION;
@@ -22,50 +22,12 @@ pub(super) fn author_token(stage: &Stage, prim: &Path, name: &str, value: impl I
     Ok(())
 }
 
-pub(super) fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "token")?
-        .set_variability(Variability::Uniform)?
-        .set_custom(false)?
-        .set(Value::Token(value.into()))?;
-    Ok(())
-}
-
-pub(super) fn author_uniform_token_vec(stage: &Stage, prim: &Path, name: &str, tokens: Vec<String>) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "token[]")?
-        .set_variability(Variability::Uniform)?
-        .set_custom(false)?
-        .set(Value::TokenVec(tokens))?;
-    Ok(())
-}
-
-pub(super) fn author_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "float")?
-        .set_custom(false)?
-        .set(Value::Float(value))?;
-    Ok(())
-}
-
 pub(super) fn author_double(stage: &Stage, prim: &Path, name: &str, value: f64) -> Result<()> {
     let attr_path = prim.append_property(name)?;
     stage
         .create_attribute(attr_path, "double")?
         .set_custom(false)?
         .set(Value::Double(value))?;
-    Ok(())
-}
-
-pub(super) fn author_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "bool")?
-        .set_custom(false)?
-        .set(Value::Bool(value))?;
     Ok(())
 }
 
@@ -234,16 +196,4 @@ pub(super) fn author_matrix4d(stage: &Stage, prim: &Path, name: &str, value: [f6
     Ok(())
 }
 
-pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
-where
-    I: IntoIterator<Item = P>,
-    P: Into<Path>,
-{
-    let rel_path = prim.append_property(name)?;
-    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
-    stage
-        .create_relationship(rel_path)?
-        .set_custom(false)?
-        .set_targets(paths)?;
-    Ok(())
-}
+pub(super) use crate::schemas::common::{author_bool, author_float, author_rel_targets, author_uniform_token};

--- a/src/schemas/geom/author/common.rs
+++ b/src/schemas/geom/author/common.rs
@@ -1,0 +1,222 @@
+//! Shared low-level authoring helpers used across the per-prim
+//! modules. Wraps [`crate::usd::Stage`]'s public authoring API with
+//! default choices that match per-attribute schema declarations in
+//! `usdGeom/schema.usda` (variability, type name, custom flag).
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::Stage;
+
+pub(super) fn author_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_custom(false)?
+        .set(Value::Token(value.into()))?;
+    Ok(())
+}
+
+pub(super) fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Token(value.into()))?;
+    Ok(())
+}
+
+pub(super) fn author_uniform_token_vec(stage: &Stage, prim: &Path, name: &str, tokens: Vec<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::TokenVec(tokens))?;
+    Ok(())
+}
+
+pub(super) fn author_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float")?
+        .set_custom(false)?
+        .set(Value::Float(value))?;
+    Ok(())
+}
+
+pub(super) fn author_double(stage: &Stage, prim: &Path, name: &str, value: f64) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "double")?
+        .set_custom(false)?
+        .set(Value::Double(value))?;
+    Ok(())
+}
+
+pub(super) fn author_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
+    Ok(())
+}
+
+pub(super) fn author_int_vec(stage: &Stage, prim: &Path, name: &str, value: Vec<i32>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "int[]")?
+        .set_custom(false)?
+        .set(Value::IntVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_vec3f_array(stage: &Stage, prim: &Path, name: &str, value: Vec<[f32; 3]>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "vector3f[]")?
+        .set_custom(false)?
+        .set(Value::Vec3fVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_point3f_array(stage: &Stage, prim: &Path, name: &str, value: Vec<[f32; 3]>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "point3f[]")?
+        .set_custom(false)?
+        .set(Value::Vec3fVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_color3f_array(stage: &Stage, prim: &Path, name: &str, value: Vec<[f32; 3]>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "color3f[]")?
+        .set_custom(false)?
+        .set(Value::Vec3fVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_float_array(stage: &Stage, prim: &Path, name: &str, value: Vec<f32>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float[]")?
+        .set_custom(false)?
+        .set(Value::FloatVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_double_array(stage: &Stage, prim: &Path, name: &str, value: Vec<f64>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "double[]")?
+        .set_custom(false)?
+        .set(Value::DoubleVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_quatf_array(stage: &Stage, prim: &Path, name: &str, value: Vec<[f32; 4]>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "quatf[]")?
+        .set_custom(false)?
+        .set(Value::QuatfVec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_int64_array(stage: &Stage, prim: &Path, name: &str, value: Vec<i64>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "int64[]")?
+        .set_custom(false)?
+        .set(Value::Int64Vec(value))?;
+    Ok(())
+}
+
+pub(super) fn author_vec3f_pair_array(stage: &Stage, prim: &Path, name: &str, value: [[f32; 3]; 2]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float3[]")?
+        .set_custom(false)?
+        .set(Value::Vec3fVec(vec![value[0], value[1]]))?;
+    Ok(())
+}
+
+pub(super) fn author_vec3f(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "vector3f")?
+        .set_custom(false)?
+        .set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+pub(super) fn author_double3(stage: &Stage, prim: &Path, name: &str, value: [f64; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "double3")?
+        .set_custom(false)?
+        .set(Value::Vec3d(value))?;
+    Ok(())
+}
+
+pub(super) fn author_float3_scalar(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float3")?
+        .set_custom(false)?
+        .set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+pub(super) fn author_float_scalar_named_type(
+    stage: &Stage,
+    prim: &Path,
+    name: &str,
+    type_name: &str,
+    value: f32,
+) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, type_name)?
+        .set_custom(false)?
+        .set(Value::Float(value))?;
+    Ok(())
+}
+
+pub(super) fn author_quatf_scalar(stage: &Stage, prim: &Path, name: &str, value: [f32; 4]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "quatf")?
+        .set_custom(false)?
+        .set(Value::Quatf(value))?;
+    Ok(())
+}
+
+pub(super) fn author_matrix4d(stage: &Stage, prim: &Path, name: &str, value: [f64; 16]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "matrix4d")?
+        .set_custom(false)?
+        .set(Value::Matrix4d(value))?;
+    Ok(())
+}
+
+pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
+where
+    I: IntoIterator<Item = P>,
+    P: Into<Path>,
+{
+    let rel_path = prim.append_property(name)?;
+    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
+    stage
+        .create_relationship(rel_path)?
+        .set_custom(false)?
+        .set_targets(paths)?;
+    Ok(())
+}

--- a/src/schemas/geom/author/curves.rs
+++ b/src/schemas/geom/author/curves.rs
@@ -1,0 +1,445 @@
+//! Curve / patch / points / tet-mesh / point-instancer authoring.
+//!
+//! Covers `UsdGeomBasisCurves`, `UsdGeomNurbsCurves`,
+//! `UsdGeomNurbsPatch`, `UsdGeomHermiteCurves`, `UsdGeomPoints`,
+//! `UsdGeomTetMesh`, and `UsdGeomPointInstancer`. Each helper
+//! authors a typed prim and exposes chainable setters for the
+//! attribute set documented in `usdGeom/schema.usda`.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::Stage;
+
+use crate::schemas::geom::tokens::{
+    A_ACCELERATIONS, A_ANGULAR_VELOCITIES, A_BASIS, A_CURVE_VERTEX_COUNTS, A_IDS, A_INVISIBLE_IDS, A_KNOTS, A_ORDER,
+    A_ORIENTATIONS, A_POINTS, A_POSITIONS, A_PROTO_INDICES, A_RANGES, A_SCALES, A_TANGENTS, A_TET_VERTEX_INDICES,
+    A_TYPE, A_U_FORM, A_U_KNOTS, A_U_ORDER, A_U_RANGE, A_U_VERTEX_COUNT, A_VELOCITIES, A_V_FORM, A_V_KNOTS, A_V_ORDER,
+    A_V_RANGE, A_V_VERTEX_COUNT, A_WIDTHS, A_WRAP, REL_PROTOTYPES, T_BASIS_CURVES, T_HERMITE_CURVES, T_NURBS_CURVES,
+    T_NURBS_PATCH, T_POINTS, T_POINT_INSTANCER, T_TET_MESH,
+};
+
+use super::common::{
+    author_double_array, author_float_array, author_int64_array, author_int_vec, author_point3f_array,
+    author_quatf_array, author_rel_targets, author_token, author_vec3f_array,
+};
+use crate::sdf::{Value, Variability};
+
+// ── BasisCurves ────────────────────────────────────────────────────
+
+pub fn define_basis_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<BasisCurvesAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_BASIS_CURVES)?;
+    Ok(BasisCurvesAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct BasisCurvesAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl BasisCurvesAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        Ok(self)
+    }
+    /// Set `type` (`linear` / `cubic`).
+    pub fn set_curve_type(self, type_name: impl Into<String>) -> Result<Self> {
+        author_token(self.stage, &self.path, A_TYPE, type_name)?;
+        Ok(self)
+    }
+    /// Set `basis` (`bezier` / `bspline` / `catmullRom`).
+    pub fn set_basis(self, basis: impl Into<String>) -> Result<Self> {
+        author_token(self.stage, &self.path, A_BASIS, basis)?;
+        Ok(self)
+    }
+    /// Set `wrap` (`nonperiodic` / `periodic` / `pinned`).
+    pub fn set_wrap(self, wrap: impl Into<String>) -> Result<Self> {
+        author_token(self.stage, &self.path, A_WRAP, wrap)?;
+        Ok(self)
+    }
+    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
+        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+        Ok(self)
+    }
+}
+
+// ── NurbsCurves ────────────────────────────────────────────────────
+
+pub fn define_nurbs_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<NurbsCurvesAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_NURBS_CURVES)?;
+    Ok(NurbsCurvesAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct NurbsCurvesAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl NurbsCurvesAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        Ok(self)
+    }
+    pub fn set_order(self, order: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_ORDER, order)?;
+        Ok(self)
+    }
+    pub fn set_knots(self, knots: Vec<f64>) -> Result<Self> {
+        author_double_array(self.stage, &self.path, A_KNOTS, knots)?;
+        Ok(self)
+    }
+    pub fn set_ranges(self, ranges: Vec<[f64; 2]>) -> Result<Self> {
+        let attr = self.path.append_property(A_RANGES)?;
+        self.stage
+            .create_attribute(attr, "double2[]")?
+            .set_custom(false)?
+            .set(Value::Vec2dVec(ranges))?;
+        Ok(self)
+    }
+    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
+        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+        Ok(self)
+    }
+}
+
+// ── NurbsPatch ─────────────────────────────────────────────────────
+
+pub fn define_nurbs_patch<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<NurbsPatchAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_NURBS_PATCH)?;
+    Ok(NurbsPatchAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct NurbsPatchAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl NurbsPatchAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    pub fn set_uv_vertex_counts(self, u_count: i32, v_count: i32) -> Result<Self> {
+        let attr_u = self.path.append_property(A_U_VERTEX_COUNT)?;
+        self.stage
+            .create_attribute(attr_u, "int")?
+            .set_custom(false)?
+            .set(Value::Int(u_count))?;
+        let attr_v = self.path.append_property(A_V_VERTEX_COUNT)?;
+        self.stage
+            .create_attribute(attr_v, "int")?
+            .set_custom(false)?
+            .set(Value::Int(v_count))?;
+        Ok(self)
+    }
+    pub fn set_uv_order(self, u_order: i32, v_order: i32) -> Result<Self> {
+        let attr_u = self.path.append_property(A_U_ORDER)?;
+        self.stage
+            .create_attribute(attr_u, "int")?
+            .set_custom(false)?
+            .set(Value::Int(u_order))?;
+        let attr_v = self.path.append_property(A_V_ORDER)?;
+        self.stage
+            .create_attribute(attr_v, "int")?
+            .set_custom(false)?
+            .set(Value::Int(v_order))?;
+        Ok(self)
+    }
+    pub fn set_uv_knots(self, u_knots: Vec<f64>, v_knots: Vec<f64>) -> Result<Self> {
+        author_double_array(self.stage, &self.path, A_U_KNOTS, u_knots)?;
+        author_double_array(self.stage, &self.path, A_V_KNOTS, v_knots)?;
+        Ok(self)
+    }
+    pub fn set_uv_range(self, u_range: [f64; 2], v_range: [f64; 2]) -> Result<Self> {
+        let attr_u = self.path.append_property(A_U_RANGE)?;
+        self.stage
+            .create_attribute(attr_u, "double2")?
+            .set_custom(false)?
+            .set(Value::Vec2d(u_range))?;
+        let attr_v = self.path.append_property(A_V_RANGE)?;
+        self.stage
+            .create_attribute(attr_v, "double2")?
+            .set_custom(false)?
+            .set(Value::Vec2d(v_range))?;
+        Ok(self)
+    }
+    /// Set `uForm` / `vForm` (uniform token, `open` / `closed` / `periodic`).
+    pub fn set_forms(self, u_form: impl Into<String>, v_form: impl Into<String>) -> Result<Self> {
+        let attr_u = self.path.append_property(A_U_FORM)?;
+        self.stage
+            .create_attribute(attr_u, "token")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::Token(u_form.into()))?;
+        let attr_v = self.path.append_property(A_V_FORM)?;
+        self.stage
+            .create_attribute(attr_v, "token")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::Token(v_form.into()))?;
+        Ok(self)
+    }
+}
+
+// ── HermiteCurves ──────────────────────────────────────────────────
+
+pub fn define_hermite_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<HermiteCurvesAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_HERMITE_CURVES)?;
+    Ok(HermiteCurvesAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct HermiteCurvesAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl HermiteCurvesAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    pub fn set_tangents(self, tangents: Vec<[f32; 3]>) -> Result<Self> {
+        author_vec3f_array(self.stage, &self.path, A_TANGENTS, tangents)?;
+        Ok(self)
+    }
+    pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        Ok(self)
+    }
+    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
+        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+        Ok(self)
+    }
+}
+
+// ── Points ─────────────────────────────────────────────────────────
+
+pub fn define_points<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PointsAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_POINTS)?;
+    Ok(PointsAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct PointsAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl PointsAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
+        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+        Ok(self)
+    }
+    pub fn set_ids(self, ids: Vec<i64>) -> Result<Self> {
+        author_int64_array(self.stage, &self.path, A_IDS, ids)?;
+        Ok(self)
+    }
+}
+
+// ── TetMesh ────────────────────────────────────────────────────────
+
+pub fn define_tet_mesh<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<TetMeshAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_TET_MESH)?;
+    Ok(TetMeshAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct TetMeshAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl TetMeshAuthor<'_> {
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+    /// Set `tetVertexIndices` — flat `int[]` of length
+    /// `4 * num_tets`. Each consecutive 4-tuple is one tetrahedron
+    /// in the order the reader expects.
+    pub fn set_tet_vertex_indices(self, indices: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_TET_VERTEX_INDICES, indices)?;
+        Ok(self)
+    }
+}
+
+// ── PointInstancer ─────────────────────────────────────────────────
+
+pub fn define_point_instancer<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PointInstancerAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_POINT_INSTANCER)?;
+    Ok(PointInstancerAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct PointInstancerAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl PointInstancerAuthor<'_> {
+    /// Set the `prototypes` rel targets — paths to the prototype prims.
+    pub fn set_prototypes<I, P>(self, prototypes: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.stage, &self.path, REL_PROTOTYPES, prototypes)?;
+        Ok(self)
+    }
+    pub fn set_proto_indices(self, indices: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_PROTO_INDICES, indices)?;
+        Ok(self)
+    }
+    pub fn set_positions(self, positions: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POSITIONS, positions)?;
+        Ok(self)
+    }
+    pub fn set_scales(self, scales: Vec<[f32; 3]>) -> Result<Self> {
+        let attr = self.path.append_property(A_SCALES)?;
+        self.stage
+            .create_attribute(attr, "float3[]")?
+            .set_custom(false)?
+            .set(Value::Vec3fVec(scales))?;
+        Ok(self)
+    }
+    pub fn set_orientations(self, quats: Vec<[f32; 4]>) -> Result<Self> {
+        author_quatf_array(self.stage, &self.path, A_ORIENTATIONS, quats)?;
+        Ok(self)
+    }
+    pub fn set_velocities(self, velocities: Vec<[f32; 3]>) -> Result<Self> {
+        author_vec3f_array(self.stage, &self.path, A_VELOCITIES, velocities)?;
+        Ok(self)
+    }
+    pub fn set_accelerations(self, accelerations: Vec<[f32; 3]>) -> Result<Self> {
+        author_vec3f_array(self.stage, &self.path, A_ACCELERATIONS, accelerations)?;
+        Ok(self)
+    }
+    pub fn set_angular_velocities(self, vels: Vec<[f32; 3]>) -> Result<Self> {
+        author_vec3f_array(self.stage, &self.path, A_ANGULAR_VELOCITIES, vels)?;
+        Ok(self)
+    }
+    pub fn set_ids(self, ids: Vec<i64>) -> Result<Self> {
+        author_int64_array(self.stage, &self.path, A_IDS, ids)?;
+        Ok(self)
+    }
+    pub fn set_invisible_ids(self, ids: Vec<i64>) -> Result<Self> {
+        author_int64_array(self.stage, &self.path, A_INVISIBLE_IDS, ids)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::geom::{
+        define_camera, define_cube, define_mesh, define_xform, set_translate, Projection, Purpose, Visibility,
+    };
+    use crate::sdf;
+
+    #[test]
+    fn basis_curves_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_basis_curves(&stage, sdf::path("/C")?)?
+            .set_points(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])?
+            .set_curve_vertex_counts(vec![2])?
+            .set_curve_type("linear")?
+            .set_basis("bezier")?
+            .set_wrap("nonperiodic")?
+            .set_widths(vec![0.1, 0.1])?;
+
+        let c = crate::schemas::geom::read_basis_curves(&stage, &sdf::path("/C")?)?.expect("BasisCurves");
+        assert_eq!(c.points.len(), 2);
+        assert_eq!(c.curve_vertex_counts, vec![2]);
+        Ok(())
+    }
+
+    #[test]
+    fn point_instancer_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_cube(&stage, sdf::path("/Proto/Marker")?)?.set_size(0.1)?;
+        define_point_instancer(&stage, sdf::path("/Instances")?)?
+            .set_prototypes([sdf::path("/Proto/Marker")?])?
+            .set_proto_indices(vec![0, 0, 0])?
+            .set_positions(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])?
+            .set_ids(vec![100, 200, 300])?
+            .set_invisible_ids(vec![200])?;
+
+        let inst =
+            crate::schemas::geom::read_point_instancer(&stage, &sdf::path("/Instances")?)?.expect("PointInstancer");
+        assert_eq!(inst.positions.len(), 3);
+        assert_eq!(inst.proto_indices, vec![0, 0, 0]);
+        assert_eq!(inst.prototypes, vec!["/Proto/Marker".to_string()]);
+        assert_eq!(inst.invisible_ids, vec![200]);
+        Ok(())
+    }
+
+    #[test]
+    fn tet_mesh_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_tet_mesh(&stage, sdf::path("/T")?)?
+            .set_points(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])?
+            .set_tet_vertex_indices(vec![0, 1, 2, 3])?;
+
+        let t = crate::schemas::geom::read_tet_mesh(&stage, &sdf::path("/T")?)?.expect("TetMesh");
+        assert_eq!(t.points.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn full_scene_authoring_to_reader_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+
+        define_xform(&stage, sdf::path("/World")?)?;
+        set_translate(&stage, &sdf::path("/World")?, [0.0, 1.0, 0.0])?;
+        super::super::set_visibility(&stage, &sdf::path("/World")?, Visibility::Inherited)?;
+        super::super::set_purpose(&stage, &sdf::path("/World")?, Purpose::Render)?;
+
+        define_cube(&stage, sdf::path("/World/Box")?)?.set_size(0.5)?;
+        define_mesh(&stage, sdf::path("/World/Mesh")?)?
+            .set_points(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]])?
+            .set_face_vertex_counts(vec![3])?
+            .set_face_vertex_indices(vec![0, 1, 2])?;
+        define_camera(&stage, sdf::path("/World/Cam")?)?
+            .set_projection(Projection::Perspective)?
+            .set_focal_length(35.0)?;
+
+        // Read every prim back via the existing readers.
+        assert_eq!(stage.type_name(&sdf::path("/World")?)?.as_deref(), Some("Xform"),);
+        assert!(crate::schemas::geom::read_cube(&stage, &sdf::path("/World/Box")?)?.is_some());
+        assert!(crate::schemas::geom::read_mesh(&stage, &sdf::path("/World/Mesh")?)?.is_some());
+        assert!(crate::schemas::geom::read_camera(&stage, &sdf::path("/World/Cam")?)?.is_some());
+        let order = crate::schemas::geom::read_xform_op_order(&stage, &sdf::path("/World")?)?.expect("xformOpOrder");
+        assert_eq!(order, vec!["xformOp:translate".to_string()]);
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/curves.rs
+++ b/src/schemas/geom/author/curves.rs
@@ -115,7 +115,8 @@ impl<'s> NurbsCurvesAuthor<'s> {
     }
     pub fn set_ranges(self, ranges: Vec<[f64; 2]>) -> Result<Self> {
         let attr = self.prim.path().append_property(A_RANGES)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr, "double2[]")?
             .set_custom(false)?
             .set(Value::Vec2dVec(ranges))?;
@@ -157,12 +158,14 @@ impl<'s> NurbsPatchAuthor<'s> {
     }
     pub fn set_uv_vertex_counts(self, u_count: i32, v_count: i32) -> Result<Self> {
         let attr_u = self.prim.path().append_property(A_U_VERTEX_COUNT)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_u, "int")?
             .set_custom(false)?
             .set(Value::Int(u_count))?;
         let attr_v = self.prim.path().append_property(A_V_VERTEX_COUNT)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_v, "int")?
             .set_custom(false)?
             .set(Value::Int(v_count))?;
@@ -170,12 +173,14 @@ impl<'s> NurbsPatchAuthor<'s> {
     }
     pub fn set_uv_order(self, u_order: i32, v_order: i32) -> Result<Self> {
         let attr_u = self.prim.path().append_property(A_U_ORDER)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_u, "int")?
             .set_custom(false)?
             .set(Value::Int(u_order))?;
         let attr_v = self.prim.path().append_property(A_V_ORDER)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_v, "int")?
             .set_custom(false)?
             .set(Value::Int(v_order))?;
@@ -188,12 +193,14 @@ impl<'s> NurbsPatchAuthor<'s> {
     }
     pub fn set_uv_range(self, u_range: [f64; 2], v_range: [f64; 2]) -> Result<Self> {
         let attr_u = self.prim.path().append_property(A_U_RANGE)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_u, "double2")?
             .set_custom(false)?
             .set(Value::Vec2d(u_range))?;
         let attr_v = self.prim.path().append_property(A_V_RANGE)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_v, "double2")?
             .set_custom(false)?
             .set(Value::Vec2d(v_range))?;
@@ -202,13 +209,15 @@ impl<'s> NurbsPatchAuthor<'s> {
     /// Set `uForm` / `vForm` (uniform token, `open` / `closed` / `periodic`).
     pub fn set_forms(self, u_form: impl Into<String>, v_form: impl Into<String>) -> Result<Self> {
         let attr_u = self.prim.path().append_property(A_U_FORM)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_u, "token")?
             .set_variability(Variability::Uniform)?
             .set_custom(false)?
             .set(Value::Token(u_form.into()))?;
         let attr_v = self.prim.path().append_property(A_V_FORM)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr_v, "token")?
             .set_variability(Variability::Uniform)?
             .set_custom(false)?
@@ -359,7 +368,8 @@ impl<'s> PointInstancerAuthor<'s> {
     }
     pub fn set_scales(self, scales: Vec<[f32; 3]>) -> Result<Self> {
         let attr = self.prim.path().append_property(A_SCALES)?;
-        self.prim.stage()
+        self.prim
+            .stage()
             .create_attribute(attr, "float3[]")?
             .set_custom(false)?
             .set(Value::Vec3fVec(scales))?;

--- a/src/schemas/geom/author/curves.rs
+++ b/src/schemas/geom/author/curves.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 
 use crate::sdf::Path;
-use crate::usd::Stage;
+use crate::usd::{Prim, Stage};
 
 use crate::schemas::geom::tokens::{
     A_ACCELERATIONS, A_ANGULAR_VELOCITIES, A_BASIS, A_CURVE_VERTEX_COUNTS, A_IDS, A_INVISIBLE_IDS, A_KNOTS, A_ORDER,
@@ -30,39 +30,38 @@ use crate::sdf::{Value, Variability};
 
 pub fn define_basis_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<BasisCurvesAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_BASIS_CURVES)?;
-    Ok(BasisCurvesAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(BasisCurvesAuthor { prim })
 }
 
 pub struct BasisCurvesAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl BasisCurvesAuthor<'_> {
+impl<'s> BasisCurvesAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_CURVE_VERTEX_COUNTS, counts)?;
         Ok(self)
     }
     /// Set `type` (`linear` / `cubic`).
     pub fn set_curve_type(self, type_name: impl Into<String>) -> Result<Self> {
-        author_token(self.stage, &self.path, A_TYPE, type_name)?;
+        author_token(self.prim.stage(), self.prim.path(), A_TYPE, type_name)?;
         Ok(self)
     }
     /// Set `basis` (`bezier` / `bspline` / `catmullRom`).
     pub fn set_basis(self, basis: impl Into<String>) -> Result<Self> {
-        author_token(self.stage, &self.path, A_BASIS, basis)?;
+        author_token(self.prim.stage(), self.prim.path(), A_BASIS, basis)?;
         Ok(self)
     }
     /// Set `wrap` (`nonperiodic` / `periodic` / `pinned`).
     pub fn set_wrap(self, wrap: impl Into<String>) -> Result<Self> {
-        author_token(self.stage, &self.path, A_WRAP, wrap)?;
+        author_token(self.prim.stage(), self.prim.path(), A_WRAP, wrap)?;
         Ok(self)
     }
     /// Set `widths` along the curve. `interpolation` is required: Pixar's
@@ -72,8 +71,8 @@ impl BasisCurvesAuthor<'_> {
     /// first sample.
     pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             A_WIDTHS,
             "float[]",
             Value::FloatVec(widths),
@@ -87,37 +86,36 @@ impl BasisCurvesAuthor<'_> {
 
 pub fn define_nurbs_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<NurbsCurvesAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_NURBS_CURVES)?;
-    Ok(NurbsCurvesAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(NurbsCurvesAuthor { prim })
 }
 
 pub struct NurbsCurvesAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl NurbsCurvesAuthor<'_> {
+impl<'s> NurbsCurvesAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_CURVE_VERTEX_COUNTS, counts)?;
         Ok(self)
     }
     pub fn set_order(self, order: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_ORDER, order)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_ORDER, order)?;
         Ok(self)
     }
     pub fn set_knots(self, knots: Vec<f64>) -> Result<Self> {
-        author_double_array(self.stage, &self.path, A_KNOTS, knots)?;
+        author_double_array(self.prim.stage(), self.prim.path(), A_KNOTS, knots)?;
         Ok(self)
     }
     pub fn set_ranges(self, ranges: Vec<[f64; 2]>) -> Result<Self> {
-        let attr = self.path.append_property(A_RANGES)?;
-        self.stage
+        let attr = self.prim.path().append_property(A_RANGES)?;
+        self.prim.stage()
             .create_attribute(attr, "double2[]")?
             .set_custom(false)?
             .set(Value::Vec2dVec(ranges))?;
@@ -127,8 +125,8 @@ impl NurbsCurvesAuthor<'_> {
     /// [`BasisCurvesAuthor::set_widths`] for the rationale).
     pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             A_WIDTHS,
             "float[]",
             Value::FloatVec(widths),
@@ -142,61 +140,60 @@ impl NurbsCurvesAuthor<'_> {
 
 pub fn define_nurbs_patch<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<NurbsPatchAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_NURBS_PATCH)?;
-    Ok(NurbsPatchAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(NurbsPatchAuthor { prim })
 }
 
 pub struct NurbsPatchAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl NurbsPatchAuthor<'_> {
+impl<'s> NurbsPatchAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     pub fn set_uv_vertex_counts(self, u_count: i32, v_count: i32) -> Result<Self> {
-        let attr_u = self.path.append_property(A_U_VERTEX_COUNT)?;
-        self.stage
+        let attr_u = self.prim.path().append_property(A_U_VERTEX_COUNT)?;
+        self.prim.stage()
             .create_attribute(attr_u, "int")?
             .set_custom(false)?
             .set(Value::Int(u_count))?;
-        let attr_v = self.path.append_property(A_V_VERTEX_COUNT)?;
-        self.stage
+        let attr_v = self.prim.path().append_property(A_V_VERTEX_COUNT)?;
+        self.prim.stage()
             .create_attribute(attr_v, "int")?
             .set_custom(false)?
             .set(Value::Int(v_count))?;
         Ok(self)
     }
     pub fn set_uv_order(self, u_order: i32, v_order: i32) -> Result<Self> {
-        let attr_u = self.path.append_property(A_U_ORDER)?;
-        self.stage
+        let attr_u = self.prim.path().append_property(A_U_ORDER)?;
+        self.prim.stage()
             .create_attribute(attr_u, "int")?
             .set_custom(false)?
             .set(Value::Int(u_order))?;
-        let attr_v = self.path.append_property(A_V_ORDER)?;
-        self.stage
+        let attr_v = self.prim.path().append_property(A_V_ORDER)?;
+        self.prim.stage()
             .create_attribute(attr_v, "int")?
             .set_custom(false)?
             .set(Value::Int(v_order))?;
         Ok(self)
     }
     pub fn set_uv_knots(self, u_knots: Vec<f64>, v_knots: Vec<f64>) -> Result<Self> {
-        author_double_array(self.stage, &self.path, A_U_KNOTS, u_knots)?;
-        author_double_array(self.stage, &self.path, A_V_KNOTS, v_knots)?;
+        author_double_array(self.prim.stage(), self.prim.path(), A_U_KNOTS, u_knots)?;
+        author_double_array(self.prim.stage(), self.prim.path(), A_V_KNOTS, v_knots)?;
         Ok(self)
     }
     pub fn set_uv_range(self, u_range: [f64; 2], v_range: [f64; 2]) -> Result<Self> {
-        let attr_u = self.path.append_property(A_U_RANGE)?;
-        self.stage
+        let attr_u = self.prim.path().append_property(A_U_RANGE)?;
+        self.prim.stage()
             .create_attribute(attr_u, "double2")?
             .set_custom(false)?
             .set(Value::Vec2d(u_range))?;
-        let attr_v = self.path.append_property(A_V_RANGE)?;
-        self.stage
+        let attr_v = self.prim.path().append_property(A_V_RANGE)?;
+        self.prim.stage()
             .create_attribute(attr_v, "double2")?
             .set_custom(false)?
             .set(Value::Vec2d(v_range))?;
@@ -204,14 +201,14 @@ impl NurbsPatchAuthor<'_> {
     }
     /// Set `uForm` / `vForm` (uniform token, `open` / `closed` / `periodic`).
     pub fn set_forms(self, u_form: impl Into<String>, v_form: impl Into<String>) -> Result<Self> {
-        let attr_u = self.path.append_property(A_U_FORM)?;
-        self.stage
+        let attr_u = self.prim.path().append_property(A_U_FORM)?;
+        self.prim.stage()
             .create_attribute(attr_u, "token")?
             .set_variability(Variability::Uniform)?
             .set_custom(false)?
             .set(Value::Token(u_form.into()))?;
-        let attr_v = self.path.append_property(A_V_FORM)?;
-        self.stage
+        let attr_v = self.prim.path().append_property(A_V_FORM)?;
+        self.prim.stage()
             .create_attribute(attr_v, "token")?
             .set_variability(Variability::Uniform)?
             .set_custom(false)?
@@ -224,36 +221,35 @@ impl NurbsPatchAuthor<'_> {
 
 pub fn define_hermite_curves<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<HermiteCurvesAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_HERMITE_CURVES)?;
-    Ok(HermiteCurvesAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(HermiteCurvesAuthor { prim })
 }
 
 pub struct HermiteCurvesAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl HermiteCurvesAuthor<'_> {
+impl<'s> HermiteCurvesAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     pub fn set_tangents(self, tangents: Vec<[f32; 3]>) -> Result<Self> {
-        author_vec3f_array(self.stage, &self.path, A_TANGENTS, tangents)?;
+        author_vec3f_array(self.prim.stage(), self.prim.path(), A_TANGENTS, tangents)?;
         Ok(self)
     }
     pub fn set_curve_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_CURVE_VERTEX_COUNTS, counts)?;
         Ok(self)
     }
     /// Set `widths` along the curve with explicit `interpolation` (see
     /// [`BasisCurvesAuthor::set_widths`] for the rationale).
     pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             A_WIDTHS,
             "float[]",
             Value::FloatVec(widths),
@@ -267,28 +263,27 @@ impl HermiteCurvesAuthor<'_> {
 
 pub fn define_points<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PointsAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_POINTS)?;
-    Ok(PointsAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(PointsAuthor { prim })
 }
 
 pub struct PointsAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl PointsAuthor<'_> {
+impl<'s> PointsAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     /// Set per-point `widths` with explicit `interpolation` (typically
     /// `Vertex` — one width per point — or `Constant`).
     pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             A_WIDTHS,
             "float[]",
             Value::FloatVec(widths),
@@ -297,7 +292,7 @@ impl PointsAuthor<'_> {
         Ok(self)
     }
     pub fn set_ids(self, ids: Vec<i64>) -> Result<Self> {
-        author_int64_array(self.stage, &self.path, A_IDS, ids)?;
+        author_int64_array(self.prim.stage(), self.prim.path(), A_IDS, ids)?;
         Ok(self)
     }
 }
@@ -306,27 +301,26 @@ impl PointsAuthor<'_> {
 
 pub fn define_tet_mesh<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<TetMeshAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_TET_MESH)?;
-    Ok(TetMeshAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(TetMeshAuthor { prim })
 }
 
 pub struct TetMeshAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl TetMeshAuthor<'_> {
+impl<'s> TetMeshAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
     /// Set `tetVertexIndices` — flat `int[]` of length
     /// `4 * num_tets`. Each consecutive 4-tuple is one tetrahedron
     /// in the order the reader expects.
     pub fn set_tet_vertex_indices(self, indices: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_TET_VERTEX_INDICES, indices)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_TET_VERTEX_INDICES, indices)?;
         Ok(self)
     }
 }
@@ -335,65 +329,64 @@ impl TetMeshAuthor<'_> {
 
 pub fn define_point_instancer<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PointInstancerAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_POINT_INSTANCER)?;
-    Ok(PointInstancerAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(PointInstancerAuthor { prim })
 }
 
 pub struct PointInstancerAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl PointInstancerAuthor<'_> {
+impl<'s> PointInstancerAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
     /// Set the `prototypes` rel targets — paths to the prototype prims.
     pub fn set_prototypes<I, P>(self, prototypes: I) -> Result<Self>
     where
         I: IntoIterator<Item = P>,
         P: Into<Path>,
     {
-        author_rel_targets(self.stage, &self.path, REL_PROTOTYPES, prototypes)?;
+        author_rel_targets(self.prim.stage(), self.prim.path(), REL_PROTOTYPES, prototypes)?;
         Ok(self)
     }
     pub fn set_proto_indices(self, indices: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_PROTO_INDICES, indices)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_PROTO_INDICES, indices)?;
         Ok(self)
     }
     pub fn set_positions(self, positions: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POSITIONS, positions)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POSITIONS, positions)?;
         Ok(self)
     }
     pub fn set_scales(self, scales: Vec<[f32; 3]>) -> Result<Self> {
-        let attr = self.path.append_property(A_SCALES)?;
-        self.stage
+        let attr = self.prim.path().append_property(A_SCALES)?;
+        self.prim.stage()
             .create_attribute(attr, "float3[]")?
             .set_custom(false)?
             .set(Value::Vec3fVec(scales))?;
         Ok(self)
     }
     pub fn set_orientations(self, quats: Vec<[f32; 4]>) -> Result<Self> {
-        author_quatf_array(self.stage, &self.path, A_ORIENTATIONS, quats)?;
+        author_quatf_array(self.prim.stage(), self.prim.path(), A_ORIENTATIONS, quats)?;
         Ok(self)
     }
     pub fn set_velocities(self, velocities: Vec<[f32; 3]>) -> Result<Self> {
-        author_vec3f_array(self.stage, &self.path, A_VELOCITIES, velocities)?;
+        author_vec3f_array(self.prim.stage(), self.prim.path(), A_VELOCITIES, velocities)?;
         Ok(self)
     }
     pub fn set_accelerations(self, accelerations: Vec<[f32; 3]>) -> Result<Self> {
-        author_vec3f_array(self.stage, &self.path, A_ACCELERATIONS, accelerations)?;
+        author_vec3f_array(self.prim.stage(), self.prim.path(), A_ACCELERATIONS, accelerations)?;
         Ok(self)
     }
     pub fn set_angular_velocities(self, vels: Vec<[f32; 3]>) -> Result<Self> {
-        author_vec3f_array(self.stage, &self.path, A_ANGULAR_VELOCITIES, vels)?;
+        author_vec3f_array(self.prim.stage(), self.prim.path(), A_ANGULAR_VELOCITIES, vels)?;
         Ok(self)
     }
     pub fn set_ids(self, ids: Vec<i64>) -> Result<Self> {
-        author_int64_array(self.stage, &self.path, A_IDS, ids)?;
+        author_int64_array(self.prim.stage(), self.prim.path(), A_IDS, ids)?;
         Ok(self)
     }
     pub fn set_invisible_ids(self, ids: Vec<i64>) -> Result<Self> {
-        author_int64_array(self.stage, &self.path, A_INVISIBLE_IDS, ids)?;
+        author_int64_array(self.prim.stage(), self.prim.path(), A_INVISIBLE_IDS, ids)?;
         Ok(self)
     }
 }

--- a/src/schemas/geom/author/curves.rs
+++ b/src/schemas/geom/author/curves.rs
@@ -20,9 +20,10 @@ use crate::schemas::geom::tokens::{
 };
 
 use super::common::{
-    author_double_array, author_float_array, author_int64_array, author_int_vec, author_point3f_array,
-    author_quatf_array, author_rel_targets, author_token, author_vec3f_array,
+    author_double_array, author_int64_array, author_int_vec, author_point3f_array, author_primvar, author_quatf_array,
+    author_rel_targets, author_token, author_vec3f_array,
 };
+use crate::schemas::geom::types::Interpolation;
 use crate::sdf::{Value, Variability};
 
 // ── BasisCurves ────────────────────────────────────────────────────
@@ -64,8 +65,20 @@ impl BasisCurvesAuthor<'_> {
         author_token(self.stage, &self.path, A_WRAP, wrap)?;
         Ok(self)
     }
-    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
-        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+    /// Set `widths` along the curve. `interpolation` is required: Pixar's
+    /// reference treats `widths` on a curve as primvar-like with its own
+    /// interpolation (typically `Vertex` or `Varying`); leaving it unauthored
+    /// makes external consumers fall back to `constant` and lose all but the
+    /// first sample.
+    pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            A_WIDTHS,
+            "float[]",
+            Value::FloatVec(widths),
+            interpolation,
+        )?;
         Ok(self)
     }
 }
@@ -110,8 +123,17 @@ impl NurbsCurvesAuthor<'_> {
             .set(Value::Vec2dVec(ranges))?;
         Ok(self)
     }
-    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
-        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+    /// Set `widths` along the curve with explicit `interpolation` (see
+    /// [`BasisCurvesAuthor::set_widths`] for the rationale).
+    pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            A_WIDTHS,
+            "float[]",
+            Value::FloatVec(widths),
+            interpolation,
+        )?;
         Ok(self)
     }
 }
@@ -226,8 +248,17 @@ impl HermiteCurvesAuthor<'_> {
         author_int_vec(self.stage, &self.path, A_CURVE_VERTEX_COUNTS, counts)?;
         Ok(self)
     }
-    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
-        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+    /// Set `widths` along the curve with explicit `interpolation` (see
+    /// [`BasisCurvesAuthor::set_widths`] for the rationale).
+    pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            A_WIDTHS,
+            "float[]",
+            Value::FloatVec(widths),
+            interpolation,
+        )?;
         Ok(self)
     }
 }
@@ -252,8 +283,17 @@ impl PointsAuthor<'_> {
         author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
         Ok(self)
     }
-    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
-        author_float_array(self.stage, &self.path, A_WIDTHS, widths)?;
+    /// Set per-point `widths` with explicit `interpolation` (typically
+    /// `Vertex` — one width per point — or `Constant`).
+    pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            A_WIDTHS,
+            "float[]",
+            Value::FloatVec(widths),
+            interpolation,
+        )?;
         Ok(self)
     }
     pub fn set_ids(self, ids: Vec<i64>) -> Result<Self> {
@@ -375,11 +415,14 @@ mod tests {
             .set_curve_type("linear")?
             .set_basis("bezier")?
             .set_wrap("nonperiodic")?
-            .set_widths(vec![0.1, 0.1])?;
+            .set_widths(vec![0.1, 0.1], Interpolation::Vertex)?;
 
         let c = crate::schemas::geom::read_basis_curves(&stage, &sdf::path("/C")?)?.expect("BasisCurves");
         assert_eq!(c.points.len(), 2);
         assert_eq!(c.curve_vertex_counts, vec![2]);
+        assert_eq!(c.widths.len(), 2);
+        let interp = stage.field::<sdf::Value>("/C.widths", "interpolation")?;
+        assert_eq!(interp, Some(sdf::Value::Token("vertex".into())));
         Ok(())
     }
 

--- a/src/schemas/geom/author/imageable.rs
+++ b/src/schemas/geom/author/imageable.rs
@@ -1,0 +1,123 @@
+//! Imageable / Boundable cross-cutting authoring.
+//!
+//! Mirrors the cross-cutting readers in [`super::super::read`].
+//! `set_visibility` / `set_purpose` author the Imageable attributes
+//! on any UsdGeom prim; `set_extent` authors the Boundable attribute
+//! on boundable prim types.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::geom::tokens::{A_EXTENT, A_PURPOSE, A_VISIBILITY};
+use crate::schemas::geom::types::{Purpose, Visibility};
+
+use super::common::{author_uniform_token, author_vec3f_pair_array};
+
+/// Set `visibility` on a UsdGeomImageable. Per Pixar's spec, an
+/// `invisible` opinion on any ancestor prunes the subtree.
+pub fn set_visibility(stage: &Stage, prim: &Path, visibility: Visibility) -> Result<()> {
+    author_uniform_token(stage, prim, A_VISIBILITY, visibility.as_token())
+}
+
+/// Set `purpose` on a UsdGeomImageable. The enum enforces the spec's
+/// allowedTokens (`default` / `render` / `proxy` / `guide`).
+pub fn set_purpose(stage: &Stage, prim: &Path, purpose: Purpose) -> Result<()> {
+    author_uniform_token(stage, prim, A_PURPOSE, purpose.as_token())
+}
+
+/// Set `extent` on a UsdGeomBoundable — two `vector3f` corners
+/// `[(min_x, min_y, min_z), (max_x, max_y, max_z)]`.
+pub fn set_extent(stage: &Stage, prim: &Path, extent: [[f32; 3]; 2]) -> Result<()> {
+    author_vec3f_pair_array(stage, prim, A_EXTENT, extent)
+}
+
+/// Chainable handle returned by [`apply_imageable_overrides`]; lets
+/// callers wrap an existing prim spec and override `visibility` /
+/// `purpose` / `extent` opinions without explicitly retyping the
+/// path each time.
+pub struct ImageableAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> ImageableAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    pub fn set_visibility(self, visibility: Visibility) -> Result<Self> {
+        set_visibility(self.prim.stage(), self.prim.path(), visibility)?;
+        Ok(self)
+    }
+
+    pub fn set_purpose(self, purpose: Purpose) -> Result<Self> {
+        set_purpose(self.prim.stage(), self.prim.path(), purpose)?;
+        Ok(self)
+    }
+
+    pub fn set_extent(self, extent: [[f32; 3]; 2]) -> Result<Self> {
+        set_extent(self.prim.stage(), self.prim.path(), extent)?;
+        Ok(self)
+    }
+}
+
+/// Open an existing prim at `path` as `over` for setting Imageable /
+/// Boundable opinions. The typed `*Author` returned by the per-shape
+/// helpers in sibling modules already expose these setters too —
+/// reach for `apply_imageable_overrides` when you need to override
+/// these fields on a prim defined elsewhere (under a reference, etc.).
+pub fn apply_imageable_overrides<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<ImageableAuthor<'s>> {
+    let prim = stage.override_prim(path)?;
+    Ok(ImageableAuthor { prim })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn visibility_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Mesh")?.set_type_name("Mesh")?;
+        set_visibility(&stage, &sdf::path("/Mesh")?, Visibility::Invisible)?;
+
+        assert_eq!(
+            crate::schemas::geom::read_visibility(&stage, &sdf::path("/Mesh")?)?,
+            Visibility::Invisible,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn purpose_and_extent_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Cube")?.set_type_name("Cube")?;
+        set_purpose(&stage, &sdf::path("/Cube")?, Purpose::Guide)?;
+        set_extent(&stage, &sdf::path("/Cube")?, [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]])?;
+
+        assert_eq!(
+            crate::schemas::geom::read_purpose(&stage, &sdf::path("/Cube")?)?,
+            Purpose::Guide,
+        );
+        let extent = crate::schemas::geom::read_extent(&stage, &sdf::path("/Cube")?)?.expect("extent");
+        assert_eq!(extent, [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]);
+        Ok(())
+    }
+
+    #[test]
+    fn imageable_overrides_chain() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Mesh")?.set_type_name("Mesh")?;
+        apply_imageable_overrides(&stage, sdf::path("/Mesh")?)?
+            .set_visibility(Visibility::Inherited)?
+            .set_purpose(Purpose::Render)?;
+
+        assert_eq!(
+            crate::schemas::geom::read_purpose(&stage, &sdf::path("/Mesh")?)?,
+            Purpose::Render,
+        );
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/imageable.rs
+++ b/src/schemas/geom/author/imageable.rs
@@ -63,10 +63,11 @@ impl<'s> ImageableAuthor<'s> {
 }
 
 /// Open an existing prim at `path` as `over` for setting Imageable /
-/// Boundable opinions. The typed `*Author` returned by the per-shape
-/// helpers in sibling modules already expose these setters too —
-/// reach for `apply_imageable_overrides` when you need to override
-/// these fields on a prim defined elsewhere (under a reference, etc.).
+/// Boundable opinions. Useful when you need to override visibility /
+/// purpose / extent on a prim defined elsewhere (under a reference,
+/// etc.) without dragging in a typed `*Author` for the underlying
+/// schema. Otherwise prefer the free [`set_visibility`] / [`set_purpose`]
+/// / [`set_extent`] helpers, which take a `&Stage` + `&Path` directly.
 pub fn apply_imageable_overrides<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<ImageableAuthor<'s>> {
     let prim = stage.override_prim(path)?;
     Ok(ImageableAuthor { prim })

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -1,0 +1,192 @@
+//! `UsdGeomMesh` + `UsdGeomSubset` authoring, plus `primvars:*` helpers.
+//!
+//! Mesh is the workhorse gprim in USD — the helpers here cover the
+//! required topology (points / faceVertexCounts / faceVertexIndices),
+//! the common Pixar primvars (`primvars:displayColor`,
+//! `primvars:st`, normals), and `subdivisionScheme`.
+//!
+//! `define_subset` authors a face-subset prim with its
+//! `elementType` / `familyName` / `indices`, which Pixar uses for
+//! per-face material binding and similar.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::Stage;
+
+use crate::schemas::geom::tokens::{
+    A_ELEMENT_TYPE, A_FACE_VERTEX_COUNTS, A_FACE_VERTEX_INDICES, A_FAMILY_NAME, A_INDICES, A_NORMALS, A_ORIENTATION,
+    A_POINTS, A_SUBDIVISION_SCHEME, T_GEOM_SUBSET, T_MESH,
+};
+use crate::schemas::geom::types::{ElementType, Orientation};
+
+use super::common::{
+    author_color3f_array, author_float_array, author_int_vec, author_point3f_array, author_uniform_token,
+    author_vec3f_array,
+};
+
+/// Author a `def Mesh` prim and return a chainable [`MeshAuthor`].
+pub fn define_mesh<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MeshAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_MESH)?;
+    Ok(MeshAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct MeshAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl MeshAuthor<'_> {
+    /// Set `points` — vertex positions.
+    pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
+        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        Ok(self)
+    }
+
+    /// Set `faceVertexCounts` — vertices per face.
+    pub fn set_face_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_FACE_VERTEX_COUNTS, counts)?;
+        Ok(self)
+    }
+
+    /// Set `faceVertexIndices` — index buffer.
+    pub fn set_face_vertex_indices(self, indices: Vec<i32>) -> Result<Self> {
+        author_int_vec(self.stage, &self.path, A_FACE_VERTEX_INDICES, indices)?;
+        Ok(self)
+    }
+
+    /// Set `normals` (varying vector3f[]). Per UsdGeomPointBased, the
+    /// builtin `normals` attribute is varying — `primvars:normals` is
+    /// the primvar form for per-face/face-varying normals.
+    pub fn set_normals(self, normals: Vec<[f32; 3]>) -> Result<Self> {
+        author_vec3f_array(self.stage, &self.path, A_NORMALS, normals)?;
+        Ok(self)
+    }
+
+    /// Set `subdivisionScheme` (uniform token, `catmullClark` / `loop`
+    /// / `bilinear` / `none`).
+    pub fn set_subdivision_scheme(self, scheme: impl Into<String>) -> Result<Self> {
+        author_uniform_token(self.stage, &self.path, A_SUBDIVISION_SCHEME, scheme)?;
+        Ok(self)
+    }
+
+    /// Set `orientation` (uniform token, `rightHanded` / `leftHanded`).
+    pub fn set_orientation(self, orientation: Orientation) -> Result<Self> {
+        author_uniform_token(self.stage, &self.path, A_ORIENTATION, orientation.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `primvars:displayColor` (color3f[]) — the most commonly
+    /// authored display primvar. The reader exposes this directly on
+    /// the curves / mesh `Read*` structs.
+    pub fn set_display_color(self, colors: Vec<[f32; 3]>) -> Result<Self> {
+        author_color3f_array(self.stage, &self.path, "primvars:displayColor", colors)?;
+        Ok(self)
+    }
+
+    /// Set `primvars:st` (texCoord2f[]) — texture coordinates.
+    pub fn set_st(self, uvs: Vec<[f32; 2]>) -> Result<Self> {
+        let attr = self.path.append_property("primvars:st")?;
+        self.stage
+            .create_attribute(attr, "texCoord2f[]")?
+            .set_custom(false)?
+            .set(Value::Vec2fVec(uvs))?;
+        Ok(self)
+    }
+
+    /// Set `primvars:widths` (float[]) — per-point widths, mainly
+    /// used by curves but also valid on PointBased prims.
+    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
+        author_float_array(self.stage, &self.path, "primvars:widths", widths)?;
+        Ok(self)
+    }
+}
+
+/// Author a `def GeomSubset` prim under a Mesh.
+pub fn define_subset<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SubsetAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_GEOM_SUBSET)?;
+    Ok(SubsetAuthor {
+        stage,
+        path: prim.path().clone(),
+    })
+}
+
+pub struct SubsetAuthor<'s> {
+    stage: &'s Stage,
+    path: Path,
+}
+
+impl SubsetAuthor<'_> {
+    /// Set `elementType` (uniform token, `face` / `point` / `edge` /
+    /// `tetrahedron`). Spec default `face`.
+    pub fn set_element_type(self, element_type: ElementType) -> Result<Self> {
+        author_uniform_token(self.stage, &self.path, A_ELEMENT_TYPE, element_type.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `familyName` (uniform token) — groups related subsets.
+    pub fn set_family_name(self, family_name: impl Into<String>) -> Result<Self> {
+        author_uniform_token(self.stage, &self.path, A_FAMILY_NAME, family_name)?;
+        Ok(self)
+    }
+
+    /// Set `indices` (int[]) — selected element indices into the
+    /// owning Mesh.
+    pub fn set_indices(self, indices: Vec<i32>) -> Result<Self> {
+        let attr = self.path.append_property(A_INDICES)?;
+        self.stage
+            .create_attribute(attr, "int[]")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::IntVec(indices))?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn mesh_roundtrip_quad() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_mesh(&stage, sdf::path("/M")?)?
+            .set_points(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])?
+            .set_face_vertex_counts(vec![4])?
+            .set_face_vertex_indices(vec![0, 1, 2, 3])?
+            .set_subdivision_scheme("none")?
+            .set_orientation(Orientation::RightHanded)?
+            .set_display_color(vec![[1.0, 0.0, 0.0]])?
+            .set_st(vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])?;
+
+        let mesh = crate::schemas::geom::read_mesh(&stage, &sdf::path("/M")?)?.expect("Mesh");
+        assert_eq!(mesh.points.len(), 4);
+        assert_eq!(mesh.face_vertex_counts, vec![4]);
+        assert_eq!(mesh.face_vertex_indices, vec![0, 1, 2, 3]);
+        assert_eq!(mesh.orientation, Orientation::RightHanded);
+        Ok(())
+    }
+
+    #[test]
+    fn subset_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_mesh(&stage, sdf::path("/M")?)?
+            .set_points(vec![[0.0, 0.0, 0.0]])?
+            .set_face_vertex_counts(vec![3])?
+            .set_face_vertex_indices(vec![0, 0, 0])?;
+        define_subset(&stage, sdf::path("/M/RedFaces")?)?
+            .set_element_type(ElementType::Face)?
+            .set_family_name("materialBinding")?
+            .set_indices(vec![0])?;
+
+        let subset = crate::schemas::geom::read_subset(&stage, &sdf::path("/M/RedFaces")?)?.expect("Subset");
+        assert_eq!(subset.element_type, ElementType::Face);
+        assert_eq!(subset.family_name.as_deref(), Some("materialBinding"));
+        assert_eq!(subset.indices, vec![0]);
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -18,11 +18,9 @@ use crate::schemas::geom::tokens::{
     A_ELEMENT_TYPE, A_FACE_VERTEX_COUNTS, A_FACE_VERTEX_INDICES, A_FAMILY_NAME, A_INDICES, A_NORMALS, A_ORIENTATION,
     A_POINTS, A_SUBDIVISION_SCHEME, T_GEOM_SUBSET, T_MESH,
 };
-use crate::schemas::geom::types::{ElementType, Orientation};
+use crate::schemas::geom::types::{ElementType, Interpolation, Orientation};
 
-use super::common::{
-    author_color3f_array, author_float_array, author_int_vec, author_point3f_array, author_uniform_token,
-};
+use super::common::{author_int_vec, author_point3f_array, author_primvar, author_uniform_token};
 
 /// Author a `def Mesh` prim and return a chainable [`MeshAuthor`].
 pub fn define_mesh<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MeshAuthor<'s>> {
@@ -57,15 +55,22 @@ impl MeshAuthor<'_> {
         Ok(self)
     }
 
-    /// Set `normals` (`normal3f[]` per `usdGeom/schema.usda`). The
-    /// `primvars:normals` form is reserved for per-face / face-varying
-    /// normals authored as a primvar.
-    pub fn set_normals(self, normals: Vec<[f32; 3]>) -> Result<Self> {
-        let attr = self.path.append_property(A_NORMALS)?;
-        self.stage
-            .create_attribute(attr, "normal3f[]")?
-            .set_custom(false)?
-            .set(Value::Vec3fVec(normals))?;
+    /// Set `normals` (`normal3f[]` per `usdGeom/schema.usda`) with the given
+    /// `interpolation`. The `primvars:normals` form is reserved for per-face
+    /// / face-varying normals authored as a primvar.
+    ///
+    /// `interpolation` is required: USD treats unauthored interpolation as
+    /// `constant`, which would silently consume only `normals[0]` for any
+    /// downstream renderer.
+    pub fn set_normals(self, normals: Vec<[f32; 3]>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            A_NORMALS,
+            "normal3f[]",
+            Value::Vec3fVec(normals),
+            interpolation,
+        )?;
         Ok(self)
     }
 
@@ -82,28 +87,47 @@ impl MeshAuthor<'_> {
         Ok(self)
     }
 
-    /// Set `primvars:displayColor` (color3f[]) — the most commonly
-    /// authored display primvar. The reader exposes this directly on
-    /// the curves / mesh `Read*` structs.
-    pub fn set_display_color(self, colors: Vec<[f32; 3]>) -> Result<Self> {
-        author_color3f_array(self.stage, &self.path, "primvars:displayColor", colors)?;
+    /// Set `primvars:displayColor` (color3f[]) — the most commonly authored
+    /// display primvar. `interpolation` is required (see [`Self::set_normals`]
+    /// for the rationale).
+    pub fn set_display_color(self, colors: Vec<[f32; 3]>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            "primvars:displayColor",
+            "color3f[]",
+            Value::Vec3fVec(colors),
+            interpolation,
+        )?;
         Ok(self)
     }
 
     /// Set `primvars:st` (texCoord2f[]) — texture coordinates.
-    pub fn set_st(self, uvs: Vec<[f32; 2]>) -> Result<Self> {
-        let attr = self.path.append_property("primvars:st")?;
-        self.stage
-            .create_attribute(attr, "texCoord2f[]")?
-            .set_custom(false)?
-            .set(Value::Vec2fVec(uvs))?;
+    /// `interpolation` is required (typically `FaceVarying` for meshes with
+    /// UV seams, or `Vertex` for shared UV layouts).
+    pub fn set_st(self, uvs: Vec<[f32; 2]>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            "primvars:st",
+            "texCoord2f[]",
+            Value::Vec2fVec(uvs),
+            interpolation,
+        )?;
         Ok(self)
     }
 
-    /// Set `primvars:widths` (float[]) — per-point widths, mainly
-    /// used by curves but also valid on PointBased prims.
-    pub fn set_widths(self, widths: Vec<f32>) -> Result<Self> {
-        author_float_array(self.stage, &self.path, "primvars:widths", widths)?;
+    /// Set `primvars:widths` (float[]) — per-point widths, mainly used by
+    /// curves but also valid on PointBased prims.
+    pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
+        author_primvar(
+            self.stage,
+            &self.path,
+            "primvars:widths",
+            "float[]",
+            Value::FloatVec(widths),
+            interpolation,
+        )?;
         Ok(self)
     }
 }
@@ -163,14 +187,43 @@ mod tests {
             .set_face_vertex_indices(vec![0, 1, 2, 3])?
             .set_subdivision_scheme("none")?
             .set_orientation(Orientation::RightHanded)?
-            .set_display_color(vec![[1.0, 0.0, 0.0]])?
-            .set_st(vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])?;
+            .set_display_color(vec![[1.0, 0.0, 0.0]], Interpolation::Constant)?
+            .set_st(
+                vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+                Interpolation::FaceVarying,
+            )?;
 
         let mesh = crate::schemas::geom::read_mesh(&stage, &sdf::path("/M")?)?.expect("Mesh");
         assert_eq!(mesh.points.len(), 4);
         assert_eq!(mesh.face_vertex_counts, vec![4]);
         assert_eq!(mesh.face_vertex_indices, vec![0, 1, 2, 3]);
         assert_eq!(mesh.orientation, Orientation::RightHanded);
+
+        let uvs = mesh.uvs.expect("uvs");
+        assert_eq!(uvs.values.len(), 4);
+        assert_eq!(uvs.interpolation, Interpolation::FaceVarying);
+        let colors = mesh.display_color.expect("displayColor");
+        assert_eq!(colors.values.len(), 1);
+        assert_eq!(colors.interpolation, Interpolation::Constant);
+        Ok(())
+    }
+
+    #[test]
+    fn mesh_normals_roundtrip_vertex_interpolation() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_mesh(&stage, sdf::path("/M")?)?
+            .set_points(vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])?
+            .set_face_vertex_counts(vec![3])?
+            .set_face_vertex_indices(vec![0, 1, 2])?
+            .set_normals(
+                vec![[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
+                Interpolation::Vertex,
+            )?;
+
+        let mesh = crate::schemas::geom::read_mesh(&stage, &sdf::path("/M")?)?.expect("Mesh");
+        let normals = mesh.normals.expect("normals");
+        assert_eq!(normals.values.len(), 3);
+        assert_eq!(normals.interpolation, Interpolation::Vertex);
         Ok(())
     }
 

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -22,7 +22,6 @@ use crate::schemas::geom::types::{ElementType, Orientation};
 
 use super::common::{
     author_color3f_array, author_float_array, author_int_vec, author_point3f_array, author_uniform_token,
-    author_vec3f_array,
 };
 
 /// Author a `def Mesh` prim and return a chainable [`MeshAuthor`].
@@ -58,11 +57,15 @@ impl MeshAuthor<'_> {
         Ok(self)
     }
 
-    /// Set `normals` (varying vector3f[]). Per UsdGeomPointBased, the
-    /// builtin `normals` attribute is varying — `primvars:normals` is
-    /// the primvar form for per-face/face-varying normals.
+    /// Set `normals` (`normal3f[]` per `usdGeom/schema.usda`). The
+    /// `primvars:normals` form is reserved for per-face / face-varying
+    /// normals authored as a primvar.
     pub fn set_normals(self, normals: Vec<[f32; 3]>) -> Result<Self> {
-        author_vec3f_array(self.stage, &self.path, A_NORMALS, normals)?;
+        let attr = self.path.append_property(A_NORMALS)?;
+        self.stage
+            .create_attribute(attr, "normal3f[]")?
+            .set_custom(false)?
+            .set(Value::Vec3fVec(normals))?;
         Ok(self)
     }
 

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -12,7 +12,7 @@
 use anyhow::Result;
 
 use crate::sdf::{Path, Value};
-use crate::usd::Stage;
+use crate::usd::{Prim, Stage};
 
 use crate::schemas::geom::tokens::{
     A_ELEMENT_TYPE, A_FACE_VERTEX_COUNTS, A_FACE_VERTEX_INDICES, A_FAMILY_NAME, A_INDICES, A_NORMALS, A_ORIENTATION,
@@ -25,33 +25,33 @@ use super::common::{author_int_vec, author_point3f_array, author_primvar, author
 /// Author a `def Mesh` prim and return a chainable [`MeshAuthor`].
 pub fn define_mesh<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MeshAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_MESH)?;
-    Ok(MeshAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(MeshAuthor { prim })
 }
 
 pub struct MeshAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl MeshAuthor<'_> {
+impl<'s> MeshAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
     /// Set `points` — vertex positions.
     pub fn set_points(self, points: Vec<[f32; 3]>) -> Result<Self> {
-        author_point3f_array(self.stage, &self.path, A_POINTS, points)?;
+        author_point3f_array(self.prim.stage(), self.prim.path(), A_POINTS, points)?;
         Ok(self)
     }
 
     /// Set `faceVertexCounts` — vertices per face.
     pub fn set_face_vertex_counts(self, counts: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_FACE_VERTEX_COUNTS, counts)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_FACE_VERTEX_COUNTS, counts)?;
         Ok(self)
     }
 
     /// Set `faceVertexIndices` — index buffer.
     pub fn set_face_vertex_indices(self, indices: Vec<i32>) -> Result<Self> {
-        author_int_vec(self.stage, &self.path, A_FACE_VERTEX_INDICES, indices)?;
+        author_int_vec(self.prim.stage(), self.prim.path(), A_FACE_VERTEX_INDICES, indices)?;
         Ok(self)
     }
 
@@ -64,8 +64,8 @@ impl MeshAuthor<'_> {
     /// downstream renderer.
     pub fn set_normals(self, normals: Vec<[f32; 3]>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             A_NORMALS,
             "normal3f[]",
             Value::Vec3fVec(normals),
@@ -77,13 +77,13 @@ impl MeshAuthor<'_> {
     /// Set `subdivisionScheme` (uniform token, `catmullClark` / `loop`
     /// / `bilinear` / `none`).
     pub fn set_subdivision_scheme(self, scheme: impl Into<String>) -> Result<Self> {
-        author_uniform_token(self.stage, &self.path, A_SUBDIVISION_SCHEME, scheme)?;
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_SUBDIVISION_SCHEME, scheme)?;
         Ok(self)
     }
 
     /// Set `orientation` (uniform token, `rightHanded` / `leftHanded`).
     pub fn set_orientation(self, orientation: Orientation) -> Result<Self> {
-        author_uniform_token(self.stage, &self.path, A_ORIENTATION, orientation.as_token())?;
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_ORIENTATION, orientation.as_token())?;
         Ok(self)
     }
 
@@ -92,8 +92,8 @@ impl MeshAuthor<'_> {
     /// for the rationale).
     pub fn set_display_color(self, colors: Vec<[f32; 3]>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             "primvars:displayColor",
             "color3f[]",
             Value::Vec3fVec(colors),
@@ -107,8 +107,8 @@ impl MeshAuthor<'_> {
     /// UV seams, or `Vertex` for shared UV layouts).
     pub fn set_st(self, uvs: Vec<[f32; 2]>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             "primvars:st",
             "texCoord2f[]",
             Value::Vec2fVec(uvs),
@@ -121,8 +121,8 @@ impl MeshAuthor<'_> {
     /// curves but also valid on PointBased prims.
     pub fn set_widths(self, widths: Vec<f32>, interpolation: Interpolation) -> Result<Self> {
         author_primvar(
-            self.stage,
-            &self.path,
+            self.prim.stage(),
+            self.prim.path(),
             "primvars:widths",
             "float[]",
             Value::FloatVec(widths),
@@ -135,37 +135,41 @@ impl MeshAuthor<'_> {
 /// Author a `def GeomSubset` prim under a Mesh.
 pub fn define_subset<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SubsetAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_GEOM_SUBSET)?;
-    Ok(SubsetAuthor {
-        stage,
-        path: prim.path().clone(),
-    })
+    Ok(SubsetAuthor { prim })
 }
 
 pub struct SubsetAuthor<'s> {
-    stage: &'s Stage,
-    path: Path,
+    prim: Prim<'s>,
 }
 
-impl SubsetAuthor<'_> {
+impl<'s> SubsetAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
     /// Set `elementType` (uniform token, `face` / `point` / `edge` /
     /// `tetrahedron`). Spec default `face`.
     pub fn set_element_type(self, element_type: ElementType) -> Result<Self> {
-        author_uniform_token(self.stage, &self.path, A_ELEMENT_TYPE, element_type.as_token())?;
+        author_uniform_token(
+            self.prim.stage(),
+            self.prim.path(),
+            A_ELEMENT_TYPE,
+            element_type.as_token(),
+        )?;
         Ok(self)
     }
 
     /// Set `familyName` (uniform token) — groups related subsets.
     pub fn set_family_name(self, family_name: impl Into<String>) -> Result<Self> {
-        author_uniform_token(self.stage, &self.path, A_FAMILY_NAME, family_name)?;
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_FAMILY_NAME, family_name)?;
         Ok(self)
     }
 
     /// Set `indices` (int[]) — selected element indices into the
     /// owning Mesh.
     pub fn set_indices(self, indices: Vec<i32>) -> Result<Self> {
-        let attr = self.path.append_property(A_INDICES)?;
-        self.stage
-            .create_attribute(attr, "int[]")?
+        self.prim
+            .create_attribute(A_INDICES, "int[]")?
             .set_custom(false)?
             .set(Value::IntVec(indices))?;
         Ok(self)

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -11,7 +11,7 @@
 
 use anyhow::Result;
 
-use crate::sdf::{Path, Value, Variability};
+use crate::sdf::{Path, Value};
 use crate::usd::Stage;
 
 use crate::schemas::geom::tokens::{
@@ -166,7 +166,6 @@ impl SubsetAuthor<'_> {
         let attr = self.path.append_property(A_INDICES)?;
         self.stage
             .create_attribute(attr, "int[]")?
-            .set_variability(Variability::Uniform)?
             .set_custom(false)?
             .set(Value::IntVec(indices))?;
         Ok(self)

--- a/src/schemas/geom/author/mesh.rs
+++ b/src/schemas/geom/author/mesh.rs
@@ -83,7 +83,12 @@ impl<'s> MeshAuthor<'s> {
 
     /// Set `orientation` (uniform token, `rightHanded` / `leftHanded`).
     pub fn set_orientation(self, orientation: Orientation) -> Result<Self> {
-        author_uniform_token(self.prim.stage(), self.prim.path(), A_ORIENTATION, orientation.as_token())?;
+        author_uniform_token(
+            self.prim.stage(),
+            self.prim.path(),
+            A_ORIENTATION,
+            orientation.as_token(),
+        )?;
         Ok(self)
     }
 

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -15,12 +15,18 @@
 
 mod camera;
 mod common;
+mod curves;
 mod imageable;
 mod mesh;
 mod shapes;
 mod xform;
 
 pub use camera::{define_camera, CameraAuthor};
+pub use curves::{
+    define_basis_curves, define_hermite_curves, define_nurbs_curves, define_nurbs_patch, define_point_instancer,
+    define_points, define_tet_mesh, BasisCurvesAuthor, HermiteCurvesAuthor, NurbsCurvesAuthor, NurbsPatchAuthor,
+    PointInstancerAuthor, PointsAuthor, TetMeshAuthor,
+};
 pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
 pub use mesh::{define_mesh, define_subset, MeshAuthor, SubsetAuthor};
 pub use shapes::{

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -1,0 +1,19 @@
+//! Authoring helpers for the [UsdGeom](super) schema family.
+//!
+//! Mirrors the per-schema reader surface in [`super::read`] /
+//! [`super::xform`] / [`super::shapes`] / `mesh` / `curves` /
+//! `camera` / `instancer` with the inverse direction — each
+//! `define_*` / `apply_*` helper authors a typed prim or sets the
+//! schema-defined attributes that the matching reader decodes
+//! losslessly.
+//!
+//! The helpers wrap [`crate::usd::Stage`]'s authoring entry points;
+//! they only know which type tokens, attribute names, and token-allowed
+//! values Pixar's `usdGeom/schema.usda` requires. Composition, layer
+//! routing, and save flow through the same APIs a hand-rolled
+//! authoring call would use.
+
+mod common;
+mod imageable;
+
+pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -15,5 +15,10 @@
 
 mod common;
 mod imageable;
+mod xform;
 
 pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
+pub use xform::{
+    set_orient, set_rotate_x, set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate,
+    set_xform_op_order,
+};

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -13,12 +13,14 @@
 //! routing, and save flow through the same APIs a hand-rolled
 //! authoring call would use.
 
+mod camera;
 mod common;
 mod imageable;
 mod mesh;
 mod shapes;
 mod xform;
 
+pub use camera::{define_camera, CameraAuthor};
 pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
 pub use mesh::{define_mesh, define_subset, MeshAuthor, SubsetAuthor};
 pub use shapes::{

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -15,9 +15,14 @@
 
 mod common;
 mod imageable;
+mod shapes;
 mod xform;
 
 pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
+pub use shapes::{
+    define_capsule, define_cone, define_cube, define_cylinder, define_plane, define_scope, define_sphere, define_xform,
+    CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, PlaneAuthor, SphereAuthor,
+};
 pub use xform::{
     set_orient, set_rotate_x, set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate,
     set_xform_op_order,

--- a/src/schemas/geom/author/mod.rs
+++ b/src/schemas/geom/author/mod.rs
@@ -15,10 +15,12 @@
 
 mod common;
 mod imageable;
+mod mesh;
 mod shapes;
 mod xform;
 
 pub use imageable::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
+pub use mesh::{define_mesh, define_subset, MeshAuthor, SubsetAuthor};
 pub use shapes::{
     define_capsule, define_cone, define_cube, define_cylinder, define_plane, define_scope, define_sphere, define_xform,
     CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, PlaneAuthor, SphereAuthor,

--- a/src/schemas/geom/author/shapes.rs
+++ b/src/schemas/geom/author/shapes.rs
@@ -1,0 +1,247 @@
+//! Intrinsic shape authoring: `Xform`, `Scope`, plus the six
+//! Boundable gprims (Cube, Sphere, Capsule, Cone, Cylinder, Plane).
+//!
+//! Per `usdGeom/schema.usda`, each gprim has a small fixed set of
+//! attributes — radius / height / axis / size — with documented
+//! defaults. The helpers below only author values the caller passes;
+//! relying on the schema-registry default when unauthored.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::geom::tokens::{
+    A_AXIS, A_DOUBLE_SIDED, A_HEIGHT, A_LENGTH, A_RADIUS, A_SIZE, A_WIDTH, T_CAPSULE, T_CONE, T_CUBE, T_CYLINDER,
+    T_PLANE, T_SCOPE, T_SPHERE, T_XFORM,
+};
+use crate::schemas::geom::types::Axis;
+
+use super::common::{author_bool, author_double, author_uniform_token};
+
+/// Author a `def Xform` prim — a transformable grouping prim, no
+/// geometry of its own. Combine with [`super::set_translate`] / friends
+/// to compose a transform stack.
+pub fn define_xform<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<Prim<'s>> {
+    Ok(stage.define_prim(path)?.set_type_name(T_XFORM)?)
+}
+
+/// Author a `def Scope` prim — a pure grouping prim (not transformable).
+pub fn define_scope<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<Prim<'s>> {
+    Ok(stage.define_prim(path)?.set_type_name(T_SCOPE)?)
+}
+
+// ── Cube ────────────────────────────────────────────────────────────
+
+pub fn define_cube<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<CubeAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_CUBE)?;
+    Ok(CubeAuthor { prim })
+}
+
+pub struct CubeAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> CubeAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `size` (double, spec default 2.0 — edge length).
+    pub fn set_size(self, size: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_SIZE, size)?;
+        Ok(self)
+    }
+}
+
+// ── Sphere ──────────────────────────────────────────────────────────
+
+pub fn define_sphere<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SphereAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_SPHERE)?;
+    Ok(SphereAuthor { prim })
+}
+
+pub struct SphereAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SphereAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `radius` (double, spec default 1.0).
+    pub fn set_radius(self, radius: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_RADIUS, radius)?;
+        Ok(self)
+    }
+}
+
+// ── Cylinder / Capsule / Cone — same attribute set ──────────────────
+
+macro_rules! axial_shape {
+    ($author:ident, $define_fn:ident, $type_name:expr) => {
+        pub fn $define_fn<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<$author<'s>> {
+            let prim = stage.define_prim(path)?.set_type_name($type_name)?;
+            Ok($author { prim })
+        }
+
+        pub struct $author<'s> {
+            prim: Prim<'s>,
+        }
+
+        impl<'s> $author<'s> {
+            pub fn into_prim(self) -> Prim<'s> {
+                self.prim
+            }
+
+            /// Set `radius` (double).
+            pub fn set_radius(self, radius: f64) -> Result<Self> {
+                author_double(self.prim.stage(), self.prim.path(), A_RADIUS, radius)?;
+                Ok(self)
+            }
+
+            /// Set `height` (double).
+            pub fn set_height(self, height: f64) -> Result<Self> {
+                author_double(self.prim.stage(), self.prim.path(), A_HEIGHT, height)?;
+                Ok(self)
+            }
+
+            /// Set `axis` token (`X` / `Y` / `Z`). Spec default `Z`.
+            pub fn set_axis(self, axis: Axis) -> Result<Self> {
+                author_uniform_token(self.prim.stage(), self.prim.path(), A_AXIS, axis.as_token())?;
+                Ok(self)
+            }
+        }
+    };
+}
+
+axial_shape!(CylinderAuthor, define_cylinder, T_CYLINDER);
+axial_shape!(CapsuleAuthor, define_capsule, T_CAPSULE);
+axial_shape!(ConeAuthor, define_cone, T_CONE);
+
+// ── Plane ───────────────────────────────────────────────────────────
+
+pub fn define_plane<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PlaneAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PLANE)?;
+    Ok(PlaneAuthor { prim })
+}
+
+pub struct PlaneAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> PlaneAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `width` (double, spec default 1.0).
+    pub fn set_width(self, width: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_WIDTH, width)?;
+        Ok(self)
+    }
+
+    /// Set `length` (double, spec default 1.0).
+    pub fn set_length(self, length: f64) -> Result<Self> {
+        author_double(self.prim.stage(), self.prim.path(), A_LENGTH, length)?;
+        Ok(self)
+    }
+
+    /// Set `axis` — normal direction of the plane (`X` / `Y` / `Z`).
+    pub fn set_axis(self, axis: Axis) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_AXIS, axis.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `doubleSided` (bool, Plane's spec default true).
+    pub fn set_double_sided(self, double_sided: bool) -> Result<Self> {
+        author_bool(self.prim.stage(), self.prim.path(), A_DOUBLE_SIDED, double_sided)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn cube_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_cube(&stage, sdf::path("/Box")?)?.set_size(0.5)?;
+
+        let cube = crate::schemas::geom::read_cube(&stage, &sdf::path("/Box")?)?.expect("Cube");
+        assert!((cube.size - 0.5).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn sphere_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_sphere(&stage, sdf::path("/Ball")?)?.set_radius(2.5)?;
+
+        let sphere = crate::schemas::geom::read_sphere(&stage, &sdf::path("/Ball")?)?.expect("Sphere");
+        assert!((sphere.radius - 2.5).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn cylinder_roundtrip_with_axis() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_cylinder(&stage, sdf::path("/Pipe")?)?
+            .set_radius(0.3)?
+            .set_height(2.0)?
+            .set_axis(Axis::X)?;
+
+        let cyl = crate::schemas::geom::read_cylinder(&stage, &sdf::path("/Pipe")?)?.expect("Cylinder");
+        assert!((cyl.radius - 0.3).abs() < 1e-6);
+        assert!((cyl.height - 2.0).abs() < 1e-6);
+        assert_eq!(cyl.axis, Axis::X);
+        Ok(())
+    }
+
+    #[test]
+    fn capsule_and_cone_share_axial_attrs() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_capsule(&stage, sdf::path("/Pill")?)?
+            .set_radius(0.5)?
+            .set_height(2.0)?;
+        define_cone(&stage, sdf::path("/Pyramid")?)?
+            .set_radius(1.0)?
+            .set_height(2.0)?;
+
+        let cap = crate::schemas::geom::read_capsule(&stage, &sdf::path("/Pill")?)?.expect("Capsule");
+        assert!((cap.radius - 0.5).abs() < 1e-6);
+        let cone = crate::schemas::geom::read_cone(&stage, &sdf::path("/Pyramid")?)?.expect("Cone");
+        assert!((cone.height - 2.0).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn plane_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_plane(&stage, sdf::path("/Ground")?)?
+            .set_width(10.0)?
+            .set_length(20.0)?
+            .set_axis(Axis::Y)?
+            .set_double_sided(false)?;
+
+        let plane = crate::schemas::geom::read_plane(&stage, &sdf::path("/Ground")?)?.expect("Plane");
+        assert!((plane.width - 10.0).abs() < 1e-6);
+        assert!((plane.length - 20.0).abs() < 1e-6);
+        assert_eq!(plane.axis, Axis::Y);
+        Ok(())
+    }
+
+    #[test]
+    fn xform_and_scope_are_pure_typed_prims() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_xform(&stage, sdf::path("/Group")?)?;
+        define_scope(&stage, sdf::path("/Stage")?)?;
+
+        assert_eq!(stage.type_name(&sdf::path("/Group")?)?.as_deref(), Some("Xform"),);
+        assert_eq!(stage.type_name(&sdf::path("/Stage")?)?.as_deref(), Some("Scope"),);
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/xform.rs
+++ b/src/schemas/geom/author/xform.rs
@@ -1,0 +1,227 @@
+//! `UsdGeomXformable` authoring — the `xformOpOrder` mechanism.
+//!
+//! Mirrors the reader in [`super::super::xform`]. Each setter writes
+//! a single `xformOp:<kind>` attribute *and* appends its full
+//! namespaced name to the prim's `xformOpOrder` token array, so the
+//! reader recovers the same authored stack.
+//!
+//! Per Pixar's spec, the order of entries in `xformOpOrder` matches
+//! the order ops are applied. The setters here preserve insertion
+//! order — call `set_translate` then `set_rotate_y` then `set_scale`
+//! to get the canonical T·R·S stack.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::Stage;
+
+const A_XFORM_OP_ORDER: &str = "xformOpOrder";
+const NS_XFORM_OP: &str = "xformOp:";
+
+/// Reset the `xformOpOrder` to the given sequence verbatim — replaces
+/// any prior ordering. Useful when an importer wants exact control
+/// over the stack rather than relying on the per-op append behaviour
+/// of the [`set_*`] helpers below.
+pub fn set_xform_op_order<I, S>(stage: &Stage, prim: &Path, order: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let tokens: Vec<String> = order.into_iter().map(Into::into).collect();
+    let attr = prim.append_property(A_XFORM_OP_ORDER)?;
+    stage
+        .create_attribute(attr, "token[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::TokenVec(tokens))?;
+    Ok(())
+}
+
+/// Author `xformOp:translate` (`double3`) and append it to
+/// `xformOpOrder`. The full op name is `xformOp:translate`.
+pub fn set_translate(stage: &Stage, prim: &Path, value: [f64; 3]) -> Result<()> {
+    let op = "translate";
+    author_xform_op(stage, prim, op, "double3", Value::Vec3d(value))?;
+    append_op(stage, prim, op)
+}
+
+/// Author `xformOp:scale` (`float3`) and append it to `xformOpOrder`.
+pub fn set_scale(stage: &Stage, prim: &Path, value: [f32; 3]) -> Result<()> {
+    let op = "scale";
+    author_xform_op(stage, prim, op, "float3", Value::Vec3f(value))?;
+    append_op(stage, prim, op)
+}
+
+/// Author `xformOp:rotateX` in degrees and append it to `xformOpOrder`.
+pub fn set_rotate_x(stage: &Stage, prim: &Path, degrees: f32) -> Result<()> {
+    set_rotate_single(stage, prim, "rotateX", degrees)
+}
+
+/// Author `xformOp:rotateY` in degrees and append it to `xformOpOrder`.
+pub fn set_rotate_y(stage: &Stage, prim: &Path, degrees: f32) -> Result<()> {
+    set_rotate_single(stage, prim, "rotateY", degrees)
+}
+
+/// Author `xformOp:rotateZ` in degrees and append it to `xformOpOrder`.
+pub fn set_rotate_z(stage: &Stage, prim: &Path, degrees: f32) -> Result<()> {
+    set_rotate_single(stage, prim, "rotateZ", degrees)
+}
+
+/// Author `xformOp:rotateXYZ` (Euler angles in degrees, applied X →
+/// Y → Z per Pixar's C++ source) and append it to `xformOpOrder`.
+pub fn set_rotate_xyz(stage: &Stage, prim: &Path, degrees: [f32; 3]) -> Result<()> {
+    let op = "rotateXYZ";
+    author_xform_op(stage, prim, op, "float3", Value::Vec3f(degrees))?;
+    append_op(stage, prim, op)
+}
+
+/// Author `xformOp:orient` (`quatf`, `(w, x, y, z)`) and append it to
+/// `xformOpOrder`.
+pub fn set_orient(stage: &Stage, prim: &Path, quat_wxyz: [f32; 4]) -> Result<()> {
+    let op = "orient";
+    author_xform_op(stage, prim, op, "quatf", Value::Quatf(quat_wxyz))?;
+    append_op(stage, prim, op)
+}
+
+/// Author `xformOp:transform` (`matrix4d`, row-major flattened) and
+/// append it to `xformOpOrder`. Useful for authoring an exact 4×4
+/// matrix that doesn't decompose cleanly into T·R·S.
+pub fn set_transform(stage: &Stage, prim: &Path, matrix: [f64; 16]) -> Result<()> {
+    let op = "transform";
+    author_xform_op(stage, prim, op, "matrix4d", Value::Matrix4d(matrix))?;
+    append_op(stage, prim, op)
+}
+
+// ── internals ──────────────────────────────────────────────────────
+
+fn set_rotate_single(stage: &Stage, prim: &Path, op: &str, degrees: f32) -> Result<()> {
+    author_xform_op(stage, prim, op, "float", Value::Float(degrees))?;
+    append_op(stage, prim, op)
+}
+
+/// Author a single `xformOp:<kind>` attribute with the given type +
+/// value. Does NOT touch `xformOpOrder` — that's the caller's job.
+fn author_xform_op(stage: &Stage, prim: &Path, kind: &str, type_name: &str, value: Value) -> Result<()> {
+    let attr_path = prim.append_property(&format!("{NS_XFORM_OP}{kind}"))?;
+    stage
+        .create_attribute(attr_path, type_name)?
+        .set_custom(false)?
+        .set(value)?;
+    Ok(())
+}
+
+/// Append `xformOp:<kind>` to `xformOpOrder`. Re-reads any existing
+/// authored order from the stage so successive `set_*` calls
+/// compose without clobbering each other.
+fn append_op(stage: &Stage, prim: &Path, kind: &str) -> Result<()> {
+    let full_name = format!("{NS_XFORM_OP}{kind}");
+
+    let existing = super::super::xform::read_xform_op_order(stage, prim)?.unwrap_or_default();
+    if existing.iter().any(|t| t == &full_name) {
+        // Already in the order — keep insertion order, don't duplicate.
+        return Ok(());
+    }
+    let mut updated = existing;
+    updated.push(full_name);
+    set_xform_op_order(stage, prim, updated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::geom::read_xform_op_order;
+    use crate::sdf;
+
+    #[test]
+    fn translate_appears_in_xform_op_order() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        set_translate(&stage, &sdf::path("/X")?, [1.0, 2.0, 3.0])?;
+
+        let order = read_xform_op_order(&stage, &sdf::path("/X")?)?.expect("authored");
+        assert_eq!(order, vec!["xformOp:translate".to_string()]);
+
+        match stage.field::<sdf::Value>("/X.xformOp:translate", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3d(v)) => assert_eq!(v, [1.0, 2.0, 3.0]),
+            other => panic!("expected Vec3d, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn trs_stack_preserves_insertion_order() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        set_translate(&stage, &sdf::path("/X")?, [1.0, 2.0, 3.0])?;
+        set_rotate_y(&stage, &sdf::path("/X")?, 90.0)?;
+        set_scale(&stage, &sdf::path("/X")?, [2.0, 2.0, 2.0])?;
+
+        let order = read_xform_op_order(&stage, &sdf::path("/X")?)?.expect("authored");
+        assert_eq!(
+            order,
+            vec![
+                "xformOp:translate".to_string(),
+                "xformOp:rotateY".to_string(),
+                "xformOp:scale".to_string(),
+            ],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn re_authoring_same_op_does_not_duplicate_order() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        set_translate(&stage, &sdf::path("/X")?, [1.0, 0.0, 0.0])?;
+        set_translate(&stage, &sdf::path("/X")?, [2.0, 0.0, 0.0])?;
+
+        let order = read_xform_op_order(&stage, &sdf::path("/X")?)?.expect("authored");
+        assert_eq!(order, vec!["xformOp:translate".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn rotate_xyz_authors_float3() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        set_rotate_xyz(&stage, &sdf::path("/X")?, [30.0, 45.0, 60.0])?;
+
+        match stage.field::<sdf::Value>("/X.xformOp:rotateXYZ", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3f(v)) => assert_eq!(v, [30.0, 45.0, 60.0]),
+            other => panic!("expected Vec3f for rotateXYZ, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn orient_writes_quatf() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        set_orient(&stage, &sdf::path("/X")?, [1.0, 0.0, 0.0, 0.0])?;
+
+        match stage.field::<sdf::Value>("/X.xformOp:orient", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Quatf(q)) => assert_eq!(q, [1.0, 0.0, 0.0, 0.0]),
+            other => panic!("expected Quatf for orient, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn transform_op_writes_matrix4d() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Xform")?;
+        let m = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            5.0, 0.0, 0.0, 1.0,
+        ];
+        set_transform(&stage, &sdf::path("/X")?, m)?;
+
+        match stage.field::<sdf::Value>("/X.xformOp:transform", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Matrix4d(value)) => assert_eq!(value[12], 5.0),
+            other => panic!("expected Matrix4d, got {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/src/schemas/geom/author/xform.rs
+++ b/src/schemas/geom/author/xform.rs
@@ -13,7 +13,7 @@
 use anyhow::Result;
 
 use crate::sdf::{Path, Value, Variability};
-use crate::usd::Stage;
+use crate::usd::{Prim, Stage};
 
 const A_XFORM_OP_ORDER: &str = "xformOpOrder";
 const NS_XFORM_OP: &str = "xformOp:";
@@ -110,20 +110,12 @@ fn author_xform_op(stage: &Stage, prim: &Path, kind: &str, type_name: &str, valu
     Ok(())
 }
 
-/// Append `xformOp:<kind>` to `xformOpOrder`. Re-reads any existing
-/// authored order from the stage so successive `set_*` calls
-/// compose without clobbering each other.
+/// Append `xformOp:<kind>` to `xformOpOrder`. Successive `set_*` calls
+/// compose without clobbering each other; the generic ordered-token-stack
+/// logic lives on [`Prim::append_to_uniform_token_array`].
 fn append_op(stage: &Stage, prim: &Path, kind: &str) -> Result<()> {
-    let full_name = format!("{NS_XFORM_OP}{kind}");
-
-    let existing = super::super::xform::read_xform_op_order(stage, prim)?.unwrap_or_default();
-    if existing.iter().any(|t| t == &full_name) {
-        // Already in the order — keep insertion order, don't duplicate.
-        return Ok(());
-    }
-    let mut updated = existing;
-    updated.push(full_name);
-    set_xform_op_order(stage, prim, updated)
+    Prim::new(stage, prim.clone()).append_to_uniform_token_array(A_XFORM_OP_ORDER, format!("{NS_XFORM_OP}{kind}"))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -39,11 +39,13 @@ mod types;
 mod xform;
 
 pub use author::{
-    apply_imageable_overrides, define_camera, define_capsule, define_cone, define_cube, define_cylinder, define_mesh,
-    define_plane, define_scope, define_sphere, define_subset, define_xform, set_extent, set_orient, set_purpose,
-    set_rotate_x, set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate, set_visibility,
-    set_xform_op_order, CameraAuthor, CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor,
-    MeshAuthor, PlaneAuthor, SphereAuthor, SubsetAuthor,
+    apply_imageable_overrides, define_basis_curves, define_camera, define_capsule, define_cone, define_cube,
+    define_cylinder, define_hermite_curves, define_mesh, define_nurbs_curves, define_nurbs_patch, define_plane,
+    define_point_instancer, define_points, define_scope, define_sphere, define_subset, define_tet_mesh, define_xform,
+    set_extent, set_orient, set_purpose, set_rotate_x, set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale,
+    set_transform, set_translate, set_visibility, set_xform_op_order, BasisCurvesAuthor, CameraAuthor, CapsuleAuthor,
+    ConeAuthor, CubeAuthor, CylinderAuthor, HermiteCurvesAuthor, ImageableAuthor, MeshAuthor, NurbsCurvesAuthor,
+    NurbsPatchAuthor, PlaneAuthor, PointInstancerAuthor, PointsAuthor, SphereAuthor, SubsetAuthor, TetMeshAuthor,
 };
 pub use camera::read_camera;
 pub use curves::{

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -39,10 +39,11 @@ mod types;
 mod xform;
 
 pub use author::{
-    apply_imageable_overrides, define_capsule, define_cone, define_cube, define_cylinder, define_plane, define_scope,
-    define_sphere, define_xform, set_extent, set_orient, set_purpose, set_rotate_x, set_rotate_xyz, set_rotate_y,
-    set_rotate_z, set_scale, set_transform, set_translate, set_visibility, set_xform_op_order, CapsuleAuthor,
-    ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor, PlaneAuthor, SphereAuthor,
+    apply_imageable_overrides, define_capsule, define_cone, define_cube, define_cylinder, define_mesh, define_plane,
+    define_scope, define_sphere, define_subset, define_xform, set_extent, set_orient, set_purpose, set_rotate_x,
+    set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate, set_visibility,
+    set_xform_op_order, CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor, MeshAuthor,
+    PlaneAuthor, SphereAuthor, SubsetAuthor,
 };
 pub use camera::read_camera;
 pub use curves::{

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -38,7 +38,10 @@ mod shapes;
 mod types;
 mod xform;
 
-pub use author::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
+pub use author::{
+    apply_imageable_overrides, set_extent, set_orient, set_purpose, set_rotate_x, set_rotate_xyz, set_rotate_y,
+    set_rotate_z, set_scale, set_transform, set_translate, set_visibility, set_xform_op_order, ImageableAuthor,
+};
 pub use camera::read_camera;
 pub use curves::{
     read_basis_curves, read_hermite_curves, read_nurbs_curves, read_nurbs_patch, read_points, read_tet_mesh,

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -39,8 +39,10 @@ mod types;
 mod xform;
 
 pub use author::{
-    apply_imageable_overrides, set_extent, set_orient, set_purpose, set_rotate_x, set_rotate_xyz, set_rotate_y,
-    set_rotate_z, set_scale, set_transform, set_translate, set_visibility, set_xform_op_order, ImageableAuthor,
+    apply_imageable_overrides, define_capsule, define_cone, define_cube, define_cylinder, define_plane, define_scope,
+    define_sphere, define_xform, set_extent, set_orient, set_purpose, set_rotate_x, set_rotate_xyz, set_rotate_y,
+    set_rotate_z, set_scale, set_transform, set_translate, set_visibility, set_xform_op_order, CapsuleAuthor,
+    ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor, PlaneAuthor, SphereAuthor,
 };
 pub use camera::read_camera;
 pub use curves::{

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -39,11 +39,11 @@ mod types;
 mod xform;
 
 pub use author::{
-    apply_imageable_overrides, define_capsule, define_cone, define_cube, define_cylinder, define_mesh, define_plane,
-    define_scope, define_sphere, define_subset, define_xform, set_extent, set_orient, set_purpose, set_rotate_x,
-    set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate, set_visibility,
-    set_xform_op_order, CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor, MeshAuthor,
-    PlaneAuthor, SphereAuthor, SubsetAuthor,
+    apply_imageable_overrides, define_camera, define_capsule, define_cone, define_cube, define_cylinder, define_mesh,
+    define_plane, define_scope, define_sphere, define_subset, define_xform, set_extent, set_orient, set_purpose,
+    set_rotate_x, set_rotate_xyz, set_rotate_y, set_rotate_z, set_scale, set_transform, set_translate, set_visibility,
+    set_xform_op_order, CameraAuthor, CapsuleAuthor, ConeAuthor, CubeAuthor, CylinderAuthor, ImageableAuthor,
+    MeshAuthor, PlaneAuthor, SphereAuthor, SubsetAuthor,
 };
 pub use camera::read_camera;
 pub use curves::{

--- a/src/schemas/geom/mod.rs
+++ b/src/schemas/geom/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod tokens;
 
+mod author;
 mod camera;
 mod curves;
 mod instancer;
@@ -37,6 +38,7 @@ mod shapes;
 mod types;
 mod xform;
 
+pub use author::{apply_imageable_overrides, set_extent, set_purpose, set_visibility, ImageableAuthor};
 pub use camera::read_camera;
 pub use curves::{
     read_basis_curves, read_hermite_curves, read_nurbs_curves, read_nurbs_patch, read_points, read_tet_mesh,

--- a/src/schemas/lux/author/boundable.rs
+++ b/src/schemas/lux/author/boundable.rs
@@ -1,0 +1,294 @@
+//! Authoring helpers for the boundable concrete light prims:
+//! `DiskLight`, `RectLight`, `SphereLight`, `CylinderLight`,
+//! `PortalLight`.
+//!
+//! All five inherit `BoundableLightBase` in `usdLux/schema.usda` and
+//! auto-apply `LightAPI`, so each `*LightAuthor` exposes the shared
+//! LightAPI setters via the [`super::LightApiSetters`] trait plus the
+//! per-light geometry attributes the schema defines.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{
+    A_HEIGHT, A_LENGTH, A_RADIUS, A_TEXTURE_FILE, A_WIDTH, T_CYLINDER_LIGHT, T_DISK_LIGHT, T_PORTAL_LIGHT,
+    T_RECT_LIGHT, T_SPHERE_LIGHT,
+};
+
+use super::common::{author_input_asset, author_input_float, author_treat_as_line, author_treat_as_point};
+use super::light_api::LightApiSetters;
+
+/// Author a `def DiskLight` prim at `path`. Returns a chainable
+/// [`DiskLightAuthor`] exposing LightAPI setters via
+/// [`LightApiSetters`] plus the disk-specific `inputs:radius`.
+pub fn define_disk_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<DiskLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_DISK_LIGHT)?;
+    Ok(DiskLightAuthor { prim })
+}
+
+pub struct DiskLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> DiskLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:radius` (spec default 0.5).
+    pub fn set_radius(self, radius: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_RADIUS, radius)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for DiskLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── RectLight ───────────────────────────────────────────────────────
+
+/// Author a `def RectLight` prim at `path`. Per spec, the rectangle is
+/// centered in the XY plane (1 unit in each axis by default) and emits
+/// light along the -Z axis.
+pub fn define_rect_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<RectLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_RECT_LIGHT)?;
+    Ok(RectLightAuthor { prim })
+}
+
+pub struct RectLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> RectLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:width` along the local X axis (spec default 1).
+    pub fn set_width(self, width: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_WIDTH, width)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:height` along the local Y axis (spec default 1).
+    pub fn set_height(self, height: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_HEIGHT, height)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:texture:file` — a color texture mapped onto the rectangle.
+    pub fn set_texture_file(self, path: impl Into<String>) -> Result<Self> {
+        author_input_asset(self.prim.stage(), self.prim.path(), A_TEXTURE_FILE, path)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for RectLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── SphereLight ─────────────────────────────────────────────────────
+
+/// Author a `def SphereLight` prim at `path`.
+pub fn define_sphere_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SphereLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_SPHERE_LIGHT)?;
+    Ok(SphereLightAuthor { prim })
+}
+
+pub struct SphereLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SphereLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:radius` (spec default 0.5).
+    pub fn set_radius(self, radius: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_RADIUS, radius)?;
+        Ok(self)
+    }
+
+    /// Set `treatAsPoint` (spec default false). Note: per spec this is
+    /// authored at the bare attribute name (not `inputs:`-prefixed).
+    pub fn set_treat_as_point(self, treat_as_point: bool) -> Result<Self> {
+        author_treat_as_point(self.prim.stage(), self.prim.path(), treat_as_point)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for SphereLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── CylinderLight ───────────────────────────────────────────────────
+
+/// Author a `def CylinderLight` prim at `path`. The cylinder is
+/// centered at the origin with its major axis along X per spec.
+pub fn define_cylinder_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<CylinderLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_CYLINDER_LIGHT)?;
+    Ok(CylinderLightAuthor { prim })
+}
+
+pub struct CylinderLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> CylinderLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:length` along the local X axis (spec default 1).
+    pub fn set_length(self, length: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_LENGTH, length)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:radius` (spec default 0.5).
+    pub fn set_radius(self, radius: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_RADIUS, radius)?;
+        Ok(self)
+    }
+
+    /// Set `treatAsLine` (spec default false). Authored at the bare
+    /// attribute name, mirroring `treatAsPoint` on SphereLight.
+    pub fn set_treat_as_line(self, treat_as_line: bool) -> Result<Self> {
+        author_treat_as_line(self.prim.stage(), self.prim.path(), treat_as_line)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for CylinderLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PortalLight ─────────────────────────────────────────────────────
+
+/// Author a `def PortalLight` prim at `path`. A portal is a rectangle
+/// in the local XY plane used to guide sampling of an enclosing
+/// DomeLight (spec default size 1×1).
+pub fn define_portal_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PortalLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PORTAL_LIGHT)?;
+    Ok(PortalLightAuthor { prim })
+}
+
+pub struct PortalLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> PortalLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:width` along the local X axis (spec default 1).
+    pub fn set_width(self, width: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_WIDTH, width)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:height` along the local Y axis (spec default 1).
+    pub fn set_height(self, height: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_HEIGHT, height)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for PortalLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn disk_light_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_disk_light(&stage, sdf::path("/Disk")?)?
+            .set_radius(0.75)?
+            .set_intensity(600.0)?
+            .set_color([1.0, 0.5, 0.5])?;
+
+        let light = crate::schemas::lux::read_disk_light(&stage, &sdf::path("/Disk")?)?.expect("DiskLight");
+        assert!((light.radius - 0.75).abs() < 1e-3);
+        assert!((light.common.intensity - 600.0).abs() < 1e-3);
+        assert_eq!(light.common.color, [1.0, 0.5, 0.5]);
+        Ok(())
+    }
+
+    #[test]
+    fn rect_light_roundtrip_with_texture() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_rect_light(&stage, sdf::path("/Rect")?)?
+            .set_width(2.0)?
+            .set_height(1.0)?
+            .set_texture_file("./softbox.exr")?
+            .set_intensity(1500.0)?;
+
+        let light = crate::schemas::lux::read_rect_light(&stage, &sdf::path("/Rect")?)?.expect("RectLight");
+        assert!((light.width - 2.0).abs() < 1e-3);
+        assert!((light.height - 1.0).abs() < 1e-3);
+        assert_eq!(light.texture_file.as_deref(), Some("./softbox.exr"));
+        assert!((light.common.intensity - 1500.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn sphere_light_treat_as_point_flag() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_sphere_light(&stage, sdf::path("/Bulb")?)?
+            .set_radius(0.1)?
+            .set_treat_as_point(true)?
+            .set_intensity(800.0)?;
+
+        let light = crate::schemas::lux::read_sphere_light(&stage, &sdf::path("/Bulb")?)?.expect("SphereLight");
+        assert!((light.radius - 0.1).abs() < 1e-3);
+        assert!(light.treat_as_point);
+        Ok(())
+    }
+
+    #[test]
+    fn cylinder_light_treat_as_line_flag() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_cylinder_light(&stage, sdf::path("/Tube")?)?
+            .set_length(3.0)?
+            .set_radius(0.05)?
+            .set_treat_as_line(true)?;
+
+        let light = crate::schemas::lux::read_cylinder_light(&stage, &sdf::path("/Tube")?)?.expect("CylinderLight");
+        assert!((light.length - 3.0).abs() < 1e-3);
+        assert!((light.radius - 0.05).abs() < 1e-3);
+        assert!(light.treat_as_line);
+        Ok(())
+    }
+
+    #[test]
+    fn portal_light_dimensions() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_portal_light(&stage, sdf::path("/Portal")?)?
+            .set_width(1.2)?
+            .set_height(2.4)?;
+
+        let portal = crate::schemas::lux::read_portal_light(&stage, &sdf::path("/Portal")?)?.expect("PortalLight");
+        assert!((portal.width - 1.2).abs() < 1e-3);
+        assert!((portal.height - 2.4).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/lux/author/common.rs
+++ b/src/schemas/lux/author/common.rs
@@ -1,0 +1,52 @@
+//! Shared low-level authoring helpers for the per-prim modules under
+//! [`super`].
+//!
+//! Mirrors `schemas::skel::author::common`: each helper wraps a
+//! [`crate::usd::Stage::create_attribute`] call with default choices that
+//! match the per-attribute schema declarations in
+//! `usdLux/schema.usda` (variability, type name, custom flag).
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value};
+use crate::usd::{Attribute, Stage};
+
+/// Author a `varying float` input on `prim` with the given default value.
+pub(super) fn author_input_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
+    varying_attribute(stage, prim, name, "float")?.set(Value::Float(value))?;
+    Ok(())
+}
+
+/// Author a `varying bool` input on `prim` with the given default value.
+pub(super) fn author_input_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
+    varying_attribute(stage, prim, name, "bool")?.set(Value::Bool(value))?;
+    Ok(())
+}
+
+/// Author a `varying color3f` input on `prim` with the given default value.
+pub(super) fn author_input_color3f(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    varying_attribute(stage, prim, name, "color3f")?.set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+/// Author a relationship at `prim.name` with a single target.
+pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
+where
+    I: IntoIterator<Item = P>,
+    P: Into<Path>,
+{
+    let rel_path = prim.append_property(name)?;
+    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
+    stage
+        .create_relationship(rel_path)?
+        .set_custom(false)?
+        .set_targets(paths)?;
+    Ok(())
+}
+
+/// Get-or-create a varying attribute with the given type. Returned
+/// handle defaults to `custom = false` and `variability = Varying`.
+fn varying_attribute<'s>(stage: &'s Stage, prim: &Path, name: &str, type_name: &str) -> Result<Attribute<'s>> {
+    let attr_path = prim.append_property(name)?;
+    Ok(stage.create_attribute(attr_path, type_name)?.set_custom(false)?)
+}

--- a/src/schemas/lux/author/common.rs
+++ b/src/schemas/lux/author/common.rs
@@ -11,6 +11,8 @@ use anyhow::Result;
 use crate::sdf::{Path, Value};
 use crate::usd::{Attribute, Stage};
 
+use crate::schemas::lux::tokens::{A_TREAT_AS_LINE, A_TREAT_AS_POINT};
+
 /// Author a `varying float` input on `prim` with the given default value.
 pub(super) fn author_input_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
     varying_attribute(stage, prim, name, "float")?.set(Value::Float(value))?;
@@ -41,6 +43,34 @@ where
         .create_relationship(rel_path)?
         .set_custom(false)?
         .set_targets(paths)?;
+    Ok(())
+}
+
+/// Author a `varying asset` input on `prim` with the given default value.
+pub(super) fn author_input_asset(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    varying_attribute(stage, prim, name, "asset")?.set(Value::AssetPath(value.into()))?;
+    Ok(())
+}
+
+/// Author the `treatAsPoint` bool flag on a SphereLight prim. Sits at
+/// the bare attribute name (not `inputs:`-prefixed) per
+/// `usdLux/schema.usda`.
+pub(super) fn author_treat_as_point(stage: &Stage, prim: &Path, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(A_TREAT_AS_POINT)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
+    Ok(())
+}
+
+/// Author the `treatAsLine` bool flag on a CylinderLight prim.
+pub(super) fn author_treat_as_line(stage: &Stage, prim: &Path, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(A_TREAT_AS_LINE)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
     Ok(())
 }
 

--- a/src/schemas/lux/author/common.rs
+++ b/src/schemas/lux/author/common.rs
@@ -60,4 +60,3 @@ pub(super) fn author_treat_as_line(stage: &Stage, prim: &Path, value: bool) -> R
         .set(Value::Bool(value))?;
     Ok(())
 }
-

--- a/src/schemas/lux/author/common.rs
+++ b/src/schemas/lux/author/common.rs
@@ -9,9 +9,11 @@
 use anyhow::Result;
 
 use crate::sdf::{Path, Value};
-use crate::usd::{Attribute, Stage};
+use crate::usd::Stage;
 
 use crate::schemas::lux::tokens::{A_TREAT_AS_LINE, A_TREAT_AS_POINT};
+
+pub(super) use crate::schemas::common::{author_rel_targets, varying_attribute};
 
 /// Author a `varying float` input on `prim` with the given default value.
 pub(super) fn author_input_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
@@ -28,21 +30,6 @@ pub(super) fn author_input_bool(stage: &Stage, prim: &Path, name: &str, value: b
 /// Author a `varying color3f` input on `prim` with the given default value.
 pub(super) fn author_input_color3f(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
     varying_attribute(stage, prim, name, "color3f")?.set(Value::Vec3f(value))?;
-    Ok(())
-}
-
-/// Author a relationship at `prim.name` with a single target.
-pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
-where
-    I: IntoIterator<Item = P>,
-    P: Into<Path>,
-{
-    let rel_path = prim.append_property(name)?;
-    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
-    stage
-        .create_relationship(rel_path)?
-        .set_custom(false)?
-        .set_targets(paths)?;
     Ok(())
 }
 
@@ -74,9 +61,3 @@ pub(super) fn author_treat_as_line(stage: &Stage, prim: &Path, value: bool) -> R
     Ok(())
 }
 
-/// Get-or-create a varying attribute with the given type. Returned
-/// handle defaults to `custom = false` and `variability = Varying`.
-fn varying_attribute<'s>(stage: &'s Stage, prim: &Path, name: &str, type_name: &str) -> Result<Attribute<'s>> {
-    let attr_path = prim.append_property(name)?;
-    Ok(stage.create_attribute(attr_path, type_name)?.set_custom(false)?)
-}

--- a/src/schemas/lux/author/dome.rs
+++ b/src/schemas/lux/author/dome.rs
@@ -47,7 +47,7 @@ impl<'s> DomeLightAuthor<'s> {
     /// (`automatic` / `latlong` / `mirroredBall` / `angular` /
     /// `cubeMapVerticalCross`).
     pub fn set_texture_format(self, format: TextureFormat) -> Result<Self> {
-        author_uniform_token_input(
+        author_token_input(
             self.prim.stage(),
             self.prim.path(),
             A_TEXTURE_FORMAT,
@@ -108,7 +108,7 @@ impl<'s> DomeLight1Author<'s> {
 
     /// Set `inputs:texture:format`.
     pub fn set_texture_format(self, format: TextureFormat) -> Result<Self> {
-        author_uniform_token_input(
+        author_token_input(
             self.prim.stage(),
             self.prim.path(),
             A_TEXTURE_FORMAT,
@@ -157,7 +157,8 @@ impl<'s> LightApiSetters<'s> for DomeLight1Author<'s> {
 
 /// Author a `varying token` input — for `inputs:texture:format`
 /// which the schema declares without the `uniform` keyword.
-fn author_uniform_token_input(stage: &Stage, prim: &Path, name: &str, value: String) -> Result<()> {
+fn author_token_input(stage: &Stage, prim: &Path, name: &str, value: String) -> Result<()> {
+    // Body unchanged — name now matches the varying behaviour.
     let attr_path = prim.append_property(name)?;
     stage
         .create_attribute(attr_path, "token")?

--- a/src/schemas/lux/author/dome.rs
+++ b/src/schemas/lux/author/dome.rs
@@ -1,0 +1,234 @@
+//! `DomeLight` + `DomeLight_1` authoring.
+//!
+//! Both prim types inherit `NonboundableLightBase` per
+//! `usdLux/schema.usda`. They share the same set of attributes
+//! (`inputs:texture:file`, `inputs:texture:format`, `portals` rel,
+//! `guideRadius`); `DomeLight_1` adds the `poleAxis` token to control
+//! the dome's starting orientation.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{
+    A_GUIDE_RADIUS, A_POLE_AXIS, A_TEXTURE_FILE, A_TEXTURE_FORMAT, REL_PORTALS, T_DOME_LIGHT, T_DOME_LIGHT_1,
+};
+use crate::schemas::lux::types::{PoleAxis, TextureFormat};
+
+use super::common::{author_input_asset, author_rel_targets};
+use super::light_api::LightApiSetters;
+
+/// Author a `def DomeLight` prim at `path`. Returns a chainable
+/// [`DomeLightAuthor`] for the dome-specific attributes plus the
+/// shared LightAPI setters via [`LightApiSetters`].
+pub fn define_dome_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<DomeLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_DOME_LIGHT)?;
+    Ok(DomeLightAuthor { prim })
+}
+
+pub struct DomeLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> DomeLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:texture:file` — IBL/HDR texture file path.
+    pub fn set_texture_file(self, path: impl Into<String>) -> Result<Self> {
+        author_input_asset(self.prim.stage(), self.prim.path(), A_TEXTURE_FILE, path)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:texture:format` — texture parameterisation. The
+    /// [`TextureFormat`] enum enforces the spec's allowedTokens set
+    /// (`automatic` / `latlong` / `mirroredBall` / `angular` /
+    /// `cubeMapVerticalCross`).
+    pub fn set_texture_format(self, format: TextureFormat) -> Result<Self> {
+        author_uniform_token_input(
+            self.prim.stage(),
+            self.prim.path(),
+            A_TEXTURE_FORMAT,
+            format.as_token().to_string(),
+        )?;
+        Ok(self)
+    }
+
+    /// Set the `portals` rel targets — paths to PortalLight prims
+    /// that focus the dome's sampling for indoor scenes.
+    pub fn set_portals<I, P>(self, targets: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.prim.stage(), self.prim.path(), REL_PORTALS, targets)?;
+        Ok(self)
+    }
+
+    /// Set `guideRadius` — radius of the guide geometry used to
+    /// visualise the dome (spec default 1.0e5).
+    pub fn set_guide_radius(self, radius: f32) -> Result<Self> {
+        author_scalar_float(self.prim.stage(), self.prim.path(), A_GUIDE_RADIUS, radius)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for DomeLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── DomeLight_1 ─────────────────────────────────────────────────────
+
+/// Author a `def DomeLight_1` prim at `path`. Same attribute set as
+/// [`DomeLightAuthor`] plus the `poleAxis` token introduced in the
+/// versioned `DomeLight_1` schema.
+pub fn define_dome_light_1<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<DomeLight1Author<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_DOME_LIGHT_1)?;
+    Ok(DomeLight1Author { prim })
+}
+
+pub struct DomeLight1Author<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> DomeLight1Author<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:texture:file`.
+    pub fn set_texture_file(self, path: impl Into<String>) -> Result<Self> {
+        author_input_asset(self.prim.stage(), self.prim.path(), A_TEXTURE_FILE, path)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:texture:format`.
+    pub fn set_texture_format(self, format: TextureFormat) -> Result<Self> {
+        author_uniform_token_input(
+            self.prim.stage(),
+            self.prim.path(),
+            A_TEXTURE_FORMAT,
+            format.as_token().to_string(),
+        )?;
+        Ok(self)
+    }
+
+    /// Set the `portals` rel targets.
+    pub fn set_portals<I, P>(self, targets: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.prim.stage(), self.prim.path(), REL_PORTALS, targets)?;
+        Ok(self)
+    }
+
+    /// Set `guideRadius`.
+    pub fn set_guide_radius(self, radius: f32) -> Result<Self> {
+        author_scalar_float(self.prim.stage(), self.prim.path(), A_GUIDE_RADIUS, radius)?;
+        Ok(self)
+    }
+
+    /// Set `poleAxis` — controls the dome's top-pole alignment. The
+    /// [`PoleAxis`] enum enforces the spec's allowedTokens
+    /// (`scene` / `Y` / `Z`).
+    pub fn set_pole_axis(self, axis: PoleAxis) -> Result<Self> {
+        author_uniform_token(
+            self.prim.stage(),
+            self.prim.path(),
+            A_POLE_AXIS,
+            axis.as_token().to_string(),
+        )?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for DomeLight1Author<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── private helpers ────────────────────────────────────────────────
+
+/// Author a `varying token` input — for `inputs:texture:format`
+/// which the schema declares without the `uniform` keyword.
+fn author_uniform_token_input(stage: &Stage, prim: &Path, name: &str, value: String) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_custom(false)?
+        .set(Value::Token(value))?;
+    Ok(())
+}
+
+/// Author a `uniform token` attribute — for `poleAxis` which the
+/// schema declares as `uniform`.
+fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: String) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Token(value))?;
+    Ok(())
+}
+
+/// Author a bare `float` (no `inputs:` prefix) — for DomeLight's
+/// `guideRadius`.
+fn author_scalar_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float")?
+        .set_custom(false)?
+        .set(Value::Float(value))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn dome_light_roundtrip_with_texture_and_portals() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_dome_light(&stage, sdf::path("/Dome")?)?
+            .set_texture_file("./studio.hdr")?
+            .set_texture_format(TextureFormat::Latlong)?
+            .set_portals([sdf::path("/Dome/Portal")?])?
+            .set_guide_radius(50.0)?
+            .set_intensity(1.0)?;
+
+        let dome = crate::schemas::lux::read_dome_light(&stage, &sdf::path("/Dome")?)?.expect("DomeLight");
+        assert_eq!(dome.texture_file.as_deref(), Some("./studio.hdr"));
+        assert_eq!(dome.texture_format, TextureFormat::Latlong);
+        assert!((dome.guide_radius - 50.0).abs() < 1e-3);
+        assert_eq!(dome.portals, vec!["/Dome/Portal".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn dome_light_1_authors_pole_axis() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_dome_light_1(&stage, sdf::path("/Dome")?)?
+            .set_texture_file("./studio.hdr")?
+            .set_pole_axis(PoleAxis::Z)?;
+
+        // The lux reader's `read_dome_light` accepts both `DomeLight`
+        // and `DomeLight_1` per the existing reader contract.
+        let dome = crate::schemas::lux::read_dome_light(&stage, &sdf::path("/Dome")?)?.expect("DomeLight_1");
+        assert_eq!(dome.texture_file.as_deref(), Some("./studio.hdr"));
+
+        // poleAxis lands on the prim as a uniform token.
+        match stage.field::<sdf::Value>("/Dome.poleAxis", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Token(t)) => assert_eq!(t, "Z"),
+            other => panic!("expected token 'Z' for poleAxis, got {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/src/schemas/lux/author/light_api.rs
+++ b/src/schemas/lux/author/light_api.rs
@@ -1,0 +1,250 @@
+//! `LightAPI` applied schema authoring.
+//!
+//! The concrete light prim types (`RectLight`, `DistantLight`, etc.)
+//! all `prepend apiSchemas = ["LightAPI"]` per Pixar's
+//! `usdLux/schema.usda`, so they pick up these attributes implicitly via
+//! the schema registry. For lights *not* covered by a built-in concrete
+//! type — applying LightAPI to a Mesh, Volume, or other Gprim —
+//! [`apply_light_api`] handles the explicit `apiSchemas += ["LightAPI"]`
+//! step.
+//!
+//! The free functions below are shared by the concrete light authors:
+//! each `*LightAuthor::set_intensity` etc. simply delegates here so the
+//! attribute-name + type-name + default-value choices live in one place.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{
+    API_LIGHT, A_COLOR, A_COLOR_TEMPERATURE, A_DIFFUSE, A_ENABLE_COLOR_TEMPERATURE, A_EXPOSURE, A_INTENSITY,
+    A_NORMALIZE, A_SPECULAR, REL_FILTERS,
+};
+
+use super::common::{author_input_bool, author_input_color3f, author_input_float, author_rel_targets};
+
+/// Apply `LightAPI` to the prim at `path` and return a chainable
+/// [`LightAuthor`] for setting the 8 schema-defined input attributes
+/// (intensity / exposure / diffuse / specular / normalize / color /
+/// enableColorTemperature / colorTemperature) and the `light:filters`
+/// relationship.
+///
+/// `apiSchemas += ["LightAPI"]` lands via
+/// [`Prim::add_applied_schema`]. The prim spec must already exist on the
+/// active edit target — use [`Stage::define_prim`] (or one of the
+/// `define_*_light` helpers in sibling modules) first.
+pub fn apply_light_api<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<LightAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_LIGHT)?;
+    Ok(LightAuthor { prim })
+}
+
+/// Chainable LightAPI authoring handle.
+///
+/// LightAPI setters live on the [`LightApiSetters`] trait so concrete
+/// light authors (e.g. `RectLightAuthor`) share the same fluent surface
+/// without duplicated methods. Bring the trait into scope to use the
+/// setters: `use openusd::schemas::lux::LightApiSetters;`.
+pub struct LightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> LightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+}
+
+// ── Free functions ──────────────────────────────────────────────────
+//
+// These are crate-internal so concrete light authors (RectLightAuthor,
+// SphereLightAuthor, …) can share the same attribute-write logic
+// without re-deriving the type-name and attribute-name choices.
+
+pub(crate) fn set_intensity(stage: &Stage, prim: &Path, value: f32) -> Result<()> {
+    author_input_float(stage, prim, A_INTENSITY, value)
+}
+
+pub(crate) fn set_exposure(stage: &Stage, prim: &Path, value: f32) -> Result<()> {
+    author_input_float(stage, prim, A_EXPOSURE, value)
+}
+
+pub(crate) fn set_diffuse(stage: &Stage, prim: &Path, value: f32) -> Result<()> {
+    author_input_float(stage, prim, A_DIFFUSE, value)
+}
+
+pub(crate) fn set_specular(stage: &Stage, prim: &Path, value: f32) -> Result<()> {
+    author_input_float(stage, prim, A_SPECULAR, value)
+}
+
+pub(crate) fn set_normalize(stage: &Stage, prim: &Path, value: bool) -> Result<()> {
+    author_input_bool(stage, prim, A_NORMALIZE, value)
+}
+
+pub(crate) fn set_color(stage: &Stage, prim: &Path, value: [f32; 3]) -> Result<()> {
+    author_input_color3f(stage, prim, A_COLOR, value)
+}
+
+pub(crate) fn set_enable_color_temperature(stage: &Stage, prim: &Path, value: bool) -> Result<()> {
+    author_input_bool(stage, prim, A_ENABLE_COLOR_TEMPERATURE, value)
+}
+
+pub(crate) fn set_color_temperature(stage: &Stage, prim: &Path, value: f32) -> Result<()> {
+    author_input_float(stage, prim, A_COLOR_TEMPERATURE, value)
+}
+
+pub(crate) fn set_filters<I, P>(stage: &Stage, prim: &Path, targets: I) -> Result<()>
+where
+    I: IntoIterator<Item = P>,
+    P: Into<Path>,
+{
+    author_rel_targets(stage, prim, REL_FILTERS, targets)
+}
+
+/// Concrete light authors implement this trait to inherit the 9
+/// LightAPI chainable setters. Each implementor exposes a `prim()`
+/// accessor; the trait's default methods route every setter through the
+/// shared free functions above so attribute-name + type-name choices
+/// live in one place.
+pub trait LightApiSetters<'s>: Sized {
+    /// Borrow the underlying prim handle. Implementations typically just
+    /// return `&self.prim`.
+    fn prim(&self) -> &Prim<'s>;
+
+    /// Set `inputs:intensity`. See [`LightAuthor::set_intensity`].
+    fn set_intensity(self, value: f32) -> Result<Self> {
+        set_intensity(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:exposure`.
+    fn set_exposure(self, value: f32) -> Result<Self> {
+        set_exposure(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:diffuse`.
+    fn set_diffuse(self, value: f32) -> Result<Self> {
+        set_diffuse(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:specular`.
+    fn set_specular(self, value: f32) -> Result<Self> {
+        set_specular(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:normalize`.
+    fn set_normalize(self, value: bool) -> Result<Self> {
+        set_normalize(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:color`.
+    fn set_color(self, value: [f32; 3]) -> Result<Self> {
+        set_color(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:enableColorTemperature`.
+    fn set_enable_color_temperature(self, value: bool) -> Result<Self> {
+        set_enable_color_temperature(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:colorTemperature` in degrees Kelvin.
+    fn set_color_temperature(self, value: f32) -> Result<Self> {
+        set_color_temperature(self.prim().stage(), self.prim().path(), value)?;
+        Ok(self)
+    }
+
+    /// Set the `light:filters` rel targets.
+    fn set_filters<I, P>(self, targets: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        set_filters(self.prim().stage(), self.prim().path(), targets)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for LightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn apply_light_api_adds_api_and_writes_inputs() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Emitter")?.set_type_name("Mesh")?;
+        apply_light_api(&stage, sdf::path("/Emitter")?)?
+            .set_intensity(1500.0)?
+            .set_exposure(1.5)?
+            .set_diffuse(0.8)?
+            .set_specular(1.2)?
+            .set_normalize(true)?
+            .set_color([1.0, 0.9, 0.8])?
+            .set_enable_color_temperature(true)?
+            .set_color_temperature(5500.0)?;
+
+        // LightAPI ended up in apiSchemas.
+        let api = stage.api_schemas(&sdf::path("/Emitter")?)?;
+        assert!(api.iter().any(|s| s == "LightAPI"));
+
+        match stage.field::<sdf::Value>("/Emitter.inputs:intensity", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Float(f)) => assert!((f - 1500.0).abs() < 1e-3),
+            other => panic!("expected Float(1500.0) for intensity, got {other:?}"),
+        }
+        match stage.field::<sdf::Value>("/Emitter.inputs:color", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3f(v)) => assert_eq!(v, [1.0, 0.9, 0.8]),
+            other => panic!("expected Vec3f for color, got {other:?}"),
+        }
+        match stage.field::<sdf::Value>("/Emitter.inputs:enableColorTemperature", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Bool(b)) => assert!(b),
+            other => panic!("expected Bool(true) for enableColorTemperature, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn set_filters_writes_relationship_targets() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Emitter")?.set_type_name("Mesh")?;
+        stage.define_prim("/Filter1")?.set_type_name("LightFilter")?;
+        stage.define_prim("/Filter2")?.set_type_name("LightFilter")?;
+        apply_light_api(&stage, sdf::path("/Emitter")?)?
+            .set_filters([sdf::path("/Filter1")?, sdf::path("/Filter2")?])?;
+
+        // Read back via the existing LightAPI reader.
+        let light = crate::schemas::lux::read_light_api(&stage, &sdf::path("/Emitter")?)?.expect("LightAPI applied");
+        assert_eq!(light.filters, vec!["/Filter1".to_string(), "/Filter2".to_string()],);
+        Ok(())
+    }
+
+    #[test]
+    fn round_trips_through_lightapi_reader() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Sun")?.set_type_name("Mesh")?;
+        apply_light_api(&stage, sdf::path("/Sun")?)?
+            .set_intensity(2000.0)?
+            .set_color([1.0, 0.95, 0.85])?
+            .set_normalize(true)?;
+
+        let light = crate::schemas::lux::read_light_api(&stage, &sdf::path("/Sun")?)?.expect("LightAPI applied");
+        assert!((light.intensity - 2000.0).abs() < 1e-3);
+        assert!((light.color[1] - 0.95).abs() < 1e-3);
+        assert!(light.normalize);
+        // Unauthored attrs fall back to Pixar's defaults.
+        assert!((light.exposure - 0.0).abs() < 1e-6);
+        assert!((light.diffuse - 1.0).abs() < 1e-6);
+        Ok(())
+    }
+}

--- a/src/schemas/lux/author/light_list.rs
+++ b/src/schemas/lux/author/light_list.rs
@@ -1,0 +1,158 @@
+//! `LightListAPI` applied schema authoring.
+//!
+//! Per `usdLux/schema.usda`, the cached light-list on a parent prim
+//! has two fields: a `lightList` rel targeting the lights in the
+//! subtree and a `lightList:cacheBehavior` token controlling how
+//! consumers consult the cache.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{API_LIGHT_LIST, A_LIGHT_LIST_CACHE_BEHAVIOR, REL_LIGHT_LIST};
+use crate::schemas::lux::types::LightListCacheBehavior;
+
+use super::common::author_rel_targets;
+
+/// Apply `LightListAPI` to the prim at `path` and return a chainable
+/// [`LightListAuthor`] for the cached light-list contents.
+///
+/// Typically applied to a model-hierarchy prim above a payload so
+/// consumers can discover lights without loading the heavy
+/// payload — see the spec's "Publishing a Cached Light List" section.
+pub fn apply_light_list<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<LightListAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_LIGHT_LIST)?;
+    Ok(LightListAuthor { prim })
+}
+
+pub struct LightListAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> LightListAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set the `lightList` rel — paths to the cached set of lights.
+    pub fn set_lights<I, P>(self, targets: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.prim.stage(), self.prim.path(), REL_LIGHT_LIST, targets)?;
+        Ok(self)
+    }
+
+    /// Set `lightList:cacheBehavior` — controls how the cached list is
+    /// consulted (`ignore` / `consumeAndContinue` / `consumeAndHalt`).
+    /// The [`LightListCacheBehavior`] enum enforces the spec's
+    /// allowedTokens at the type level.
+    pub fn set_cache_behavior(self, behavior: LightListCacheBehavior) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_LIGHT_LIST_CACHE_BEHAVIOR)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "token")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::Token(behavior.as_token().to_string()))?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn light_list_api_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/World")?.set_type_name("Xform")?;
+        stage.define_prim("/World/Sun")?.set_type_name("DistantLight")?;
+        stage.define_prim("/World/Lamp")?.set_type_name("SphereLight")?;
+        apply_light_list(&stage, sdf::path("/World")?)?
+            .set_lights([sdf::path("/World/Sun")?, sdf::path("/World/Lamp")?])?
+            .set_cache_behavior(LightListCacheBehavior::ConsumeAndContinue)?;
+
+        let list = crate::schemas::lux::read_light_list(&stage, &sdf::path("/World")?)?.expect("LightListAPI");
+        assert_eq!(list.cache_behavior, LightListCacheBehavior::ConsumeAndContinue);
+        assert_eq!(list.lights, vec!["/World/Sun".to_string(), "/World/Lamp".to_string()],);
+        Ok(())
+    }
+
+    /// End-to-end check: author a complete lit scene with every concrete
+    /// light type + ShapingAPI + ShadowAPI + LightListAPI, then read it
+    /// back through the existing lux reader and assert every field
+    /// matches.
+    #[test]
+    fn full_scene_roundtrip_authoring_to_reader() -> Result<()> {
+        use crate::schemas::lux::{
+            apply_shadow, apply_shaping, define_cylinder_light, define_disk_light, define_distant_light,
+            define_dome_light, define_geometry_light, define_portal_light, define_rect_light, define_sphere_light,
+            LightApiSetters, TextureFormat,
+        };
+
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/World")?.set_type_name("Xform")?;
+        stage.define_prim("/World/Emitter")?.set_type_name("Mesh")?;
+
+        // Every concrete light type the reader covers.
+        define_distant_light(&stage, sdf::path("/World/Sun")?)?
+            .set_angle_deg(0.53)?
+            .set_color([1.0, 0.95, 0.85])?;
+        define_sphere_light(&stage, sdf::path("/World/Bulb")?)?
+            .set_radius(0.1)?
+            .set_intensity(800.0)?;
+        define_rect_light(&stage, sdf::path("/World/Panel")?)?
+            .set_width(2.0)?
+            .set_height(1.0)?;
+        define_disk_light(&stage, sdf::path("/World/Disk")?)?.set_radius(0.5)?;
+        define_cylinder_light(&stage, sdf::path("/World/Tube")?)?
+            .set_length(2.0)?
+            .set_treat_as_line(true)?;
+        define_dome_light(&stage, sdf::path("/World/Dome")?)?.set_texture_format(TextureFormat::Latlong)?;
+        define_geometry_light(&stage, sdf::path("/World/MeshLight")?)?.set_geometry(sdf::path("/World/Emitter")?)?;
+        define_portal_light(&stage, sdf::path("/World/Portal")?)?.set_width(1.2)?;
+
+        // Applied APIs on a shaped, shadowed light.
+        apply_shaping(&stage, sdf::path("/World/Panel")?)?.set_cone_angle_deg(45.0)?;
+        apply_shadow(&stage, sdf::path("/World/Panel")?)?.set_distance(10.0)?;
+
+        // LightListAPI on the parent.
+        apply_light_list(&stage, sdf::path("/World")?)?
+            .set_lights([
+                sdf::path("/World/Sun")?,
+                sdf::path("/World/Bulb")?,
+                sdf::path("/World/Panel")?,
+                sdf::path("/World/Disk")?,
+                sdf::path("/World/Tube")?,
+                sdf::path("/World/Dome")?,
+                sdf::path("/World/MeshLight")?,
+                sdf::path("/World/Portal")?,
+            ])?
+            .set_cache_behavior(LightListCacheBehavior::ConsumeAndContinue)?;
+
+        // Round-trip every prim through the reader.
+        assert!(crate::schemas::lux::read_distant_light(&stage, &sdf::path("/World/Sun")?)?.is_some());
+        assert!(crate::schemas::lux::read_sphere_light(&stage, &sdf::path("/World/Bulb")?)?.is_some());
+        assert!(crate::schemas::lux::read_rect_light(&stage, &sdf::path("/World/Panel")?)?.is_some());
+        assert!(crate::schemas::lux::read_disk_light(&stage, &sdf::path("/World/Disk")?)?.is_some());
+        assert!(crate::schemas::lux::read_cylinder_light(&stage, &sdf::path("/World/Tube")?)?.is_some());
+        assert!(crate::schemas::lux::read_dome_light(&stage, &sdf::path("/World/Dome")?)?.is_some());
+        assert!(crate::schemas::lux::read_geometry_light(&stage, &sdf::path("/World/MeshLight")?)?.is_some());
+        assert!(crate::schemas::lux::read_portal_light(&stage, &sdf::path("/World/Portal")?)?.is_some());
+
+        let shaping =
+            crate::schemas::lux::read_shaping(&stage, &sdf::path("/World/Panel")?)?.expect("ShapingAPI applied");
+        assert!((shaping.cone_angle_deg - 45.0).abs() < 1e-3);
+
+        let shadow = crate::schemas::lux::read_shadow(&stage, &sdf::path("/World/Panel")?)?.expect("ShadowAPI applied");
+        assert!((shadow.distance - 10.0).abs() < 1e-3);
+
+        let list = crate::schemas::lux::read_light_list(&stage, &sdf::path("/World")?)?.expect("LightListAPI applied");
+        assert_eq!(list.lights.len(), 8);
+        Ok(())
+    }
+}

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -18,6 +18,7 @@ mod boundable;
 mod common;
 mod dome;
 mod light_api;
+mod light_list;
 mod nonboundable;
 mod shaping;
 
@@ -27,5 +28,6 @@ pub use boundable::{
 };
 pub use dome::{define_dome_light, define_dome_light_1, DomeLight1Author, DomeLightAuthor};
 pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};
+pub use light_list::{apply_light_list, LightListAuthor};
 pub use nonboundable::{define_distant_light, define_geometry_light, DistantLightAuthor, GeometryLightAuthor};
 pub use shaping::{apply_shadow, apply_shaping, ShadowAuthor, ShapingAuthor};

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -14,7 +14,12 @@
 //! routing is the caller's job via
 //! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target).
 
+mod boundable;
 mod common;
 mod light_api;
 
+pub use boundable::{
+    define_cylinder_light, define_disk_light, define_portal_light, define_rect_light, define_sphere_light,
+    CylinderLightAuthor, DiskLightAuthor, PortalLightAuthor, RectLightAuthor, SphereLightAuthor,
+};
 pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -19,6 +19,7 @@ mod common;
 mod dome;
 mod light_api;
 mod nonboundable;
+mod shaping;
 
 pub use boundable::{
     define_cylinder_light, define_disk_light, define_portal_light, define_rect_light, define_sphere_light,
@@ -27,3 +28,4 @@ pub use boundable::{
 pub use dome::{define_dome_light, define_dome_light_1, DomeLight1Author, DomeLightAuthor};
 pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};
 pub use nonboundable::{define_distant_light, define_geometry_light, DistantLightAuthor, GeometryLightAuthor};
+pub use shaping::{apply_shadow, apply_shaping, ShadowAuthor, ShapingAuthor};

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -17,9 +17,11 @@
 mod boundable;
 mod common;
 mod light_api;
+mod nonboundable;
 
 pub use boundable::{
     define_cylinder_light, define_disk_light, define_portal_light, define_rect_light, define_sphere_light,
     CylinderLightAuthor, DiskLightAuthor, PortalLightAuthor, RectLightAuthor, SphereLightAuthor,
 };
 pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};
+pub use nonboundable::{define_distant_light, define_geometry_light, DistantLightAuthor, GeometryLightAuthor};

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -16,6 +16,7 @@
 
 mod boundable;
 mod common;
+mod dome;
 mod light_api;
 mod nonboundable;
 
@@ -23,5 +24,6 @@ pub use boundable::{
     define_cylinder_light, define_disk_light, define_portal_light, define_rect_light, define_sphere_light,
     CylinderLightAuthor, DiskLightAuthor, PortalLightAuthor, RectLightAuthor, SphereLightAuthor,
 };
+pub use dome::{define_dome_light, define_dome_light_1, DomeLight1Author, DomeLightAuthor};
 pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};
 pub use nonboundable::{define_distant_light, define_geometry_light, DistantLightAuthor, GeometryLightAuthor};

--- a/src/schemas/lux/author/mod.rs
+++ b/src/schemas/lux/author/mod.rs
@@ -1,0 +1,20 @@
+//! Authoring helpers for the [UsdLux](super) schema family.
+//!
+//! Same shape as the [`super::read`] surface, in reverse: each
+//! `define_*_light` / `apply_*` helper writes a typed prim or an applied
+//! API schema in the form the corresponding reader decodes losslessly.
+//!
+//! The helpers wrap [`crate::usd::Stage`]'s authoring entry points; they
+//! only know which type tokens, attribute names, type names, and metadata
+//! keys Pixar's `usdLux/schema.usda` requires. Everything else
+//! (composition, layer routing, save) flows through the public
+//! [`crate::usd::Stage`] / [`crate::sdf::Layer`] APIs.
+//!
+//! Each helper writes opinions to the stage's current edit target. Layer
+//! routing is the caller's job via
+//! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target).
+
+mod common;
+mod light_api;
+
+pub use light_api::{apply_light_api, LightApiSetters, LightAuthor};

--- a/src/schemas/lux/author/nonboundable.rs
+++ b/src/schemas/lux/author/nonboundable.rs
@@ -1,0 +1,141 @@
+//! Authoring helpers for the nonboundable concrete light prims:
+//! `DistantLight` and `GeometryLight`.
+//!
+//! Both inherit `NonboundableLightBase` per
+//! `usdLux/schema.usda` and auto-apply `LightAPI`. `DistantLight`
+//! additionally overrides `LightAPI.inputs:intensity = 1` with
+//! `50000` — modelling the sun reaching Earth at ~50000 lux.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{A_ANGLE, REL_GEOMETRY, T_DISTANT_LIGHT, T_GEOMETRY_LIGHT};
+
+use super::common::{author_input_float, author_rel_targets};
+use super::light_api::LightApiSetters;
+
+/// Author a `def DistantLight` prim at `path`. Returns a chainable
+/// [`DistantLightAuthor`] exposing LightAPI setters via
+/// [`LightApiSetters`] plus the DistantLight-specific `inputs:angle`.
+///
+/// Per Pixar's `usdLux/schema.usda`, DistantLight overrides LightAPI's
+/// default intensity of `1` with `50000`. The schema declares it as a
+/// schema-registry fallback (`apiSchemaOverride = true`) — Pixar's
+/// `UsdLuxDistantLight::Define()` does not author an explicit opinion,
+/// and our reader's [`ReadDistantLight::default`] already returns 50000
+/// for unauthored intensity. The helper mirrors that contract: no
+/// implicit write. Callers chain [`LightApiSetters::set_intensity`]
+/// only when they need a non-sun value.
+///
+/// [`ReadDistantLight::default`]: crate::schemas::lux::ReadDistantLight
+pub fn define_distant_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<DistantLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_DISTANT_LIGHT)?;
+    Ok(DistantLightAuthor { prim })
+}
+
+pub struct DistantLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> DistantLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:angle` — angular diameter of the light in degrees.
+    /// Spec default is `0.53` (approximately the sun as seen from
+    /// Earth); higher values broaden the light and soften shadow edges.
+    pub fn set_angle_deg(self, angle: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_ANGLE, angle)?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for DistantLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── GeometryLight ───────────────────────────────────────────────────
+
+/// Author a `def GeometryLight` prim at `path`. Returns a chainable
+/// [`GeometryLightAuthor`] that wires the required `geometry` rel.
+///
+/// Per the schema, GeometryLight uses an arbitrary geometric prim
+/// (typically a Mesh) as the emissive surface. The `geometry` rel must
+/// point at that source prim.
+pub fn define_geometry_light<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<GeometryLightAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_GEOMETRY_LIGHT)?;
+    Ok(GeometryLightAuthor { prim })
+}
+
+pub struct GeometryLightAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> GeometryLightAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set the `geometry` rel target — path to the gprim acting as the
+    /// emissive surface.
+    pub fn set_geometry(self, geometry: impl Into<Path>) -> Result<Self> {
+        author_rel_targets(self.prim.stage(), self.prim.path(), REL_GEOMETRY, [geometry.into()])?;
+        Ok(self)
+    }
+}
+
+impl<'s> LightApiSetters<'s> for GeometryLightAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn distant_light_defaults_intensity_to_50000_per_spec() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_distant_light(&stage, sdf::path("/Sun")?)?.set_angle_deg(0.53)?;
+
+        let light = crate::schemas::lux::read_distant_light(&stage, &sdf::path("/Sun")?)?.expect("DistantLight");
+        assert!((light.common.intensity - 50000.0).abs() < 1e-3);
+        assert!((light.angle_deg - 0.53).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn distant_light_caller_intensity_override() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_distant_light(&stage, sdf::path("/Sun")?)?
+            .set_intensity(12000.0)?
+            .set_angle_deg(2.0)?;
+
+        let light = crate::schemas::lux::read_distant_light(&stage, &sdf::path("/Sun")?)?.expect("DistantLight");
+        assert!((light.common.intensity - 12000.0).abs() < 1e-3);
+        assert!((light.angle_deg - 2.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn geometry_light_links_source_mesh() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/World/Emitter")?.set_type_name("Mesh")?;
+        define_geometry_light(&stage, sdf::path("/World/Light")?)?
+            .set_geometry(sdf::path("/World/Emitter")?)?
+            .set_intensity(200.0)?;
+
+        let light =
+            crate::schemas::lux::read_geometry_light(&stage, &sdf::path("/World/Light")?)?.expect("GeometryLight");
+        assert_eq!(light.geometry.as_deref(), Some("/World/Emitter"));
+        assert!((light.common.intensity - 200.0).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/lux/author/shaping.rs
+++ b/src/schemas/lux/author/shaping.rs
@@ -1,0 +1,179 @@
+//! `ShapingAPI` and `ShadowAPI` applied schema authoring.
+//!
+//! Both schemas are applied via `apiSchemas +=` and then set their
+//! `inputs:shaping:*` / `inputs:shadow:*` attributes on the host light
+//! prim per `usdLux/schema.usda`.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::lux::tokens::{
+    API_SHADOW, API_SHAPING, A_SHADOW_COLOR, A_SHADOW_DISTANCE, A_SHADOW_ENABLE, A_SHADOW_FALLOFF,
+    A_SHADOW_FALLOFF_GAMMA, A_SHAPING_CONE_ANGLE, A_SHAPING_CONE_SOFTNESS, A_SHAPING_FOCUS, A_SHAPING_FOCUS_TINT,
+    A_SHAPING_IES_ANGLE_SCALE, A_SHAPING_IES_FILE, A_SHAPING_IES_NORMALIZE,
+};
+
+use super::common::{author_input_asset, author_input_bool, author_input_color3f, author_input_float};
+
+// ── ShapingAPI ──────────────────────────────────────────────────────
+
+/// Apply `ShapingAPI` to the prim at `path` and return a chainable
+/// [`ShapingAuthor`] for the 7 spec-defined inputs (focus + focusTint,
+/// cone angle/softness, IES file/angleScale/normalize).
+pub fn apply_shaping<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<ShapingAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_SHAPING)?;
+    Ok(ShapingAuthor { prim })
+}
+
+pub struct ShapingAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> ShapingAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:shaping:focus` (spec default 0).
+    pub fn set_focus(self, focus: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHAPING_FOCUS, focus)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:focusTint` (spec default (0, 0, 0)).
+    pub fn set_focus_tint(self, tint: [f32; 3]) -> Result<Self> {
+        author_input_color3f(self.prim.stage(), self.prim.path(), A_SHAPING_FOCUS_TINT, tint)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:cone:angle` in degrees (spec default 90).
+    pub fn set_cone_angle_deg(self, angle: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHAPING_CONE_ANGLE, angle)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:cone:softness` (spec default 0).
+    pub fn set_cone_softness(self, softness: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHAPING_CONE_SOFTNESS, softness)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:ies:file` — path to an IES light profile.
+    pub fn set_ies_file(self, path: impl Into<String>) -> Result<Self> {
+        author_input_asset(self.prim.stage(), self.prim.path(), A_SHAPING_IES_FILE, path)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:ies:angleScale` (spec default 0).
+    pub fn set_ies_angle_scale(self, scale: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHAPING_IES_ANGLE_SCALE, scale)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shaping:ies:normalize` (spec default false).
+    pub fn set_ies_normalize(self, normalize: bool) -> Result<Self> {
+        author_input_bool(self.prim.stage(), self.prim.path(), A_SHAPING_IES_NORMALIZE, normalize)?;
+        Ok(self)
+    }
+}
+
+// ── ShadowAPI ───────────────────────────────────────────────────────
+
+/// Apply `ShadowAPI` to the prim at `path` and return a chainable
+/// [`ShadowAuthor`] for the 5 spec-defined inputs.
+pub fn apply_shadow<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<ShadowAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_SHADOW)?;
+    Ok(ShadowAuthor { prim })
+}
+
+pub struct ShadowAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> ShadowAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `inputs:shadow:enable` (spec default true).
+    pub fn set_enable(self, enable: bool) -> Result<Self> {
+        author_input_bool(self.prim.stage(), self.prim.path(), A_SHADOW_ENABLE, enable)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shadow:color` (spec default (0, 0, 0)).
+    pub fn set_color(self, color: [f32; 3]) -> Result<Self> {
+        author_input_color3f(self.prim.stage(), self.prim.path(), A_SHADOW_COLOR, color)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shadow:distance` (spec default -1.0, meaning no limit).
+    pub fn set_distance(self, distance: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHADOW_DISTANCE, distance)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shadow:falloff` (spec default -1.0, meaning no falloff).
+    pub fn set_falloff(self, falloff: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHADOW_FALLOFF, falloff)?;
+        Ok(self)
+    }
+
+    /// Set `inputs:shadow:falloffGamma` (spec default 1.0).
+    pub fn set_falloff_gamma(self, gamma: f32) -> Result<Self> {
+        author_input_float(self.prim.stage(), self.prim.path(), A_SHADOW_FALLOFF_GAMMA, gamma)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn shaping_api_roundtrip_full_surface() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Spot")?.set_type_name("RectLight")?;
+        apply_shaping(&stage, sdf::path("/Spot")?)?
+            .set_focus(4.0)?
+            .set_focus_tint([0.1, 0.2, 0.3])?
+            .set_cone_angle_deg(45.0)?
+            .set_cone_softness(0.2)?
+            .set_ies_file("./profile.ies")?
+            .set_ies_angle_scale(1.0)?
+            .set_ies_normalize(true)?;
+
+        let shaping = crate::schemas::lux::read_shaping(&stage, &sdf::path("/Spot")?)?.expect("ShapingAPI");
+        assert!((shaping.focus - 4.0).abs() < 1e-3);
+        assert_eq!(shaping.focus_tint, [0.1, 0.2, 0.3]);
+        assert!((shaping.cone_angle_deg - 45.0).abs() < 1e-3);
+        assert!((shaping.cone_softness - 0.2).abs() < 1e-3);
+        assert_eq!(shaping.ies_file.as_deref(), Some("./profile.ies"));
+        assert!((shaping.ies_angle_scale - 1.0).abs() < 1e-3);
+        assert!(shaping.ies_normalize);
+        Ok(())
+    }
+
+    #[test]
+    fn shadow_api_roundtrip_full_surface() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Spot")?.set_type_name("RectLight")?;
+        apply_shadow(&stage, sdf::path("/Spot")?)?
+            .set_enable(false)?
+            .set_color([0.1, 0.1, 0.1])?
+            .set_distance(10.0)?
+            .set_falloff(2.0)?
+            .set_falloff_gamma(1.5)?;
+
+        let shadow = crate::schemas::lux::read_shadow(&stage, &sdf::path("/Spot")?)?.expect("ShadowAPI");
+        assert!(!shadow.enable);
+        assert_eq!(shadow.color, [0.1, 0.1, 0.1]);
+        assert!((shadow.distance - 10.0).abs() < 1e-3);
+        assert!((shadow.falloff - 2.0).abs() < 1e-3);
+        assert!((shadow.falloff_gamma - 1.5).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -45,7 +45,11 @@ mod author;
 mod read;
 mod types;
 
-pub use author::{apply_light_api, LightApiSetters, LightAuthor};
+pub use author::{
+    apply_light_api, define_cylinder_light, define_disk_light, define_portal_light, define_rect_light,
+    define_sphere_light, CylinderLightAuthor, DiskLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor,
+    RectLightAuthor, SphereLightAuthor,
+};
 
 pub use read::{
     find_lux_prims, is_light_type, read_cylinder_light, read_cylinder_light_at, read_disk_light, read_disk_light_at,

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -46,10 +46,10 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_light_api, define_cylinder_light, define_disk_light, define_distant_light, define_geometry_light,
-    define_portal_light, define_rect_light, define_sphere_light, CylinderLightAuthor, DiskLightAuthor,
-    DistantLightAuthor, GeometryLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor,
-    SphereLightAuthor,
+    apply_light_api, define_cylinder_light, define_disk_light, define_distant_light, define_dome_light,
+    define_dome_light_1, define_geometry_light, define_portal_light, define_rect_light, define_sphere_light,
+    CylinderLightAuthor, DiskLightAuthor, DistantLightAuthor, DomeLight1Author, DomeLightAuthor, GeometryLightAuthor,
+    LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor, SphereLightAuthor,
 };
 
 pub use read::{

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -46,10 +46,11 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_light_api, define_cylinder_light, define_disk_light, define_distant_light, define_dome_light,
-    define_dome_light_1, define_geometry_light, define_portal_light, define_rect_light, define_sphere_light,
-    CylinderLightAuthor, DiskLightAuthor, DistantLightAuthor, DomeLight1Author, DomeLightAuthor, GeometryLightAuthor,
-    LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor, SphereLightAuthor,
+    apply_light_api, apply_shadow, apply_shaping, define_cylinder_light, define_disk_light, define_distant_light,
+    define_dome_light, define_dome_light_1, define_geometry_light, define_portal_light, define_rect_light,
+    define_sphere_light, CylinderLightAuthor, DiskLightAuthor, DistantLightAuthor, DomeLight1Author, DomeLightAuthor,
+    GeometryLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor, ShadowAuthor, ShapingAuthor,
+    SphereLightAuthor,
 };
 
 pub use read::{

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -41,8 +41,11 @@
 
 pub mod tokens;
 
+mod author;
 mod read;
 mod types;
+
+pub use author::{apply_light_api, LightApiSetters, LightAuthor};
 
 pub use read::{
     find_lux_prims, is_light_type, read_cylinder_light, read_cylinder_light_at, read_disk_light, read_disk_light_at,

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -46,9 +46,10 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_light_api, define_cylinder_light, define_disk_light, define_portal_light, define_rect_light,
-    define_sphere_light, CylinderLightAuthor, DiskLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor,
-    RectLightAuthor, SphereLightAuthor,
+    apply_light_api, define_cylinder_light, define_disk_light, define_distant_light, define_geometry_light,
+    define_portal_light, define_rect_light, define_sphere_light, CylinderLightAuthor, DiskLightAuthor,
+    DistantLightAuthor, GeometryLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor,
+    SphereLightAuthor,
 };
 
 pub use read::{

--- a/src/schemas/lux/mod.rs
+++ b/src/schemas/lux/mod.rs
@@ -46,11 +46,11 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_light_api, apply_shadow, apply_shaping, define_cylinder_light, define_disk_light, define_distant_light,
-    define_dome_light, define_dome_light_1, define_geometry_light, define_portal_light, define_rect_light,
-    define_sphere_light, CylinderLightAuthor, DiskLightAuthor, DistantLightAuthor, DomeLight1Author, DomeLightAuthor,
-    GeometryLightAuthor, LightApiSetters, LightAuthor, PortalLightAuthor, RectLightAuthor, ShadowAuthor, ShapingAuthor,
-    SphereLightAuthor,
+    apply_light_api, apply_light_list, apply_shadow, apply_shaping, define_cylinder_light, define_disk_light,
+    define_distant_light, define_dome_light, define_dome_light_1, define_geometry_light, define_portal_light,
+    define_rect_light, define_sphere_light, CylinderLightAuthor, DiskLightAuthor, DistantLightAuthor, DomeLight1Author,
+    DomeLightAuthor, GeometryLightAuthor, LightApiSetters, LightAuthor, LightListAuthor, PortalLightAuthor,
+    RectLightAuthor, ShadowAuthor, ShapingAuthor, SphereLightAuthor,
 };
 
 pub use read::{

--- a/src/schemas/mod.rs
+++ b/src/schemas/mod.rs
@@ -21,6 +21,9 @@
 //! See [`registry`] for the eventual schema-registry surface
 //! (currently a stub).
 
+#[cfg(any(feature = "geom", feature = "lux", feature = "physics", feature = "skel"))]
+mod common;
+
 #[cfg(feature = "geom")]
 pub mod geom;
 #[cfg(feature = "lux")]

--- a/src/schemas/physics/author/collision.rs
+++ b/src/schemas/physics/author/collision.rs
@@ -1,0 +1,174 @@
+//! `PhysicsCollisionAPI`, `PhysicsMeshCollisionAPI`, and
+//! `PhysicsMaterialAPI` authoring.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{
+    API_COLLISION, API_MESH_COLLISION, API_PHYSICS_MATERIAL, A_APPROXIMATION, A_COLLISION_ENABLED, A_DENSITY,
+    A_DYNAMIC_FRICTION, A_RESTITUTION, A_SIMULATION_OWNER, A_STATIC_FRICTION,
+};
+use crate::schemas::physics::types::CollisionApprox;
+
+use super::common::{author_bool, author_float, author_rel_targets, author_uniform_token};
+
+// ── PhysicsCollisionAPI ─────────────────────────────────────────────
+
+/// Apply `PhysicsCollisionAPI` to the prim at `path` and return a
+/// chainable [`CollisionAuthor`].
+pub fn apply_collision<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<CollisionAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_COLLISION)?;
+    Ok(CollisionAuthor { prim })
+}
+
+pub struct CollisionAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> CollisionAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:collisionEnabled` (spec default true).
+    pub fn set_enabled(self, enabled: bool) -> Result<Self> {
+        author_bool(self.prim.stage(), self.prim.path(), A_COLLISION_ENABLED, enabled)?;
+        Ok(self)
+    }
+
+    /// Set `physics:simulationOwner` — relationship to the
+    /// `PhysicsScene` driving this collider.
+    pub fn set_simulation_owner(self, scene: impl Into<Path>) -> Result<Self> {
+        author_rel_targets(self.prim.stage(), self.prim.path(), A_SIMULATION_OWNER, [scene.into()])?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsMeshCollisionAPI ─────────────────────────────────────────
+
+/// Apply `PhysicsMeshCollisionAPI` to a Mesh prim at `path` and return
+/// a chainable [`MeshCollisionAuthor`]. Per spec, this API must be
+/// applied alongside `PhysicsCollisionAPI` on a `UsdGeomMesh`.
+pub fn apply_mesh_collision<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MeshCollisionAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_MESH_COLLISION)?;
+    Ok(MeshCollisionAuthor { prim })
+}
+
+pub struct MeshCollisionAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> MeshCollisionAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:approximation` (uniform token). The
+    /// [`CollisionApprox`] enum enforces the spec's allowedTokens
+    /// (`none` / `convexDecomposition` / `convexHull` /
+    /// `boundingSphere` / `boundingCube` / `meshSimplification`).
+    pub fn set_approximation(self, approx: CollisionApprox) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_APPROXIMATION, approx.as_token())?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsMaterialAPI ──────────────────────────────────────────────
+
+/// Apply `PhysicsMaterialAPI` to a Material prim at `path` and return
+/// a chainable [`MaterialAuthor`].
+pub fn apply_physics_material<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MaterialAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_PHYSICS_MATERIAL)?;
+    Ok(MaterialAuthor { prim })
+}
+
+pub struct MaterialAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> MaterialAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:dynamicFriction` (spec default 0.0).
+    pub fn set_dynamic_friction(self, mu: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_DYNAMIC_FRICTION, mu)?;
+        Ok(self)
+    }
+
+    /// Set `physics:staticFriction` (spec default 0.0).
+    pub fn set_static_friction(self, mu: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_STATIC_FRICTION, mu)?;
+        Ok(self)
+    }
+
+    /// Set `physics:restitution` (spec default 0.0).
+    pub fn set_restitution(self, e: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_RESTITUTION, e)?;
+        Ok(self)
+    }
+
+    /// Set `physics:density` (spec default 0.0 — ignored).
+    pub fn set_density(self, density: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_DENSITY, density)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn collision_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Box")?.set_type_name("Cube")?;
+        stage.define_prim("/Scene")?.set_type_name("PhysicsScene")?;
+        apply_collision(&stage, sdf::path("/Box")?)?
+            .set_enabled(true)?
+            .set_simulation_owner(sdf::path("/Scene")?)?;
+
+        let shape =
+            crate::schemas::physics::read_collision_shape(&stage, &sdf::path("/Box")?)?.expect("PhysicsCollisionAPI");
+        assert!(shape.has_collision_api);
+        assert!(shape.collision_enabled);
+        assert_eq!(shape.simulation_owner.as_deref(), Some("/Scene"));
+        Ok(())
+    }
+
+    #[test]
+    fn mesh_collision_writes_approximation_token() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Body")?.set_type_name("Mesh")?;
+        apply_collision(&stage, sdf::path("/Body")?)?;
+        apply_mesh_collision(&stage, sdf::path("/Body")?)?.set_approximation(CollisionApprox::ConvexHull)?;
+
+        let shape = crate::schemas::physics::read_collision_shape(&stage, &sdf::path("/Body")?)?.expect("CollisionAPI");
+        assert!(shape.has_mesh_collision_api);
+        assert_eq!(shape.approximation, Some(CollisionApprox::ConvexHull));
+        Ok(())
+    }
+
+    #[test]
+    fn material_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Mat")?.set_type_name("Material")?;
+        apply_physics_material(&stage, sdf::path("/Mat")?)?
+            .set_static_friction(0.6)?
+            .set_dynamic_friction(0.4)?
+            .set_restitution(0.2)?
+            .set_density(1000.0)?;
+
+        let mat =
+            crate::schemas::physics::read_physics_material(&stage, &sdf::path("/Mat")?)?.expect("PhysicsMaterialAPI");
+        assert!((mat.static_friction.unwrap() - 0.6).abs() < 1e-3);
+        assert!((mat.dynamic_friction.unwrap() - 0.4).abs() < 1e-3);
+        assert!((mat.restitution.unwrap() - 0.2).abs() < 1e-3);
+        assert!((mat.density.unwrap() - 1000.0).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/physics/author/common.rs
+++ b/src/schemas/physics/author/common.rs
@@ -1,0 +1,129 @@
+//! Shared low-level authoring helpers used across the per-prim modules.
+//!
+//! Wraps [`crate::usd::Stage::create_attribute`] +
+//! [`crate::usd::Stage::create_relationship`] with default choices that
+//! match the per-attribute schema declarations in
+//! `usdPhysics/schema.usda` (variability, type name, custom flag).
+
+// Helpers below are consumed progressively across the per-prim
+// modules (`scene`, `rigid_body`, `collision`, `joint`, `limit_drive`,
+// …). Mark unused ones during the early commits so the build stays
+// warning-clean.
+#![allow(dead_code)]
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::Stage;
+
+/// Author a `varying float` attribute with the given default.
+pub(super) fn author_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float")?
+        .set_custom(false)?
+        .set(Value::Float(value))?;
+    Ok(())
+}
+
+/// Author a `varying bool` attribute with the given default.
+pub(super) fn author_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
+    Ok(())
+}
+
+/// Author a `uniform bool` attribute with the given default. Used for
+/// `startsAsleep` and `excludeFromArticulation`.
+pub(super) fn author_uniform_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "bool")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Bool(value))?;
+    Ok(())
+}
+
+/// Author a `varying vector3f` attribute with the given default.
+pub(super) fn author_vector3f(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "vector3f")?
+        .set_custom(false)?
+        .set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+/// Author a `varying point3f` attribute with the given default.
+pub(super) fn author_point3f(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "point3f")?
+        .set_custom(false)?
+        .set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+/// Author a `varying float3` attribute with the given default. Used
+/// for `diagonalInertia`.
+pub(super) fn author_float3(stage: &Stage, prim: &Path, name: &str, value: [f32; 3]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "float3")?
+        .set_custom(false)?
+        .set(Value::Vec3f(value))?;
+    Ok(())
+}
+
+/// Author a `varying quatf` attribute with the given default. Used for
+/// MassAPI's `principalAxes` and joint `localRot0` / `localRot1`.
+pub(super) fn author_quatf(stage: &Stage, prim: &Path, name: &str, value: [f32; 4]) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "quatf")?
+        .set_custom(false)?
+        .set(Value::Quatf(value))?;
+    Ok(())
+}
+
+/// Author a `uniform token` attribute with the given default. Used for
+/// MeshCollisionAPI's `approximation` and joint `axis`.
+pub(super) fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Token(value.into()))?;
+    Ok(())
+}
+
+/// Author a `varying string` attribute with the given default. Used
+/// for `CollisionGroup.mergeGroup`.
+pub(super) fn author_string(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "string")?
+        .set_custom(false)?
+        .set(Value::String(value.into()))?;
+    Ok(())
+}
+
+/// Author a relationship at `prim.name` with the given target paths.
+pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
+where
+    I: IntoIterator<Item = P>,
+    P: Into<Path>,
+{
+    let rel_path = prim.append_property(name)?;
+    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
+    stage
+        .create_relationship(rel_path)?
+        .set_custom(false)?
+        .set_targets(paths)?;
+    Ok(())
+}

--- a/src/schemas/physics/author/common.rs
+++ b/src/schemas/physics/author/common.rs
@@ -10,25 +10,7 @@ use anyhow::Result;
 use crate::sdf::{Path, Value, Variability};
 use crate::usd::Stage;
 
-/// Author a `varying float` attribute with the given default.
-pub(super) fn author_float(stage: &Stage, prim: &Path, name: &str, value: f32) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "float")?
-        .set_custom(false)?
-        .set(Value::Float(value))?;
-    Ok(())
-}
-
-/// Author a `varying bool` attribute with the given default.
-pub(super) fn author_bool(stage: &Stage, prim: &Path, name: &str, value: bool) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "bool")?
-        .set_custom(false)?
-        .set(Value::Bool(value))?;
-    Ok(())
-}
+pub(super) use crate::schemas::common::{author_bool, author_float, author_rel_targets, author_uniform_token};
 
 /// Author a `uniform bool` attribute with the given default. Used for
 /// `startsAsleep` and `excludeFromArticulation`.
@@ -84,18 +66,6 @@ pub(super) fn author_quatf(stage: &Stage, prim: &Path, name: &str, value: [f32; 
     Ok(())
 }
 
-/// Author a `uniform token` attribute with the given default. Used for
-/// MeshCollisionAPI's `approximation` and joint `axis`.
-pub(super) fn author_uniform_token(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "token")?
-        .set_variability(Variability::Uniform)?
-        .set_custom(false)?
-        .set(Value::Token(value.into()))?;
-    Ok(())
-}
-
 /// Author a `varying string` attribute with the given default. Used
 /// for `CollisionGroup.mergeGroup`.
 pub(super) fn author_string(stage: &Stage, prim: &Path, name: &str, value: impl Into<String>) -> Result<()> {
@@ -104,20 +74,5 @@ pub(super) fn author_string(stage: &Stage, prim: &Path, name: &str, value: impl 
         .create_attribute(attr_path, "string")?
         .set_custom(false)?
         .set(Value::String(value.into()))?;
-    Ok(())
-}
-
-/// Author a relationship at `prim.name` with the given target paths.
-pub(super) fn author_rel_targets<I, P>(stage: &Stage, prim: &Path, name: &str, targets: I) -> Result<()>
-where
-    I: IntoIterator<Item = P>,
-    P: Into<Path>,
-{
-    let rel_path = prim.append_property(name)?;
-    let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
-    stage
-        .create_relationship(rel_path)?
-        .set_custom(false)?
-        .set_targets(paths)?;
     Ok(())
 }

--- a/src/schemas/physics/author/common.rs
+++ b/src/schemas/physics/author/common.rs
@@ -5,12 +5,6 @@
 //! match the per-attribute schema declarations in
 //! `usdPhysics/schema.usda` (variability, type name, custom flag).
 
-// Helpers below are consumed progressively across the per-prim
-// modules (`scene`, `rigid_body`, `collision`, `joint`, `limit_drive`,
-// …). Mark unused ones during the early commits so the build stays
-// warning-clean.
-#![allow(dead_code)]
-
 use anyhow::Result;
 
 use crate::sdf::{Path, Value, Variability};

--- a/src/schemas/physics/author/groups.rs
+++ b/src/schemas/physics/author/groups.rs
@@ -1,0 +1,149 @@
+//! `PhysicsCollisionGroup` typed prim, plus `PhysicsFilteredPairsAPI`
+//! and `PhysicsArticulationRootAPI` applied schemas.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{
+    API_ARTICULATION_ROOT, API_FILTERED_PAIRS, A_FILTERED_GROUPS, A_FILTERED_PAIRS, A_INVERT_FILTERED_GROUPS,
+    A_MERGE_GROUP, T_PHYSICS_COLLISION_GROUP,
+};
+
+use super::common::{author_bool, author_rel_targets, author_string};
+
+// ── PhysicsCollisionGroup ──────────────────────────────────────────
+
+/// Author a `def PhysicsCollisionGroup` prim at `path`. Per spec, the
+/// prim auto-applies `CollectionAPI:colliders` via the schema
+/// registry; members are managed through that collection rather than
+/// directly here.
+pub fn define_collision_group<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<CollisionGroupAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_COLLISION_GROUP)?;
+    Ok(CollisionGroupAuthor { prim })
+}
+
+pub struct CollisionGroupAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> CollisionGroupAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:filteredGroups` rel — other CollisionGroup prims
+    /// whose pairwise collisions should be filtered.
+    pub fn set_filtered_groups<I, P>(self, groups: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.prim.stage(), self.prim.path(), A_FILTERED_GROUPS, groups)?;
+        Ok(self)
+    }
+
+    /// Set `physics:mergeGroup` (string) — groups sharing the same
+    /// `mergeGroup` token are treated as one logical group.
+    pub fn set_merge_group(self, group: impl Into<String>) -> Result<Self> {
+        author_string(self.prim.stage(), self.prim.path(), A_MERGE_GROUP, group)?;
+        Ok(self)
+    }
+
+    /// Set `physics:invertFilteredGroups` — when true, the filter
+    /// disables collisions against every group except those in
+    /// `filteredGroups`.
+    pub fn set_invert_filtered_groups(self, invert: bool) -> Result<Self> {
+        author_bool(self.prim.stage(), self.prim.path(), A_INVERT_FILTERED_GROUPS, invert)?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsFilteredPairsAPI ────────────────────────────────────────
+
+/// Apply `PhysicsFilteredPairsAPI` to the prim at `path` and return a
+/// chainable [`FilteredPairsAuthor`] for the `filteredPairs` rel.
+pub fn apply_filtered_pairs<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<FilteredPairsAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_FILTERED_PAIRS)?;
+    Ok(FilteredPairsAuthor { prim })
+}
+
+pub struct FilteredPairsAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> FilteredPairsAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:filteredPairs` rel — pairs against which collision
+    /// should be disabled.
+    pub fn set_filtered_pairs<I, P>(self, pairs: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        author_rel_targets(self.prim.stage(), self.prim.path(), A_FILTERED_PAIRS, pairs)?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsArticulationRootAPI ─────────────────────────────────────
+
+/// Apply `PhysicsArticulationRootAPI` to the prim at `path`. The API
+/// has no own attributes — it's a marker for reduced-coordinate
+/// articulation roots per the spec.
+pub fn apply_articulation_root<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<Prim<'s>> {
+    Ok(stage.override_prim(path)?.add_applied_schema(API_ARTICULATION_ROOT)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn collision_group_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_collision_group(&stage, sdf::path("/GroupA")?)?;
+        define_collision_group(&stage, sdf::path("/GroupB")?)?
+            .set_filtered_groups([sdf::path("/GroupA")?])?
+            .set_merge_group("vehicles")?
+            .set_invert_filtered_groups(false)?;
+
+        let group =
+            crate::schemas::physics::read_collision_group(&stage, &sdf::path("/GroupB")?)?.expect("CollisionGroup");
+        assert_eq!(group.filtered_groups, vec!["/GroupA".to_string()]);
+        assert_eq!(group.merge_group.as_deref(), Some("vehicles"));
+        assert!(!group.invert_filtered_groups);
+        Ok(())
+    }
+
+    #[test]
+    fn filtered_pairs_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Body")?.set_type_name("Xform")?;
+        stage.define_prim("/Other")?.set_type_name("Xform")?;
+        apply_filtered_pairs(&stage, sdf::path("/Body")?)?.set_filtered_pairs([sdf::path("/Other")?])?;
+
+        let pairs =
+            crate::schemas::physics::read_filtered_pairs(&stage, &sdf::path("/Body")?)?.expect("FilteredPairsAPI");
+        assert_eq!(pairs.filtered, vec!["/Other".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn articulation_root_is_a_marker() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Robot")?.set_type_name("Xform")?;
+        apply_articulation_root(&stage, sdf::path("/Robot")?)?;
+
+        assert!(crate::schemas::physics::read_has_articulation_root(
+            &stage,
+            &sdf::path("/Robot")?,
+        )?);
+        Ok(())
+    }
+}

--- a/src/schemas/physics/author/joint.rs
+++ b/src/schemas/physics/author/joint.rs
@@ -1,0 +1,430 @@
+//! Authoring helpers for `PhysicsJoint` and its 5 typed subclasses:
+//! `PhysicsFixedJoint`, `PhysicsRevoluteJoint`, `PhysicsPrismaticJoint`,
+//! `PhysicsSphericalJoint`, `PhysicsDistanceJoint`.
+//!
+//! The base [`JointSetters`] trait exposes the 11 attrs every joint
+//! type inherits from `PhysicsJoint`. Concrete joint authors layer
+//! their own attrs on top via inherent methods.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{
+    AXIS_X, AXIS_Y, AXIS_Z, A_AXIS, A_BODY0, A_BODY1, A_BREAK_FORCE, A_BREAK_TORQUE, A_CONE_ANGLE_0_LIMIT,
+    A_CONE_ANGLE_1_LIMIT, A_EXCLUDE_FROM_ARTICULATION, A_JOINT_COLLISION_ENABLED, A_JOINT_ENABLED, A_LOCAL_POS_0,
+    A_LOCAL_POS_1, A_LOCAL_ROT_0, A_LOCAL_ROT_1, A_LOWER_LIMIT, A_MAX_DISTANCE, A_MIN_DISTANCE, A_UPPER_LIMIT,
+    T_PHYSICS_DISTANCE_JOINT, T_PHYSICS_FIXED_JOINT, T_PHYSICS_JOINT, T_PHYSICS_PRISMATIC_JOINT,
+    T_PHYSICS_REVOLUTE_JOINT, T_PHYSICS_SPHERICAL_JOINT,
+};
+
+use super::common::{
+    author_bool, author_float, author_point3f, author_quatf, author_rel_targets, author_uniform_bool,
+    author_uniform_token,
+};
+
+/// Axis token for single-axis joints (`PhysicsRevoluteJoint`,
+/// `PhysicsPrismaticJoint`, `PhysicsSphericalJoint`). Mirrors the
+/// schema's `allowedTokens = ["X", "Y", "Z"]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JointAxis {
+    X,
+    Y,
+    Z,
+}
+
+impl JointAxis {
+    fn as_token(self) -> &'static str {
+        match self {
+            JointAxis::X => AXIS_X,
+            JointAxis::Y => AXIS_Y,
+            JointAxis::Z => AXIS_Z,
+        }
+    }
+}
+
+/// Setters shared by every `PhysicsJoint` subclass.
+///
+/// Each implementor exposes a `prim()` accessor; the trait's default
+/// methods route through the shared free functions so the
+/// attribute-name choices live in one place.
+pub trait JointSetters<'s>: Sized {
+    fn prim(&self) -> &Prim<'s>;
+
+    /// Set `physics:body0` rel target (UsdGeomXformable).
+    fn set_body0(self, body: impl Into<Path>) -> Result<Self> {
+        author_rel_targets(self.prim().stage(), self.prim().path(), A_BODY0, [body.into()])?;
+        Ok(self)
+    }
+
+    /// Set `physics:body1` rel target (UsdGeomXformable).
+    fn set_body1(self, body: impl Into<Path>) -> Result<Self> {
+        author_rel_targets(self.prim().stage(), self.prim().path(), A_BODY1, [body.into()])?;
+        Ok(self)
+    }
+
+    /// Set `physics:localPos0` — joint frame in body0's local space.
+    fn set_local_pos0(self, pos: [f32; 3]) -> Result<Self> {
+        author_point3f(self.prim().stage(), self.prim().path(), A_LOCAL_POS_0, pos)?;
+        Ok(self)
+    }
+
+    /// Set `physics:localRot0` — joint frame rotation in body0's
+    /// local space. Quat order `(w, x, y, z)`.
+    fn set_local_rot0(self, rot: [f32; 4]) -> Result<Self> {
+        author_quatf(self.prim().stage(), self.prim().path(), A_LOCAL_ROT_0, rot)?;
+        Ok(self)
+    }
+
+    /// Set `physics:localPos1`.
+    fn set_local_pos1(self, pos: [f32; 3]) -> Result<Self> {
+        author_point3f(self.prim().stage(), self.prim().path(), A_LOCAL_POS_1, pos)?;
+        Ok(self)
+    }
+
+    /// Set `physics:localRot1`.
+    fn set_local_rot1(self, rot: [f32; 4]) -> Result<Self> {
+        author_quatf(self.prim().stage(), self.prim().path(), A_LOCAL_ROT_1, rot)?;
+        Ok(self)
+    }
+
+    /// Set `physics:jointEnabled` (spec default true).
+    fn set_enabled(self, enabled: bool) -> Result<Self> {
+        author_bool(self.prim().stage(), self.prim().path(), A_JOINT_ENABLED, enabled)?;
+        Ok(self)
+    }
+
+    /// Set `physics:collisionEnabled` on the joint (spec default
+    /// false — jointed bodies typically don't collide).
+    fn set_collision_enabled(self, enabled: bool) -> Result<Self> {
+        author_bool(
+            self.prim().stage(),
+            self.prim().path(),
+            A_JOINT_COLLISION_ENABLED,
+            enabled,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `physics:excludeFromArticulation` (uniform bool, spec
+    /// default false).
+    fn set_exclude_from_articulation(self, exclude: bool) -> Result<Self> {
+        author_uniform_bool(
+            self.prim().stage(),
+            self.prim().path(),
+            A_EXCLUDE_FROM_ARTICULATION,
+            exclude,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `physics:breakForce` (spec default +inf).
+    fn set_break_force(self, force: f32) -> Result<Self> {
+        author_float(self.prim().stage(), self.prim().path(), A_BREAK_FORCE, force)?;
+        Ok(self)
+    }
+
+    /// Set `physics:breakTorque` (spec default +inf).
+    fn set_break_torque(self, torque: f32) -> Result<Self> {
+        author_float(self.prim().stage(), self.prim().path(), A_BREAK_TORQUE, torque)?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsJoint (base / D6) ────────────────────────────────────────
+
+/// Author a `def PhysicsJoint` prim — generic 6-DOF joint base. All
+/// degrees of freedom are free until a [`super::apply_limit`] /
+/// [`super::apply_drive`] caller restricts them.
+pub fn define_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<JointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_JOINT)?;
+    Ok(JointAuthor { prim })
+}
+
+pub struct JointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> JointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+}
+
+impl<'s> JointSetters<'s> for JointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PhysicsFixedJoint ───────────────────────────────────────────────
+
+/// Author a `def PhysicsFixedJoint` prim — all DOFs locked.
+pub fn define_fixed_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<FixedJointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_FIXED_JOINT)?;
+    Ok(FixedJointAuthor { prim })
+}
+
+pub struct FixedJointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> FixedJointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+}
+
+impl<'s> JointSetters<'s> for FixedJointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PhysicsRevoluteJoint ────────────────────────────────────────────
+
+/// Author a `def PhysicsRevoluteJoint` prim — single rotational axis.
+pub fn define_revolute_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<RevoluteJointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_REVOLUTE_JOINT)?;
+    Ok(RevoluteJointAuthor { prim })
+}
+
+pub struct RevoluteJointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> RevoluteJointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:axis` (uniform token, `X` / `Y` / `Z`).
+    pub fn set_axis(self, axis: JointAxis) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_AXIS, axis.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `physics:lowerLimit` in degrees (spec default -inf).
+    pub fn set_lower_limit_deg(self, deg: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_LOWER_LIMIT, deg)?;
+        Ok(self)
+    }
+
+    /// Set `physics:upperLimit` in degrees (spec default +inf).
+    pub fn set_upper_limit_deg(self, deg: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_UPPER_LIMIT, deg)?;
+        Ok(self)
+    }
+}
+
+impl<'s> JointSetters<'s> for RevoluteJointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PhysicsPrismaticJoint ───────────────────────────────────────────
+
+/// Author a `def PhysicsPrismaticJoint` prim — single translational axis.
+pub fn define_prismatic_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PrismaticJointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_PRISMATIC_JOINT)?;
+    Ok(PrismaticJointAuthor { prim })
+}
+
+pub struct PrismaticJointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> PrismaticJointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:axis` (uniform token, `X` / `Y` / `Z`).
+    pub fn set_axis(self, axis: JointAxis) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_AXIS, axis.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `physics:lowerLimit` in distance units.
+    pub fn set_lower_limit(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_LOWER_LIMIT, value)?;
+        Ok(self)
+    }
+
+    /// Set `physics:upperLimit` in distance units.
+    pub fn set_upper_limit(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_UPPER_LIMIT, value)?;
+        Ok(self)
+    }
+}
+
+impl<'s> JointSetters<'s> for PrismaticJointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PhysicsSphericalJoint ───────────────────────────────────────────
+
+/// Author a `def PhysicsSphericalJoint` prim — ball joint with cone
+/// limits around `axis`.
+pub fn define_spherical_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SphericalJointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_SPHERICAL_JOINT)?;
+    Ok(SphericalJointAuthor { prim })
+}
+
+pub struct SphericalJointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SphericalJointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:axis` — cone limit axis.
+    pub fn set_axis(self, axis: JointAxis) -> Result<Self> {
+        author_uniform_token(self.prim.stage(), self.prim.path(), A_AXIS, axis.as_token())?;
+        Ok(self)
+    }
+
+    /// Set `physics:coneAngle0Limit` in degrees (spec default -1 — no limit).
+    pub fn set_cone_angle_0_limit_deg(self, deg: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_CONE_ANGLE_0_LIMIT, deg)?;
+        Ok(self)
+    }
+
+    /// Set `physics:coneAngle1Limit` in degrees (spec default -1 — no limit).
+    pub fn set_cone_angle_1_limit_deg(self, deg: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_CONE_ANGLE_1_LIMIT, deg)?;
+        Ok(self)
+    }
+}
+
+impl<'s> JointSetters<'s> for SphericalJointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+// ── PhysicsDistanceJoint ────────────────────────────────────────────
+
+/// Author a `def PhysicsDistanceJoint` prim — min/max distance constraint.
+pub fn define_distance_joint<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<DistanceJointAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_DISTANCE_JOINT)?;
+    Ok(DistanceJointAuthor { prim })
+}
+
+pub struct DistanceJointAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> DistanceJointAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:minDistance` (negative = unlimited).
+    pub fn set_min_distance(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_MIN_DISTANCE, value)?;
+        Ok(self)
+    }
+
+    /// Set `physics:maxDistance` (negative = unlimited).
+    pub fn set_max_distance(self, value: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_MAX_DISTANCE, value)?;
+        Ok(self)
+    }
+}
+
+impl<'s> JointSetters<'s> for DistanceJointAuthor<'s> {
+    fn prim(&self) -> &Prim<'s> {
+        &self.prim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::physics::types::JointKind;
+    use crate::sdf;
+
+    #[test]
+    fn revolute_joint_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/A")?.set_type_name("Xform")?;
+        stage.define_prim("/B")?.set_type_name("Xform")?;
+        define_revolute_joint(&stage, sdf::path("/Hinge")?)?
+            .set_body0(sdf::path("/A")?)?
+            .set_body1(sdf::path("/B")?)?
+            .set_axis(JointAxis::Y)?
+            .set_lower_limit_deg(-90.0)?
+            .set_upper_limit_deg(90.0)?
+            .set_enabled(true)?;
+
+        let joint = crate::schemas::physics::read_joint(&stage, &sdf::path("/Hinge")?)?.expect("RevoluteJoint");
+        assert_eq!(joint.kind, JointKind::Revolute);
+        assert_eq!(joint.body0.as_deref(), Some("/A"));
+        assert_eq!(joint.body1.as_deref(), Some("/B"));
+        assert_eq!(joint.axis.as_deref(), Some("Y"));
+        assert!((joint.lower_limit.unwrap() - -90.0).abs() < 1e-3);
+        assert!((joint.upper_limit.unwrap() - 90.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_joint_locks_all_dofs() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_fixed_joint(&stage, sdf::path("/Weld")?)?.set_enabled(true)?;
+
+        let joint = crate::schemas::physics::read_joint(&stage, &sdf::path("/Weld")?)?.expect("FixedJoint");
+        assert_eq!(joint.kind, JointKind::Fixed);
+        Ok(())
+    }
+
+    #[test]
+    fn prismatic_joint_with_translation_limits() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_prismatic_joint(&stage, sdf::path("/Slider")?)?
+            .set_axis(JointAxis::X)?
+            .set_lower_limit(0.0)?
+            .set_upper_limit(2.5)?;
+
+        let joint = crate::schemas::physics::read_joint(&stage, &sdf::path("/Slider")?)?.expect("PrismaticJoint");
+        assert_eq!(joint.kind, JointKind::Prismatic);
+        assert_eq!(joint.axis.as_deref(), Some("X"));
+        assert!((joint.upper_limit.unwrap() - 2.5).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn spherical_joint_cone_limits() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_spherical_joint(&stage, sdf::path("/Ball")?)?
+            .set_axis(JointAxis::Z)?
+            .set_cone_angle_0_limit_deg(30.0)?
+            .set_cone_angle_1_limit_deg(45.0)?;
+
+        let joint = crate::schemas::physics::read_joint(&stage, &sdf::path("/Ball")?)?.expect("SphericalJoint");
+        assert_eq!(joint.kind, JointKind::Spherical);
+        assert!((joint.cone_angle_0.unwrap() - 30.0).abs() < 1e-3);
+        assert!((joint.cone_angle_1.unwrap() - 45.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn distance_joint_range() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_distance_joint(&stage, sdf::path("/Rope")?)?
+            .set_min_distance(0.5)?
+            .set_max_distance(2.0)?;
+
+        let joint = crate::schemas::physics::read_joint(&stage, &sdf::path("/Rope")?)?.expect("DistanceJoint");
+        assert_eq!(joint.kind, JointKind::Distance);
+        assert!((joint.min_distance.unwrap() - 0.5).abs() < 1e-3);
+        assert!((joint.max_distance.unwrap() - 2.0).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/physics/author/limit_drive.rs
+++ b/src/schemas/physics/author/limit_drive.rs
@@ -1,0 +1,280 @@
+//! `PhysicsLimitAPI` and `PhysicsDriveAPI` multi-apply schema
+//! authoring.
+//!
+//! Per `usdPhysics/schema.usda`, both are `multipleApply` schemas with
+//! a token instance name (typically a [`Dof`] like `transX` / `rotY`
+//! or a joint-specific alias like `linear` / `angular` / `distance`).
+//!
+//! - `PhysicsLimitAPI:<dof>` → attrs at `limit:<dof>:physics:low` / `high`
+//! - `PhysicsDriveAPI:<dof>` → attrs at `drive:<dof>:physics:type` /
+//!   `targetPosition` / `targetVelocity` / `damping` / `stiffness` /
+//!   `maxForce`
+//!
+//! `apply_limit(stage, joint, dof)` / `apply_drive(stage, joint, dof)`
+//! write the namespaced apiSchemas token and return chainable
+//! authors for the per-instance attributes.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{
+    API_DRIVE, API_LIMIT, DRIVE_SUB_DAMPING, DRIVE_SUB_MAX_FORCE, DRIVE_SUB_STIFFNESS, DRIVE_SUB_TARGET_POSITION,
+    DRIVE_SUB_TARGET_VELOCITY, DRIVE_SUB_TYPE, LIMIT_SUB_HIGH, LIMIT_SUB_LOW,
+};
+use crate::schemas::physics::types::{Dof, DriveType};
+
+use super::common::{author_float, author_uniform_token};
+
+// ── PhysicsLimitAPI ─────────────────────────────────────────────────
+
+/// Apply `PhysicsLimitAPI:<dof>` to the joint at `path` and return a
+/// chainable [`LimitAuthor`] for the per-DOF `low` / `high` attrs.
+pub fn apply_limit<'s>(stage: &'s Stage, path: impl Into<Path>, dof: Dof) -> Result<LimitAuthor<'s>> {
+    let api_name = format!("{API_LIMIT}:{}", dof.as_token());
+    let prim = stage.override_prim(path)?.add_applied_schema(api_name)?;
+    Ok(LimitAuthor { prim, dof })
+}
+
+pub struct LimitAuthor<'s> {
+    prim: Prim<'s>,
+    dof: Dof,
+}
+
+impl<'s> LimitAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `limit:<dof>:physics:low` (spec default -inf — no lower limit).
+    pub fn set_low(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &limit_attr_name(self.dof, LIMIT_SUB_LOW),
+            value,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `limit:<dof>:physics:high` (spec default +inf — no upper limit).
+    pub fn set_high(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &limit_attr_name(self.dof, LIMIT_SUB_HIGH),
+            value,
+        )?;
+        Ok(self)
+    }
+}
+
+fn limit_attr_name(dof: Dof, sub: &str) -> String {
+    format!("limit:{}:physics:{sub}", dof.as_token())
+}
+
+// ── PhysicsDriveAPI ─────────────────────────────────────────────────
+
+/// Apply `PhysicsDriveAPI:<dof>` to the joint at `path` and return a
+/// chainable [`DriveAuthor`] for the per-DOF drive attrs.
+pub fn apply_drive<'s>(stage: &'s Stage, path: impl Into<Path>, dof: Dof) -> Result<DriveAuthor<'s>> {
+    let api_name = format!("{API_DRIVE}:{}", dof.as_token());
+    let prim = stage.override_prim(path)?.add_applied_schema(api_name)?;
+    Ok(DriveAuthor { prim, dof })
+}
+
+pub struct DriveAuthor<'s> {
+    prim: Prim<'s>,
+    dof: Dof,
+}
+
+impl<'s> DriveAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `drive:<dof>:physics:type` (uniform token, `force` / `acceleration`).
+    pub fn set_type(self, drive_type: DriveType) -> Result<Self> {
+        author_uniform_token(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_TYPE),
+            drive_type.as_token(),
+        )?;
+        Ok(self)
+    }
+
+    /// Set `drive:<dof>:physics:targetPosition`.
+    pub fn set_target_position(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_TARGET_POSITION),
+            value,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `drive:<dof>:physics:targetVelocity`.
+    pub fn set_target_velocity(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_TARGET_VELOCITY),
+            value,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `drive:<dof>:physics:damping`.
+    pub fn set_damping(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_DAMPING),
+            value,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `drive:<dof>:physics:stiffness`.
+    pub fn set_stiffness(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_STIFFNESS),
+            value,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `drive:<dof>:physics:maxForce` (spec default +inf — unlimited).
+    pub fn set_max_force(self, value: f32) -> Result<Self> {
+        author_float(
+            self.prim.stage(),
+            self.prim.path(),
+            &drive_attr_name(self.dof, DRIVE_SUB_MAX_FORCE),
+            value,
+        )?;
+        Ok(self)
+    }
+}
+
+fn drive_attr_name(dof: Dof, sub: &str) -> String {
+    format!("drive:{}:physics:{sub}", dof.as_token())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::physics::{define_revolute_joint, JointAxis, JointSetters};
+    use crate::sdf;
+
+    #[test]
+    fn limit_api_authors_per_dof_attrs() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_revolute_joint(&stage, sdf::path("/Hinge")?)?.set_enabled(true)?;
+        apply_limit(&stage, sdf::path("/Hinge")?, Dof::RotZ)?
+            .set_low(-45.0)?
+            .set_high(45.0)?;
+
+        let limits = crate::schemas::physics::read_joint_limits(&stage, &sdf::path("/Hinge")?)?;
+        assert_eq!(limits.len(), 1);
+        assert_eq!(limits[0].dof, Dof::RotZ);
+        assert!((limits[0].low - -45.0).abs() < 1e-3);
+        assert!((limits[0].high - 45.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn drive_api_authors_per_dof_attrs() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_revolute_joint(&stage, sdf::path("/Hinge")?)?.set_axis(JointAxis::Z)?;
+        apply_drive(&stage, sdf::path("/Hinge")?, Dof::Angular)?
+            .set_type(DriveType::Force)?
+            .set_target_position(0.0)?
+            .set_target_velocity(10.0)?
+            .set_damping(0.5)?
+            .set_stiffness(100.0)?
+            .set_max_force(1000.0)?;
+
+        let drives = crate::schemas::physics::read_joint_drives(&stage, &sdf::path("/Hinge")?)?;
+        assert_eq!(drives.len(), 1);
+        assert_eq!(drives[0].dof, Dof::Angular);
+        assert_eq!(drives[0].drive_type, DriveType::Force);
+        assert!((drives[0].damping - 0.5).abs() < 1e-3);
+        assert!((drives[0].stiffness - 100.0).abs() < 1e-3);
+        assert!((drives[0].max_force.unwrap() - 1000.0).abs() < 1e-3);
+        Ok(())
+    }
+
+    #[test]
+    fn full_scene_roundtrip_authoring_to_reader() -> Result<()> {
+        use crate::schemas::physics::{
+            apply_articulation_root, apply_collision, apply_filtered_pairs, apply_mass, apply_mesh_collision,
+            apply_physics_material, apply_rigid_body, define_collision_group, define_distance_joint,
+            define_physics_scene, CollisionApprox,
+        };
+
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/World")?.set_type_name("Xform")?;
+        stage.define_prim("/World/Box")?.set_type_name("Cube")?;
+        stage.define_prim("/World/Ball")?.set_type_name("Sphere")?;
+        stage.define_prim("/World/Material")?.set_type_name("Material")?;
+
+        // Scene + simulationOwner
+        define_physics_scene(&stage, sdf::path("/World/Scene")?)?.set_gravity_magnitude(9.81)?;
+
+        // RigidBody + Mass + Collision on the cube.
+        apply_rigid_body(&stage, sdf::path("/World/Box")?)?.set_simulation_owner(sdf::path("/World/Scene")?)?;
+        apply_mass(&stage, sdf::path("/World/Box")?)?.set_mass(1.0)?;
+        apply_collision(&stage, sdf::path("/World/Box")?)?;
+        apply_mesh_collision(&stage, sdf::path("/World/Box")?)?.set_approximation(CollisionApprox::BoundingCube)?;
+
+        apply_collision(&stage, sdf::path("/World/Ball")?)?;
+        apply_physics_material(&stage, sdf::path("/World/Material")?)?
+            .set_static_friction(0.5)?
+            .set_restitution(0.3)?;
+
+        // Articulation root + filtered pair.
+        apply_articulation_root(&stage, sdf::path("/World")?)?;
+        apply_filtered_pairs(&stage, sdf::path("/World/Box")?)?.set_filtered_pairs([sdf::path("/World/Ball")?])?;
+
+        // Collision group.
+        define_collision_group(&stage, sdf::path("/World/StaticGroup")?)?.set_merge_group("static")?;
+
+        // Distance joint between bodies + Limit + Drive on a separate D6 joint.
+        define_distance_joint(&stage, sdf::path("/World/Rope")?)?
+            .set_body0(sdf::path("/World/Box")?)?
+            .set_body1(sdf::path("/World/Ball")?)?
+            .set_min_distance(0.5)?
+            .set_max_distance(2.0)?;
+        super::super::define_joint(&stage, sdf::path("/World/D6")?)?.set_enabled(true)?;
+        apply_limit(&stage, sdf::path("/World/D6")?, Dof::TransX)?
+            .set_low(-1.0)?
+            .set_high(1.0)?;
+        apply_drive(&stage, sdf::path("/World/D6")?, Dof::TransX)?
+            .set_type(DriveType::Force)?
+            .set_stiffness(50.0)?
+            .set_damping(2.0)?;
+
+        // Roundtrip via the reader.
+        let scene =
+            crate::schemas::physics::read_physics_scene(&stage, &sdf::path("/World/Scene")?)?.expect("PhysicsScene");
+        assert!((scene.gravity_magnitude.unwrap() - 9.81).abs() < 1e-3);
+
+        assert!(crate::schemas::physics::read_has_articulation_root(
+            &stage,
+            &sdf::path("/World")?,
+        )?);
+        assert!(crate::schemas::physics::read_rigid_body(&stage, &sdf::path("/World/Box")?)?.is_some());
+        assert!(crate::schemas::physics::read_mass(&stage, &sdf::path("/World/Box")?)?.is_some());
+
+        let limits = crate::schemas::physics::read_joint_limits(&stage, &sdf::path("/World/D6")?)?;
+        assert_eq!(limits.len(), 1);
+        let drives = crate::schemas::physics::read_joint_drives(&stage, &sdf::path("/World/D6")?)?;
+        assert_eq!(drives.len(), 1);
+        Ok(())
+    }
+}

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -18,6 +18,7 @@
 mod collision;
 mod common;
 mod groups;
+mod joint;
 mod rigid_body;
 mod scene;
 
@@ -26,6 +27,11 @@ pub use collision::{
 };
 pub use groups::{
     apply_articulation_root, apply_filtered_pairs, define_collision_group, CollisionGroupAuthor, FilteredPairsAuthor,
+};
+pub use joint::{
+    define_distance_joint, define_fixed_joint, define_joint, define_prismatic_joint, define_revolute_joint,
+    define_spherical_joint, DistanceJointAuthor, FixedJointAuthor, JointAuthor, JointAxis, JointSetters,
+    PrismaticJointAuthor, RevoluteJointAuthor, SphericalJointAuthor,
 };
 pub use rigid_body::{apply_mass, apply_rigid_body, MassAuthor, RigidBodyAuthor};
 pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -1,0 +1,21 @@
+//! Authoring helpers for the [UsdPhysics](super) schema family.
+//!
+//! Mirrors the per-schema reader surface in [`super::read`] with the inverse
+//! direction — each `define_*` / `apply_*` helper authors a typed prim or an
+//! applied API schema in the form the corresponding reader decodes losslessly.
+//!
+//! The helpers wrap [`crate::usd::Stage`]'s authoring entry points; they only
+//! know which type tokens, attribute names, type names, and token-allowed
+//! values Pixar's `usdPhysics/schema.usda` requires. Composition, layer
+//! routing, and save flow through the same APIs a hand-rolled authoring call
+//! would use.
+//!
+//! `PhysicsLimitAPI` and `PhysicsDriveAPI` are multi-apply schemas: their
+//! `apply_*` helpers take a [`super::Dof`] instance and author the
+//! correctly-namespaced `apiSchemas` token plus the namespaced attribute set
+//! (`limit:<dof>:physics:*` / `drive:<dof>:physics:*`).
+
+mod common;
+mod scene;
+
+pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -19,6 +19,7 @@ mod collision;
 mod common;
 mod groups;
 mod joint;
+mod limit_drive;
 mod rigid_body;
 mod scene;
 
@@ -33,5 +34,6 @@ pub use joint::{
     define_spherical_joint, DistanceJointAuthor, FixedJointAuthor, JointAuthor, JointAxis, JointSetters,
     PrismaticJointAuthor, RevoluteJointAuthor, SphericalJointAuthor,
 };
+pub use limit_drive::{apply_drive, apply_limit, DriveAuthor, LimitAuthor};
 pub use rigid_body::{apply_mass, apply_rigid_body, MassAuthor, RigidBodyAuthor};
 pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -17,11 +17,15 @@
 
 mod collision;
 mod common;
+mod groups;
 mod rigid_body;
 mod scene;
 
 pub use collision::{
     apply_collision, apply_mesh_collision, apply_physics_material, CollisionAuthor, MaterialAuthor, MeshCollisionAuthor,
+};
+pub use groups::{
+    apply_articulation_root, apply_filtered_pairs, define_collision_group, CollisionGroupAuthor, FilteredPairsAuthor,
 };
 pub use rigid_body::{apply_mass, apply_rigid_body, MassAuthor, RigidBodyAuthor};
 pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -16,6 +16,8 @@
 //! (`limit:<dof>:physics:*` / `drive:<dof>:physics:*`).
 
 mod common;
+mod rigid_body;
 mod scene;
 
+pub use rigid_body::{apply_mass, apply_rigid_body, MassAuthor, RigidBodyAuthor};
 pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/mod.rs
+++ b/src/schemas/physics/author/mod.rs
@@ -15,9 +15,13 @@
 //! correctly-namespaced `apiSchemas` token plus the namespaced attribute set
 //! (`limit:<dof>:physics:*` / `drive:<dof>:physics:*`).
 
+mod collision;
 mod common;
 mod rigid_body;
 mod scene;
 
+pub use collision::{
+    apply_collision, apply_mesh_collision, apply_physics_material, CollisionAuthor, MaterialAuthor, MeshCollisionAuthor,
+};
 pub use rigid_body::{apply_mass, apply_rigid_body, MassAuthor, RigidBodyAuthor};
 pub use scene::{define_physics_scene, PhysicsSceneAuthor};

--- a/src/schemas/physics/author/rigid_body.rs
+++ b/src/schemas/physics/author/rigid_body.rs
@@ -1,0 +1,186 @@
+//! `PhysicsRigidBodyAPI` and `PhysicsMassAPI` authoring.
+//!
+//! `apply_rigid_body` adds the API to any UsdGeomXformable; the chain
+//! exposes the 6 spec'd attributes. `apply_mass` does the same for
+//! `PhysicsMassAPI` (5 attrs).
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{
+    API_MASS, API_RIGID_BODY, A_ANGULAR_VELOCITY, A_CENTER_OF_MASS, A_DENSITY, A_DIAGONAL_INERTIA, A_KINEMATIC_ENABLED,
+    A_MASS, A_PRINCIPAL_AXES, A_RIGID_BODY_ENABLED, A_SIMULATION_OWNER, A_STARTS_ASLEEP, A_VELOCITY,
+};
+
+use super::common::{
+    author_bool, author_float, author_float3, author_point3f, author_quatf, author_rel_targets, author_uniform_bool,
+    author_vector3f,
+};
+
+// ── PhysicsRigidBodyAPI ─────────────────────────────────────────────
+
+/// Apply `PhysicsRigidBodyAPI` to the prim at `path` and return a
+/// chainable [`RigidBodyAuthor`] for the 6 spec-defined attrs plus the
+/// `simulationOwner` relationship.
+pub fn apply_rigid_body<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<RigidBodyAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_RIGID_BODY)?;
+    Ok(RigidBodyAuthor { prim })
+}
+
+pub struct RigidBodyAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> RigidBodyAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:rigidBodyEnabled` (spec default true).
+    pub fn set_enabled(self, enabled: bool) -> Result<Self> {
+        author_bool(self.prim.stage(), self.prim.path(), A_RIGID_BODY_ENABLED, enabled)?;
+        Ok(self)
+    }
+
+    /// Set `physics:kinematicEnabled` (spec default false). A kinematic
+    /// body is moved through animated poses; the simulator derives
+    /// velocities from the motion rather than integrating forces.
+    pub fn set_kinematic(self, kinematic: bool) -> Result<Self> {
+        author_bool(self.prim.stage(), self.prim.path(), A_KINEMATIC_ENABLED, kinematic)?;
+        Ok(self)
+    }
+
+    /// Set `physics:startsAsleep` (uniform bool, spec default false).
+    pub fn set_starts_asleep(self, asleep: bool) -> Result<Self> {
+        author_uniform_bool(self.prim.stage(), self.prim.path(), A_STARTS_ASLEEP, asleep)?;
+        Ok(self)
+    }
+
+    /// Set `physics:velocity` in distance/second.
+    pub fn set_velocity(self, velocity: [f32; 3]) -> Result<Self> {
+        author_vector3f(self.prim.stage(), self.prim.path(), A_VELOCITY, velocity)?;
+        Ok(self)
+    }
+
+    /// Set `physics:angularVelocity` in degrees/second.
+    pub fn set_angular_velocity(self, angular_velocity: [f32; 3]) -> Result<Self> {
+        author_vector3f(
+            self.prim.stage(),
+            self.prim.path(),
+            A_ANGULAR_VELOCITY,
+            angular_velocity,
+        )?;
+        Ok(self)
+    }
+
+    /// Set `physics:simulationOwner` — relationship to the
+    /// `PhysicsScene` driving this body.
+    pub fn set_simulation_owner(self, scene: impl Into<Path>) -> Result<Self> {
+        author_rel_targets(self.prim.stage(), self.prim.path(), A_SIMULATION_OWNER, [scene.into()])?;
+        Ok(self)
+    }
+}
+
+// ── PhysicsMassAPI ──────────────────────────────────────────────────
+
+/// Apply `PhysicsMassAPI` to the prim at `path` and return a chainable
+/// [`MassAuthor`] for the 5 spec-defined attrs.
+pub fn apply_mass<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<MassAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_MASS)?;
+    Ok(MassAuthor { prim })
+}
+
+pub struct MassAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> MassAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:mass` (spec default 0.0 — meaning "ignored, derive
+    /// from density × volume"). Per spec, parent's mass overrides
+    /// child's.
+    pub fn set_mass(self, mass: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_MASS, mass)?;
+        Ok(self)
+    }
+
+    /// Set `physics:density` (spec default 0.0 — ignored). Child's
+    /// density overrides parent's (opposite precedence vs `mass`).
+    pub fn set_density(self, density: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_DENSITY, density)?;
+        Ok(self)
+    }
+
+    /// Set `physics:centerOfMass` in the prim's local space.
+    pub fn set_center_of_mass(self, center: [f32; 3]) -> Result<Self> {
+        author_point3f(self.prim.stage(), self.prim.path(), A_CENTER_OF_MASS, center)?;
+        Ok(self)
+    }
+
+    /// Set `physics:diagonalInertia` along the principal axes.
+    pub fn set_diagonal_inertia(self, inertia: [f32; 3]) -> Result<Self> {
+        author_float3(self.prim.stage(), self.prim.path(), A_DIAGONAL_INERTIA, inertia)?;
+        Ok(self)
+    }
+
+    /// Set `physics:principalAxes` orientation. Quat order `(w, x, y, z)`.
+    pub fn set_principal_axes(self, quat: [f32; 4]) -> Result<Self> {
+        author_quatf(self.prim.stage(), self.prim.path(), A_PRINCIPAL_AXES, quat)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn rigid_body_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Body")?.set_type_name("Xform")?;
+        stage.define_prim("/Scene")?.set_type_name("PhysicsScene")?;
+        apply_rigid_body(&stage, sdf::path("/Body")?)?
+            .set_enabled(true)?
+            .set_kinematic(false)?
+            .set_starts_asleep(true)?
+            .set_velocity([1.0, 0.0, 0.0])?
+            .set_angular_velocity([0.0, 0.0, 30.0])?
+            .set_simulation_owner(sdf::path("/Scene")?)?;
+
+        let body =
+            crate::schemas::physics::read_rigid_body(&stage, &sdf::path("/Body")?)?.expect("PhysicsRigidBodyAPI");
+        assert!(body.rigid_body_enabled);
+        assert!(!body.kinematic_enabled);
+        assert!(body.starts_asleep);
+        assert_eq!(body.velocity, Some([1.0, 0.0, 0.0]));
+        assert_eq!(body.angular_velocity, Some([0.0, 0.0, 30.0]));
+        assert_eq!(body.simulation_owner.as_deref(), Some("/Scene"));
+        Ok(())
+    }
+
+    #[test]
+    fn mass_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Body")?.set_type_name("Xform")?;
+        apply_mass(&stage, sdf::path("/Body")?)?
+            .set_mass(10.0)?
+            .set_density(1000.0)?
+            .set_center_of_mass([0.0, 0.5, 0.0])?
+            .set_diagonal_inertia([1.0, 2.0, 3.0])?
+            .set_principal_axes([1.0, 0.0, 0.0, 0.0])?;
+
+        let mass = crate::schemas::physics::read_mass(&stage, &sdf::path("/Body")?)?.expect("PhysicsMassAPI");
+        assert_eq!(mass.mass, Some(10.0));
+        assert_eq!(mass.density, Some(1000.0));
+        assert_eq!(mass.center_of_mass, Some([0.0, 0.5, 0.0]));
+        assert_eq!(mass.diagonal_inertia, Some([1.0, 2.0, 3.0]));
+        assert_eq!(mass.principal_axes, Some([1.0, 0.0, 0.0, 0.0]));
+        Ok(())
+    }
+}

--- a/src/schemas/physics/author/scene.rs
+++ b/src/schemas/physics/author/scene.rs
@@ -1,0 +1,66 @@
+//! `PhysicsScene` prim authoring.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::physics::tokens::{A_GRAVITY_DIRECTION, A_GRAVITY_MAGNITUDE, T_PHYSICS_SCENE};
+
+use super::common::{author_float, author_vector3f};
+
+/// Author a `def PhysicsScene` prim at `path` and return a chainable
+/// [`PhysicsSceneAuthor`] for the two simulation-wide attributes the
+/// spec defines.
+///
+/// Per `usdPhysics/schema.usda`, `gravityDirection = (0, 0, 0)` is a
+/// request to use the negative `upAxis`, and `gravityMagnitude < 0` is
+/// a request to use the renderer's Earth-gravity equivalent — both
+/// remain valid authored opinions, the helper just exposes them.
+pub fn define_physics_scene<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<PhysicsSceneAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_PHYSICS_SCENE)?;
+    Ok(PhysicsSceneAuthor { prim })
+}
+
+pub struct PhysicsSceneAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> PhysicsSceneAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `physics:gravityDirection` (spec default (0, 0, 0) — i.e. use
+    /// negative `upAxis`).
+    pub fn set_gravity_direction(self, direction: [f32; 3]) -> Result<Self> {
+        author_vector3f(self.prim.stage(), self.prim.path(), A_GRAVITY_DIRECTION, direction)?;
+        Ok(self)
+    }
+
+    /// Set `physics:gravityMagnitude` in distance/second² (spec
+    /// default `-inf` — i.e. use Earth gravity equivalent).
+    pub fn set_gravity_magnitude(self, magnitude: f32) -> Result<Self> {
+        author_float(self.prim.stage(), self.prim.path(), A_GRAVITY_MAGNITUDE, magnitude)?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn physics_scene_roundtrip() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_physics_scene(&stage, sdf::path("/Scene")?)?
+            .set_gravity_direction([0.0, -1.0, 0.0])?
+            .set_gravity_magnitude(9.81)?;
+
+        let scene = crate::schemas::physics::read_physics_scene(&stage, &sdf::path("/Scene")?)?.expect("PhysicsScene");
+        assert_eq!(scene.gravity_direction, Some([0.0, -1.0, 0.0]));
+        assert!((scene.gravity_magnitude.unwrap() - 9.81).abs() < 1e-3);
+        Ok(())
+    }
+}

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -59,7 +59,10 @@ mod author;
 mod read;
 mod types;
 
-pub use author::{apply_mass, apply_rigid_body, define_physics_scene, MassAuthor, PhysicsSceneAuthor, RigidBodyAuthor};
+pub use author::{
+    apply_collision, apply_mass, apply_mesh_collision, apply_physics_material, apply_rigid_body, define_physics_scene,
+    CollisionAuthor, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor, RigidBodyAuthor,
+};
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,
     read_has_collision, read_has_rigid_body, read_is_physics_scene, read_joint, read_joint_drives, read_joint_limits,

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -61,9 +61,11 @@ mod types;
 
 pub use author::{
     apply_articulation_root, apply_collision, apply_filtered_pairs, apply_mass, apply_mesh_collision,
-    apply_physics_material, apply_rigid_body, define_collision_group, define_physics_scene, CollisionAuthor,
-    CollisionGroupAuthor, FilteredPairsAuthor, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor,
-    RigidBodyAuthor,
+    apply_physics_material, apply_rigid_body, define_collision_group, define_distance_joint, define_fixed_joint,
+    define_joint, define_physics_scene, define_prismatic_joint, define_revolute_joint, define_spherical_joint,
+    CollisionAuthor, CollisionGroupAuthor, DistanceJointAuthor, FilteredPairsAuthor, FixedJointAuthor, JointAuthor,
+    JointAxis, JointSetters, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor, PrismaticJointAuthor,
+    RevoluteJointAuthor, RigidBodyAuthor, SphericalJointAuthor,
 };
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -60,8 +60,10 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_collision, apply_mass, apply_mesh_collision, apply_physics_material, apply_rigid_body, define_physics_scene,
-    CollisionAuthor, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor, RigidBodyAuthor,
+    apply_articulation_root, apply_collision, apply_filtered_pairs, apply_mass, apply_mesh_collision,
+    apply_physics_material, apply_rigid_body, define_collision_group, define_physics_scene, CollisionAuthor,
+    CollisionGroupAuthor, FilteredPairsAuthor, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor,
+    RigidBodyAuthor,
 };
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -59,7 +59,7 @@ mod author;
 mod read;
 mod types;
 
-pub use author::{define_physics_scene, PhysicsSceneAuthor};
+pub use author::{apply_mass, apply_rigid_body, define_physics_scene, MassAuthor, PhysicsSceneAuthor, RigidBodyAuthor};
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,
     read_has_collision, read_has_rigid_body, read_is_physics_scene, read_joint, read_joint_drives, read_joint_limits,

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -55,9 +55,11 @@
 
 pub mod tokens;
 
+mod author;
 mod read;
 mod types;
 
+pub use author::{define_physics_scene, PhysicsSceneAuthor};
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,
     read_has_collision, read_has_rigid_body, read_is_physics_scene, read_joint, read_joint_drives, read_joint_limits,

--- a/src/schemas/physics/mod.rs
+++ b/src/schemas/physics/mod.rs
@@ -60,12 +60,13 @@ mod read;
 mod types;
 
 pub use author::{
-    apply_articulation_root, apply_collision, apply_filtered_pairs, apply_mass, apply_mesh_collision,
-    apply_physics_material, apply_rigid_body, define_collision_group, define_distance_joint, define_fixed_joint,
-    define_joint, define_physics_scene, define_prismatic_joint, define_revolute_joint, define_spherical_joint,
-    CollisionAuthor, CollisionGroupAuthor, DistanceJointAuthor, FilteredPairsAuthor, FixedJointAuthor, JointAuthor,
-    JointAxis, JointSetters, MassAuthor, MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor, PrismaticJointAuthor,
-    RevoluteJointAuthor, RigidBodyAuthor, SphericalJointAuthor,
+    apply_articulation_root, apply_collision, apply_drive, apply_filtered_pairs, apply_limit, apply_mass,
+    apply_mesh_collision, apply_physics_material, apply_rigid_body, define_collision_group, define_distance_joint,
+    define_fixed_joint, define_joint, define_physics_scene, define_prismatic_joint, define_revolute_joint,
+    define_spherical_joint, CollisionAuthor, CollisionGroupAuthor, DistanceJointAuthor, DriveAuthor,
+    FilteredPairsAuthor, FixedJointAuthor, JointAuthor, JointAxis, JointSetters, LimitAuthor, MassAuthor,
+    MaterialAuthor, MeshCollisionAuthor, PhysicsSceneAuthor, PrismaticJointAuthor, RevoluteJointAuthor,
+    RigidBodyAuthor, SphericalJointAuthor,
 };
 pub use read::{
     find_physics_prims, read_collision_group, read_collision_shape, read_filtered_pairs, read_has_articulation_root,

--- a/src/schemas/skel/author/binding.rs
+++ b/src/schemas/skel/author/binding.rs
@@ -1,0 +1,277 @@
+//! `SkelBindingAPI` authoring.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::skel::tokens::{
+    API_SKEL_BINDING, A_GEOM_BIND_TRANSFORM, A_JOINT_INDICES, A_JOINT_WEIGHTS, A_SKEL_BLEND_SHAPES, A_SKEL_JOINTS,
+    A_SKINNING_METHOD, META_ELEMENT_SIZE, META_INTERPOLATION, REL_SKEL_ANIMATION_SOURCE, REL_SKEL_BLEND_SHAPE_TARGETS,
+    REL_SKEL_SKELETON,
+};
+use crate::schemas::skel::types::{InfluenceInterpolation, SkinningMethod};
+
+/// Apply `SkelBindingAPI` to the prim at `path` (existing prim spec
+/// required — typically a skinnable Mesh under a SkelRoot subtree)
+/// and return a chainable [`SkelBindingAuthor`].
+///
+/// Authors `apiSchemas += ["SkelBindingAPI"]` via
+/// [`Prim::add_applied_schema`], then offers setters for the 9
+/// attributes / relationships defined by Pixar's
+/// `usdSkel/schema.usda`:
+///
+/// Relationships:
+/// - `skel:skeleton` — bound Skeleton
+/// - `skel:animationSource` — bound SkelAnimation
+/// - `skel:blendShapeTargets` — ordered targets to BlendShape prims
+///
+/// Attributes:
+/// - `primvars:skel:skinningMethod` (uniform token, allowedTokens =
+///   `classicLinear` / `dualQuaternion`)
+/// - `primvars:skel:geomBindTransform` (matrix4d singleton)
+/// - `skel:joints` (uniform token[], joint-name subset)
+/// - `primvars:skel:jointIndices` (int[] primvar with
+///   `elementSize` + `interpolation` metadata)
+/// - `primvars:skel:jointWeights` (float[] primvar with
+///   `elementSize` + `interpolation` metadata)
+/// - `skel:blendShapes` (uniform token[])
+pub fn apply_skel_binding<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SkelBindingAuthor<'s>> {
+    let prim = stage.override_prim(path)?.add_applied_schema(API_SKEL_BINDING)?;
+    Ok(SkelBindingAuthor { prim })
+}
+
+/// Chainable SkelBindingAPI authoring handle.
+pub struct SkelBindingAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SkelBindingAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Author `skel:skeleton` — relationship target to the bound Skeleton prim.
+    pub fn set_skeleton(self, skeleton: impl Into<Path>) -> Result<Self> {
+        let rel_path = self.prim.path().append_property(REL_SKEL_SKELETON)?;
+        self.prim
+            .stage()
+            .create_relationship(rel_path)?
+            .set_custom(false)?
+            .set_targets([skeleton.into()])?;
+        Ok(self)
+    }
+
+    /// Author `skel:animationSource` — relationship target to the bound SkelAnimation prim.
+    pub fn set_animation_source(self, anim: impl Into<Path>) -> Result<Self> {
+        let rel_path = self.prim.path().append_property(REL_SKEL_ANIMATION_SOURCE)?;
+        self.prim
+            .stage()
+            .create_relationship(rel_path)?
+            .set_custom(false)?
+            .set_targets([anim.into()])?;
+        Ok(self)
+    }
+
+    /// Author `skel:blendShapeTargets` — ordered list of relationship
+    /// targets to BlendShape prims, paired by index with
+    /// [`Self::set_blend_shapes`].
+    pub fn set_blend_shape_targets<I, P>(self, targets: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<Path>,
+    {
+        let rel_path = self.prim.path().append_property(REL_SKEL_BLEND_SHAPE_TARGETS)?;
+        let paths: Vec<Path> = targets.into_iter().map(Into::into).collect();
+        self.prim
+            .stage()
+            .create_relationship(rel_path)?
+            .set_custom(false)?
+            .set_targets(paths)?;
+        Ok(self)
+    }
+
+    /// Author `primvars:skel:skinningMethod` — uniform token with
+    /// allowedTokens `classicLinear` / `dualQuaternion`. The
+    /// [`SkinningMethod`] enum enforces the spec's allowed values at
+    /// the type level.
+    pub fn set_skinning_method(self, method: SkinningMethod) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_SKINNING_METHOD)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "token")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::Token(method.as_token().to_string()))?;
+        Ok(self)
+    }
+
+    /// Author `primvars:skel:geomBindTransform` — singleton matrix4d
+    /// recording the bind-time world transform of the prim.
+    pub fn set_geom_bind_transform(self, transform: [f64; 16]) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_GEOM_BIND_TRANSFORM)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "matrix4d")?
+            .set_custom(false)?
+            .set(Value::Matrix4d(transform))?;
+        Ok(self)
+    }
+
+    /// Author `skel:joints` — uniform token[] joint subset. When
+    /// authored, `primvars:skel:jointIndices` index into this list
+    /// instead of the bound Skeleton's `joints`.
+    pub fn set_joints<I, S>(self, joints: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = joints.into_iter().map(Into::into).collect();
+        let attr_path = self.prim.path().append_property(A_SKEL_JOINTS)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "token[]")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::TokenVec(tokens))?;
+        Ok(self)
+    }
+
+    /// Author `primvars:skel:jointIndices` — int[] primvar. Per spec,
+    /// the primvar carries `elementSize` (joint influences per point)
+    /// and `interpolation` (`constant` / `vertex`).
+    pub fn set_joint_indices(
+        self,
+        indices: Vec<i32>,
+        element_size: i32,
+        interpolation: InfluenceInterpolation,
+    ) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_JOINT_INDICES)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "int[]")?
+            .set_custom(false)?
+            .set(Value::IntVec(indices))?
+            .set_metadata(META_ELEMENT_SIZE, Value::Int(element_size))?
+            .set_metadata(META_INTERPOLATION, Value::Token(interpolation.as_token().to_string()))?;
+        Ok(self)
+    }
+
+    /// Author `primvars:skel:jointWeights` — float[] primvar. Same
+    /// `elementSize` + `interpolation` metadata as
+    /// [`Self::set_joint_indices`]; per spec the two primvars must
+    /// match in length, interpolation, and elementSize.
+    pub fn set_joint_weights(
+        self,
+        weights: Vec<f32>,
+        element_size: i32,
+        interpolation: InfluenceInterpolation,
+    ) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_JOINT_WEIGHTS)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "float[]")?
+            .set_custom(false)?
+            .set(Value::FloatVec(weights))?
+            .set_metadata(META_ELEMENT_SIZE, Value::Int(element_size))?
+            .set_metadata(META_INTERPOLATION, Value::Token(interpolation.as_token().to_string()))?;
+        Ok(self)
+    }
+
+    /// Author `skel:blendShapes` — uniform token[] mapping animation
+    /// blend-shape names to entries in [`Self::set_blend_shape_targets`].
+    pub fn set_blend_shapes<I, S>(self, blend_shapes: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = blend_shapes.into_iter().map(Into::into).collect();
+        let attr_path = self.prim.path().append_property(A_SKEL_BLEND_SHAPES)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "token[]")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::TokenVec(tokens))?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    fn identity() -> [f64; 16] {
+        let mut m = [0.0; 16];
+        m[0] = 1.0;
+        m[5] = 1.0;
+        m[10] = 1.0;
+        m[15] = 1.0;
+        m
+    }
+
+    #[test]
+    fn apply_skel_binding_adds_api_to_prim() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        // Mesh must exist before applying the API.
+        stage.define_prim("/Body")?.set_type_name("Mesh")?;
+        apply_skel_binding(&stage, sdf::path("/Body")?)?;
+
+        let api = stage.api_schemas(&sdf::path("/Body")?)?;
+        assert!(api.iter().any(|s| s == "SkelBindingAPI"));
+        Ok(())
+    }
+
+    #[test]
+    fn full_binding_roundtrip_via_reader() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        // Build a minimal scene: Skeleton + SkelAnimation + BlendShape +
+        // skinnable mesh with SkelBindingAPI.
+        stage.define_prim("/World/Body")?.set_type_name("Mesh")?;
+        apply_skel_binding(&stage, sdf::path("/World/Body")?)?
+            .set_skeleton(sdf::path("/World/Rig")?)?
+            .set_animation_source(sdf::path("/World/Anim")?)?
+            .set_skinning_method(SkinningMethod::ClassicLinear)?
+            .set_geom_bind_transform(identity())?
+            .set_joints(["Root/Hip", "Root/Hip/Knee"])?
+            .set_joint_indices(vec![0, 1, 0, 1], 2, InfluenceInterpolation::Vertex)?
+            .set_joint_weights(vec![1.0, 0.0, 0.5, 0.5], 2, InfluenceInterpolation::Vertex)?
+            .set_blend_shapes(["smile"])?
+            .set_blend_shape_targets([sdf::path("/World/Smile")?])?;
+
+        // Read it back via the existing reader and verify every field.
+        let bind = crate::schemas::skel::read_skel_binding(&stage, &sdf::path("/World/Body")?)?
+            .expect("SkelBindingAPI authored");
+
+        assert_eq!(bind.path, "/World/Body");
+        assert_eq!(bind.skeleton.as_deref(), Some("/World/Rig"));
+        assert_eq!(bind.animation_source.as_deref(), Some("/World/Anim"));
+        assert_eq!(bind.skinning_method, SkinningMethod::ClassicLinear);
+        assert!(bind.geom_bind_transform.is_some());
+        assert_eq!(
+            bind.joint_subset,
+            vec!["Root/Hip".to_string(), "Root/Hip/Knee".to_string()]
+        );
+        assert_eq!(bind.joint_indices, vec![0, 1, 0, 1]);
+        assert_eq!(bind.joint_weights, vec![1.0, 0.0, 0.5, 0.5]);
+        assert_eq!(bind.elements_per_element, 2);
+        assert_eq!(bind.interpolation, InfluenceInterpolation::Vertex);
+        assert_eq!(bind.blend_shapes, vec!["smile".to_string()]);
+        assert_eq!(bind.blend_shape_targets, vec!["/World/Smile".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn skinning_method_dual_quaternion_authored() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/Body")?.set_type_name("Mesh")?;
+        apply_skel_binding(&stage, sdf::path("/Body")?)?.set_skinning_method(SkinningMethod::DualQuaternion)?;
+
+        match stage.field::<sdf::Value>("/Body.primvars:skel:skinningMethod", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Token(t)) => assert_eq!(t, "dualQuaternion"),
+            other => panic!("expected dualQuaternion token, got {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/src/schemas/skel/author/blend_shape.rs
+++ b/src/schemas/skel/author/blend_shape.rs
@@ -1,0 +1,131 @@
+//! `BlendShape` prim authoring.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::skel::tokens::{A_NORMAL_OFFSETS, A_OFFSETS, A_POINT_INDICES, T_BLEND_SHAPE};
+
+/// Author a `def BlendShape` prim at `path`. Returns a chainable
+/// [`BlendShapeAuthor`] for setting the spec-defined uniform arrays:
+///
+/// - `offsets` (uniform vector3f[]) — required position offsets
+/// - `normalOffsets` (uniform vector3f[]) — required normal offsets
+/// - `pointIndices` (uniform int[]) — **optional** sparse mapping; when
+///   authored, restricts `offsets` / `normalOffsets` to the listed
+///   point indices on the bound mesh.
+///
+/// Inbetween shapes (`inbetweens:NAME` with `weight` metadata) are
+/// authored separately via [`BlendShapeAuthor::add_inbetween`] in a
+/// follow-up commit.
+pub fn define_blend_shape<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<BlendShapeAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_BLEND_SHAPE)?;
+    Ok(BlendShapeAuthor { prim })
+}
+
+/// Chainable BlendShape authoring handle.
+pub struct BlendShapeAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> BlendShapeAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `offsets` — required position offsets. Adding these to the
+    /// base pose produces the target shape.
+    pub fn set_offsets(self, values: Vec<[f32; 3]>) -> Result<Self> {
+        author_uniform_vec3f_array(self.prim.stage(), self.prim.path(), A_OFFSETS, values)?;
+        Ok(self)
+    }
+
+    /// Set `normalOffsets` — required normal offsets paired with
+    /// [`Self::set_offsets`].
+    pub fn set_normal_offsets(self, values: Vec<[f32; 3]>) -> Result<Self> {
+        author_uniform_vec3f_array(self.prim.stage(), self.prim.path(), A_NORMAL_OFFSETS, values)?;
+        Ok(self)
+    }
+
+    /// Set `pointIndices` — optional sparse mapping. When authored,
+    /// `offsets[i]` / `normalOffsets[i]` apply to the bound mesh point
+    /// at `pointIndices[i]`. Per spec, the lengths of `pointIndices`
+    /// and `offsets` must match when authored.
+    pub fn set_point_indices(self, indices: Vec<i32>) -> Result<Self> {
+        let attr_path = self.prim.path().append_property(A_POINT_INDICES)?;
+        self.prim
+            .stage()
+            .create_attribute(attr_path, "int[]")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::IntVec(indices))?;
+        Ok(self)
+    }
+}
+
+fn author_uniform_vec3f_array(stage: &Stage, prim: &Path, name: &str, values: Vec<[f32; 3]>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "vector3f[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Vec3fVec(values))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn define_blend_shape_writes_required_arrays() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_blend_shape(&stage, sdf::path("/Smile")?)?
+            .set_offsets(vec![[0.0, 0.1, 0.0], [0.0, 0.2, 0.0]])?
+            .set_normal_offsets(vec![[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]])?;
+
+        let prim = sdf::path("/Smile")?;
+        assert_eq!(stage.type_name(&prim)?.as_deref(), Some(T_BLEND_SHAPE));
+
+        match stage.field::<sdf::Value>("/Smile.offsets", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3fVec(v)) => assert_eq!(v, vec![[0.0, 0.1, 0.0], [0.0, 0.2, 0.0]]),
+            other => panic!("expected Vec3fVec for offsets, got {other:?}"),
+        }
+        match stage.field::<sdf::Value>("/Smile.normalOffsets", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3fVec(v)) => assert_eq!(v.len(), 2),
+            other => panic!("expected Vec3fVec for normalOffsets, got {other:?}"),
+        }
+        assert_eq!(
+            stage.field::<sdf::Value>("/Smile.offsets", sdf::FieldKey::Variability)?,
+            Some(sdf::Value::Variability(sdf::Variability::Uniform)),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn point_indices_are_optional() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_blend_shape(&stage, sdf::path("/Smile")?)?
+            .set_offsets(vec![[0.0, 0.1, 0.0]])?
+            .set_normal_offsets(vec![[0.0, 1.0, 0.0]])?;
+
+        // pointIndices unauthored — no attribute spec at all.
+        assert!(stage
+            .field::<sdf::Value>("/Smile.pointIndices", sdf::FieldKey::Default)?
+            .is_none());
+
+        // Now set pointIndices and confirm it lands.
+        define_blend_shape(&stage, sdf::path("/SmileSparse")?)?
+            .set_offsets(vec![[0.0, 0.1, 0.0]])?
+            .set_normal_offsets(vec![[0.0, 1.0, 0.0]])?
+            .set_point_indices(vec![3])?;
+
+        match stage.field::<sdf::Value>("/SmileSparse.pointIndices", sdf::FieldKey::Default)? {
+            Some(sdf::Value::IntVec(v)) => assert_eq!(v, vec![3]),
+            other => panic!("expected IntVec for pointIndices, got {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/src/schemas/skel/author/blend_shape.rs
+++ b/src/schemas/skel/author/blend_shape.rs
@@ -19,8 +19,7 @@ use crate::schemas::skel::tokens::{
 ///   point indices on the bound mesh.
 ///
 /// Inbetween shapes (`inbetweens:NAME` with `weight` metadata) are
-/// authored separately via [`BlendShapeAuthor::add_inbetween`] in a
-/// follow-up commit.
+/// authored separately via [`BlendShapeAuthor::add_inbetween`].
 pub fn define_blend_shape<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<BlendShapeAuthor<'s>> {
     let prim = stage.define_prim(path)?.set_type_name(T_BLEND_SHAPE)?;
     Ok(BlendShapeAuthor { prim })

--- a/src/schemas/skel/author/blend_shape.rs
+++ b/src/schemas/skel/author/blend_shape.rs
@@ -5,7 +5,9 @@ use anyhow::Result;
 use crate::sdf::{Path, Value, Variability};
 use crate::usd::{Prim, Stage};
 
-use crate::schemas::skel::tokens::{A_NORMAL_OFFSETS, A_OFFSETS, A_POINT_INDICES, T_BLEND_SHAPE};
+use crate::schemas::skel::tokens::{
+    A_NORMAL_OFFSETS, A_OFFSETS, A_POINT_INDICES, META_WEIGHT, NS_INBETWEENS, T_BLEND_SHAPE,
+};
 
 /// Author a `def BlendShape` prim at `path`. Returns a chainable
 /// [`BlendShapeAuthor`] for setting the spec-defined uniform arrays:
@@ -62,6 +64,51 @@ impl<'s> BlendShapeAuthor<'s> {
             .set(Value::IntVec(indices))?;
         Ok(self)
     }
+
+    /// Add an inbetween shape named `name` at the given `weight` location
+    /// on `[0, 1]`. Authors:
+    ///
+    /// - `inbetweens:NAME` (uniform vector3f[]) with `weight` metadata
+    /// - `inbetweens:NAME:normalOffsets` (uniform vector3f[]) when
+    ///   `normal_offsets` is provided
+    ///
+    /// Per Pixar's `usdSkel/inbetweenShape.h`, the `weight` is stored as
+    /// a generic property-level metadata field on the offsets
+    /// attribute itself — not under `customData` — which the reader
+    /// pulls via `stage.field(attr_path, "weight")`.
+    pub fn add_inbetween(
+        self,
+        name: &str,
+        weight: f32,
+        offsets: Vec<[f32; 3]>,
+        normal_offsets: Option<Vec<[f32; 3]>>,
+    ) -> Result<Self> {
+        let stage = self.prim.stage();
+        let prim_path = self.prim.path().clone();
+
+        // Offsets attribute carries the weight as a property-level field.
+        let attr_name = format!("{NS_INBETWEENS}{name}");
+        let attr_path = prim_path.append_property(&attr_name)?;
+        stage
+            .create_attribute(attr_path, "vector3f[]")?
+            .set_variability(Variability::Uniform)?
+            .set_custom(false)?
+            .set(Value::Vec3fVec(offsets))?
+            .set_metadata(META_WEIGHT, Value::Float(weight))?;
+
+        // Optional normals sibling — `inbetweens:NAME:normalOffsets`.
+        if let Some(normals) = normal_offsets {
+            let normals_name = format!("{NS_INBETWEENS}{name}:normalOffsets");
+            let normals_path = prim_path.append_property(&normals_name)?;
+            stage
+                .create_attribute(normals_path, "vector3f[]")?
+                .set_variability(Variability::Uniform)?
+                .set_custom(false)?
+                .set(Value::Vec3fVec(normals))?;
+        }
+
+        Ok(self)
+    }
 }
 
 fn author_uniform_vec3f_array(stage: &Stage, prim: &Path, name: &str, values: Vec<[f32; 3]>) -> Result<()> {
@@ -101,6 +148,55 @@ mod tests {
             stage.field::<sdf::Value>("/Smile.offsets", sdf::FieldKey::Variability)?,
             Some(sdf::Value::Variability(sdf::Variability::Uniform)),
         );
+        Ok(())
+    }
+
+    #[test]
+    fn add_inbetween_writes_offsets_with_weight_metadata() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_blend_shape(&stage, sdf::path("/Smile")?)?
+            .set_offsets(vec![[0.0, 0.1, 0.0], [0.0, 0.1, 0.0]])?
+            .set_normal_offsets(vec![[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]])?
+            .add_inbetween(
+                "half",
+                0.5,
+                vec![[0.0, 0.05, 0.0], [0.0, 0.05, 0.0]],
+                Some(vec![[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
+            )?;
+
+        // The inbetween attribute itself.
+        match stage.field::<sdf::Value>("/Smile.inbetweens:half", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3fVec(v)) => assert_eq!(v, vec![[0.0, 0.05, 0.0], [0.0, 0.05, 0.0]]),
+            other => panic!("expected Vec3fVec for inbetweens:half, got {other:?}"),
+        }
+        // weight property metadata (read directly by reader).
+        match stage.field::<sdf::Value>("/Smile.inbetweens:half", "weight")? {
+            Some(sdf::Value::Float(f)) => assert!((f - 0.5).abs() < 1e-6),
+            other => panic!("expected weight = 0.5 on inbetween, got {other:?}"),
+        }
+        // Sibling normals attribute.
+        match stage.field::<sdf::Value>("/Smile.inbetweens:half:normalOffsets", sdf::FieldKey::Default)? {
+            Some(sdf::Value::Vec3fVec(v)) => assert_eq!(v.len(), 2),
+            other => panic!("expected Vec3fVec for normalOffsets sibling, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn add_inbetween_normals_are_optional() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_blend_shape(&stage, sdf::path("/Smile")?)?
+            .set_offsets(vec![[0.0, 0.1, 0.0]])?
+            .set_normal_offsets(vec![[0.0, 1.0, 0.0]])?
+            .add_inbetween("half", 0.5, vec![[0.0, 0.05, 0.0]], None)?;
+
+        // Offsets + weight authored, but normals sibling absent.
+        assert!(stage
+            .field::<sdf::Value>("/Smile.inbetweens:half", sdf::FieldKey::Default)?
+            .is_some());
+        assert!(stage
+            .field::<sdf::Value>("/Smile.inbetweens:half:normalOffsets", sdf::FieldKey::Default)?
+            .is_none());
         Ok(())
     }
 

--- a/src/schemas/skel/author/common.rs
+++ b/src/schemas/skel/author/common.rs
@@ -1,0 +1,43 @@
+//! Shared low-level authoring helpers used across the per-prim
+//! modules under [`super`].
+//!
+//! These wrap [`crate::usd::Stage`]'s public authoring entry points
+//! (`create_attribute` + `Attribute` fluent setters) with default
+//! choices that match Pixar's per-attribute schema declarations
+//! (variability, type name, custom flag). Keeping the wrapping local
+//! to one file means each schema-specific module reads as pure spec
+//! plumbing rather than repeated boilerplate.
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value, Variability};
+use crate::usd::Stage;
+
+/// Author a `uniform token[]` attribute on `prim` with name `name` and
+/// the given default value.
+pub(super) fn author_uniform_token_array(stage: &Stage, prim: &Path, name: &str, tokens: Vec<String>) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "token[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::TokenVec(tokens))?;
+    Ok(())
+}
+
+/// Author a `uniform matrix4d[]` attribute on `prim` with the given default.
+/// Matrices are USD's row-major flattened `[f64; 16]` representation.
+pub(super) fn author_uniform_matrix4d_array(
+    stage: &Stage,
+    prim: &Path,
+    name: &str,
+    matrices: Vec<[f64; 16]>,
+) -> Result<()> {
+    let attr_path = prim.append_property(name)?;
+    stage
+        .create_attribute(attr_path, "matrix4d[]")?
+        .set_variability(Variability::Uniform)?
+        .set_custom(false)?
+        .set(Value::Matrix4dVec(matrices))?;
+    Ok(())
+}

--- a/src/schemas/skel/author/common.rs
+++ b/src/schemas/skel/author/common.rs
@@ -13,17 +13,7 @@ use anyhow::Result;
 use crate::sdf::{Path, Value, Variability};
 use crate::usd::Stage;
 
-/// Author a `uniform token[]` attribute on `prim` with name `name` and
-/// the given default value.
-pub(super) fn author_uniform_token_array(stage: &Stage, prim: &Path, name: &str, tokens: Vec<String>) -> Result<()> {
-    let attr_path = prim.append_property(name)?;
-    stage
-        .create_attribute(attr_path, "token[]")?
-        .set_variability(Variability::Uniform)?
-        .set_custom(false)?
-        .set(Value::TokenVec(tokens))?;
-    Ok(())
-}
+pub(super) use crate::schemas::common::{author_uniform_token_vec as author_uniform_token_array, varying_attribute};
 
 /// Author a `uniform matrix4d[]` attribute on `prim` with the given default.
 /// Matrices are USD's row-major flattened `[f64; 16]` representation.
@@ -42,15 +32,3 @@ pub(super) fn author_uniform_matrix4d_array(
     Ok(())
 }
 
-/// Get-or-create a varying attribute on `prim` with the given typed
-/// `type_name`. Caller writes the value via the returned
-/// [`crate::usd::Attribute`].
-pub(super) fn varying_attribute<'s>(
-    stage: &'s Stage,
-    prim: &Path,
-    name: &str,
-    type_name: &str,
-) -> Result<crate::usd::Attribute<'s>> {
-    let attr_path = prim.append_property(name)?;
-    Ok(stage.create_attribute(attr_path, type_name)?.set_custom(false)?)
-}

--- a/src/schemas/skel/author/common.rs
+++ b/src/schemas/skel/author/common.rs
@@ -31,4 +31,3 @@ pub(super) fn author_uniform_matrix4d_array(
         .set(Value::Matrix4dVec(matrices))?;
     Ok(())
 }
-

--- a/src/schemas/skel/author/common.rs
+++ b/src/schemas/skel/author/common.rs
@@ -41,3 +41,16 @@ pub(super) fn author_uniform_matrix4d_array(
         .set(Value::Matrix4dVec(matrices))?;
     Ok(())
 }
+
+/// Get-or-create a varying attribute on `prim` with the given typed
+/// `type_name`. Caller writes the value via the returned
+/// [`crate::usd::Attribute`].
+pub(super) fn varying_attribute<'s>(
+    stage: &'s Stage,
+    prim: &Path,
+    name: &str,
+    type_name: &str,
+) -> Result<crate::usd::Attribute<'s>> {
+    let attr_path = prim.append_property(name)?;
+    Ok(stage.create_attribute(attr_path, type_name)?.set_custom(false)?)
+}

--- a/src/schemas/skel/author/mod.rs
+++ b/src/schemas/skel/author/mod.rs
@@ -18,6 +18,9 @@
 //! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target) between
 //! calls.
 
+mod common;
 mod skel_root;
+mod skeleton;
 
 pub use skel_root::define_skel_root;
+pub use skeleton::{define_skeleton, SkeletonAuthor};

--- a/src/schemas/skel/author/mod.rs
+++ b/src/schemas/skel/author/mod.rs
@@ -1,0 +1,23 @@
+//! Authoring helpers for the [UsdSkel](super) schema family.
+//!
+//! Mirrors the per-schema reader surface in [`super::read`] with the inverse
+//! direction — each `define_*` / `apply_*` helper authors a typed prim or an
+//! applied API schema onto a [`crate::usd::Stage`] in a form that the
+//! corresponding reader will decode losslessly.
+//!
+//! The helpers are thin wrappers over the generic
+//! [`Stage::define_prim`](crate::usd::Stage::define_prim) and
+//! [`Layer::create_attribute`](crate::sdf::Layer::create_attribute) machinery:
+//! they only know which type tokens, attribute names, type names, and
+//! metadata keys Pixar's `usdSkel/schema.usda` requires. Everything else
+//! (composition, layer routing, save) goes through the same APIs a hand-rolled
+//! authoring call would use.
+//!
+//! Each helper writes opinions to the stage's current edit target. Author
+//! across multiple layers by setting the edit target via
+//! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target) between
+//! calls.
+
+mod skel_root;
+
+pub use skel_root::define_skel_root;

--- a/src/schemas/skel/author/mod.rs
+++ b/src/schemas/skel/author/mod.rs
@@ -19,8 +19,10 @@
 //! calls.
 
 mod common;
+mod skel_animation;
 mod skel_root;
 mod skeleton;
 
+pub use skel_animation::{define_skel_animation, SkelAnimationAuthor};
 pub use skel_root::define_skel_root;
 pub use skeleton::{define_skeleton, SkeletonAuthor};

--- a/src/schemas/skel/author/mod.rs
+++ b/src/schemas/skel/author/mod.rs
@@ -18,11 +18,13 @@
 //! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target) between
 //! calls.
 
+mod blend_shape;
 mod common;
 mod skel_animation;
 mod skel_root;
 mod skeleton;
 
+pub use blend_shape::{define_blend_shape, BlendShapeAuthor};
 pub use skel_animation::{define_skel_animation, SkelAnimationAuthor};
 pub use skel_root::define_skel_root;
 pub use skeleton::{define_skeleton, SkeletonAuthor};

--- a/src/schemas/skel/author/mod.rs
+++ b/src/schemas/skel/author/mod.rs
@@ -18,12 +18,14 @@
 //! [`Stage::set_edit_target`](crate::usd::Stage::set_edit_target) between
 //! calls.
 
+mod binding;
 mod blend_shape;
 mod common;
 mod skel_animation;
 mod skel_root;
 mod skeleton;
 
+pub use binding::{apply_skel_binding, SkelBindingAuthor};
 pub use blend_shape::{define_blend_shape, BlendShapeAuthor};
 pub use skel_animation::{define_skel_animation, SkelAnimationAuthor};
 pub use skel_root::define_skel_root;

--- a/src/schemas/skel/author/skel_animation.rs
+++ b/src/schemas/skel/author/skel_animation.rs
@@ -1,0 +1,214 @@
+//! `SkelAnimation` prim authoring.
+
+use anyhow::Result;
+use half::f16;
+
+use crate::sdf::{Path, Value};
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::skel::tokens::{
+    A_BLEND_SHAPES, A_BLEND_SHAPE_WEIGHTS, A_JOINTS, A_ROTATIONS, A_SCALES, A_TRANSLATIONS, T_SKEL_ANIMATION,
+};
+
+use super::common::{author_uniform_token_array, varying_attribute};
+
+/// Author a `def SkelAnimation` prim at `path`. Returns a chainable
+/// [`SkelAnimationAuthor`] for setting the spec-defined attributes:
+///
+/// - `joints` (uniform token[])
+/// - `translations` (float3[]) — time-sampleable
+/// - `rotations` (quatf[]) — time-sampleable
+/// - `scales` (half3[]) — 16-bit per spec; time-sampleable
+/// - `blendShapes` (uniform token[])
+/// - `blendShapeWeights` (float[]) — time-sampleable
+pub fn define_skel_animation<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SkelAnimationAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_SKEL_ANIMATION)?;
+    Ok(SkelAnimationAuthor { prim })
+}
+
+/// Chainable SkelAnimation authoring handle.
+pub struct SkelAnimationAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SkelAnimationAuthor<'s> {
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `joints` — uniform token[]. Each token identifies a joint
+    /// the corresponding component in `translations` / `rotations` /
+    /// `scales` applies to.
+    pub fn set_joints<I, S>(self, joints: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = joints.into_iter().map(Into::into).collect();
+        author_uniform_token_array(self.prim.stage(), self.prim.path(), A_JOINTS, tokens)?;
+        Ok(self)
+    }
+
+    /// Set `blendShapes` — uniform token[]. Each token must appear in
+    /// `skel:blendShapes` on the bound SkelBindingAPI.
+    pub fn set_blend_shapes<I, S>(self, blend_shapes: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = blend_shapes.into_iter().map(Into::into).collect();
+        author_uniform_token_array(self.prim.stage(), self.prim.path(), A_BLEND_SHAPES, tokens)?;
+        Ok(self)
+    }
+
+    /// Set the default value of `translations`. Per spec, joint-local
+    /// translations; array length matches `joints`.
+    pub fn set_translations(self, values: Vec<[f32; 3]>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_TRANSLATIONS, "float3[]")?
+            .set(Value::Vec3fVec(values))?;
+        Ok(self)
+    }
+
+    /// Set a time sample of `translations` at `time`.
+    pub fn set_translations_at(self, time: f64, values: Vec<[f32; 3]>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_TRANSLATIONS, "float3[]")?
+            .set_at(time, Value::Vec3fVec(values))?;
+        Ok(self)
+    }
+
+    /// Set the default value of `rotations` — unit quaternions in USD's
+    /// `(w, x, y, z)` order. Array length matches `joints`.
+    pub fn set_rotations(self, values: Vec<[f32; 4]>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_ROTATIONS, "quatf[]")?.set(Value::QuatfVec(values))?;
+        Ok(self)
+    }
+
+    /// Set a time sample of `rotations` at `time`.
+    pub fn set_rotations_at(self, time: f64, values: Vec<[f32; 4]>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_ROTATIONS, "quatf[]")?
+            .set_at(time, Value::QuatfVec(values))?;
+        Ok(self)
+    }
+
+    /// Set the default value of `scales`. Per spec, stored as **half3** —
+    /// each component widens to f16. Callers pass f32 for convenience;
+    /// the helper handles the precision conversion.
+    pub fn set_scales(self, values: Vec<[f32; 3]>) -> Result<Self> {
+        let halves = values.into_iter().map(scale_to_half3).collect();
+        varying_attribute(self.prim.stage(), self.prim.path(), A_SCALES, "half3[]")?.set(Value::Vec3hVec(halves))?;
+        Ok(self)
+    }
+
+    /// Set a time sample of `scales` at `time` — see [`Self::set_scales`].
+    pub fn set_scales_at(self, time: f64, values: Vec<[f32; 3]>) -> Result<Self> {
+        let halves = values.into_iter().map(scale_to_half3).collect();
+        varying_attribute(self.prim.stage(), self.prim.path(), A_SCALES, "half3[]")?
+            .set_at(time, Value::Vec3hVec(halves))?;
+        Ok(self)
+    }
+
+    /// Set the default value of `blendShapeWeights`. Per spec, must
+    /// be the same length as `blendShapes`.
+    pub fn set_blend_shape_weights(self, values: Vec<f32>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_BLEND_SHAPE_WEIGHTS, "float[]")?
+            .set(Value::FloatVec(values))?;
+        Ok(self)
+    }
+
+    /// Set a time sample of `blendShapeWeights` at `time`.
+    pub fn set_blend_shape_weights_at(self, time: f64, values: Vec<f32>) -> Result<Self> {
+        varying_attribute(self.prim.stage(), self.prim.path(), A_BLEND_SHAPE_WEIGHTS, "float[]")?
+            .set_at(time, Value::FloatVec(values))?;
+        Ok(self)
+    }
+}
+
+fn scale_to_half3(v: [f32; 3]) -> [f16; 3] {
+    [f16::from_f32(v[0]), f16::from_f32(v[1]), f16::from_f32(v[2])]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    #[test]
+    fn define_skel_animation_authors_typed_prim_with_joints_and_blend_shapes() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skel_animation(&stage, sdf::path("/Anim")?)?
+            .set_joints(["Root", "Root/Hip"])?
+            .set_blend_shapes(["smile", "frown"])?;
+
+        let anim = sdf::path("/Anim")?;
+        assert_eq!(stage.type_name(&anim)?.as_deref(), Some(T_SKEL_ANIMATION));
+        assert_eq!(
+            stage.field::<sdf::Value>("/Anim.joints", sdf::FieldKey::Default)?,
+            Some(sdf::Value::TokenVec(vec!["Root".into(), "Root/Hip".into()])),
+        );
+        assert_eq!(
+            stage.field::<sdf::Value>("/Anim.blendShapes", sdf::FieldKey::Default)?,
+            Some(sdf::Value::TokenVec(vec!["smile".into(), "frown".into()])),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn default_pose_round_trips_translations_rotations_scales() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skel_animation(&stage, sdf::path("/Anim")?)?
+            .set_joints(["A", "B"])?
+            .set_translations(vec![[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])?
+            .set_rotations(vec![[1.0, 0.0, 0.0, 0.0], [0.707, 0.0, 0.0, 0.707]])?
+            .set_scales(vec![[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])?;
+
+        let t = stage.field::<sdf::Value>("/Anim.translations", sdf::FieldKey::Default)?;
+        match t {
+            Some(sdf::Value::Vec3fVec(v)) => assert_eq!(v, vec![[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]),
+            other => panic!("expected Vec3fVec, got {other:?}"),
+        }
+
+        let r = stage.field::<sdf::Value>("/Anim.rotations", sdf::FieldKey::Default)?;
+        match r {
+            Some(sdf::Value::QuatfVec(v)) => {
+                assert_eq!(v[0], [1.0, 0.0, 0.0, 0.0]);
+                assert!((v[1][0] - 0.707).abs() < 1e-3);
+            }
+            other => panic!("expected QuatfVec, got {other:?}"),
+        }
+
+        // scales widened to half3 per spec.
+        let s = stage.field::<sdf::Value>("/Anim.scales", sdf::FieldKey::Default)?;
+        match s {
+            Some(sdf::Value::Vec3hVec(v)) => {
+                assert_eq!(v.len(), 2);
+                assert!((v[0][0].to_f32() - 1.0).abs() < 1e-3);
+                assert!((v[1][0].to_f32() - 2.0).abs() < 1e-3);
+            }
+            other => panic!("expected Vec3hVec (half3) for scales per spec, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn time_sampled_translations_and_blendshape_weights_landed() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skel_animation(&stage, sdf::path("/Anim")?)?
+            .set_joints(["A"])?
+            .set_blend_shapes(["smile"])?
+            .set_translations_at(0.0, vec![[0.0, 0.0, 0.0]])?
+            .set_translations_at(10.0, vec![[1.0, 0.0, 0.0]])?
+            .set_blend_shape_weights_at(0.0, vec![0.0])?
+            .set_blend_shape_weights_at(10.0, vec![1.0])?;
+
+        let samples = stage.time_samples("/Anim.translations")?.expect("translations samples");
+        assert_eq!(samples.len(), 2);
+        match samples.iter().find(|(t, _)| *t == 0.0) {
+            Some((_, sdf::Value::Vec3fVec(v))) => assert_eq!(v, &vec![[0.0, 0.0, 0.0]]),
+            other => panic!("expected Vec3fVec at t=0, got {other:?}"),
+        }
+
+        let bsw = stage.time_samples("/Anim.blendShapeWeights")?.expect("bsw samples");
+        assert_eq!(bsw.len(), 2);
+        Ok(())
+    }
+}

--- a/src/schemas/skel/author/skel_root.rs
+++ b/src/schemas/skel/author/skel_root.rs
@@ -1,0 +1,58 @@
+//! `SkelRoot` prim authoring.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::skel::tokens::T_SKEL_ROOT;
+
+/// Author a `def SkelRoot` prim at `path` on the stage's edit target. Returns
+/// a [`Prim`] handle so callers can chain further attribute / API authoring
+/// (e.g. `apply_skel_binding` later in this module).
+///
+/// `SkelRoot` inherits from `Boundable` per Pixar's
+/// `usdSkel/schema.usda` and itself has no Skel-specific attributes —
+/// `extent` / `xformOpOrder` come from the UsdGeom side and are
+/// authored separately. The prim only carries the typed `SkelRoot`
+/// `typeName` so downstream traversals (`find_skel_roots`,
+/// `discover_bindings`) recognise the subtree.
+pub fn define_skel_root<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<Prim<'s>> {
+    Ok(stage.define_prim(path)?.set_type_name(T_SKEL_ROOT)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+    use crate::usd::Stage;
+
+    #[test]
+    fn define_skel_root_authors_typed_prim() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skel_root(&stage, sdf::path("/World/Character")?)?;
+
+        let path = sdf::path("/World/Character")?;
+        assert_eq!(stage.spec_type(&path)?, Some(sdf::SpecType::Prim));
+        assert_eq!(stage.type_name(&path)?.as_deref(), Some(T_SKEL_ROOT));
+        assert_eq!(
+            stage.field::<sdf::Value>(&path, sdf::FieldKey::Specifier)?,
+            Some(sdf::Value::Specifier(sdf::Specifier::Def)),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn define_skel_root_creates_ancestor_overs() -> Result<()> {
+        // Ancestor prim chain auto-creates as `over`; only the leaf is the
+        // typed `def SkelRoot`.
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skel_root(&stage, sdf::path("/World/Character")?)?;
+
+        assert_eq!(
+            stage.field::<sdf::Value>("/World", sdf::FieldKey::Specifier)?,
+            Some(sdf::Value::Specifier(sdf::Specifier::Over)),
+        );
+        Ok(())
+    }
+}

--- a/src/schemas/skel/author/skeleton.rs
+++ b/src/schemas/skel/author/skeleton.rs
@@ -1,0 +1,174 @@
+//! `Skeleton` prim authoring.
+
+use anyhow::Result;
+
+use crate::sdf::Path;
+use crate::usd::{Prim, Stage};
+
+use crate::schemas::skel::tokens::{A_BIND_TRANSFORMS, A_JOINTS, A_JOINT_NAMES, A_REST_TRANSFORMS, T_SKELETON};
+
+use super::common::{author_uniform_matrix4d_array, author_uniform_token_array};
+
+/// Author a `def Skeleton` prim at `path` and return a chainable
+/// [`SkeletonAuthor`] for setting the spec-defined uniform attributes:
+/// `joints`, `jointNames`, `bindTransforms`, `restTransforms`.
+///
+/// Per Pixar's `usdSkel/schema.usda`, all four are `uniform` arrays —
+/// the authoring helpers default to that variability without the caller
+/// having to thread it through.
+pub fn define_skeleton<'s>(stage: &'s Stage, path: impl Into<Path>) -> Result<SkeletonAuthor<'s>> {
+    let prim = stage.define_prim(path)?.set_type_name(T_SKELETON)?;
+    Ok(SkeletonAuthor { prim })
+}
+
+/// Chainable Skeleton authoring handle. Each setter writes one of the
+/// 4 spec'd uniform arrays.
+pub struct SkeletonAuthor<'s> {
+    prim: Prim<'s>,
+}
+
+impl<'s> SkeletonAuthor<'s> {
+    /// The underlying Skeleton prim handle, ready for further
+    /// `apply_*` API authoring or to extract the path.
+    pub fn into_prim(self) -> Prim<'s> {
+        self.prim
+    }
+
+    /// Set `joints` — array of path tokens defining the skeleton's
+    /// joint topology and ordering.
+    pub fn set_joints<I, S>(self, joints: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = joints.into_iter().map(Into::into).collect();
+        author_uniform_token_array(self.prim.stage(), self.prim.path(), A_JOINTS, tokens)?;
+        Ok(self)
+    }
+
+    /// Set `jointNames` — optional human-readable names per joint, in
+    /// the same order as [`Self::set_joints`]. Useful for DCC apps
+    /// that require unique joint names (USD itself allows non-unique
+    /// leaf names because the joint paths are full SdfPath tokens).
+    pub fn set_joint_names<I, S>(self, names: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let tokens: Vec<String> = names.into_iter().map(Into::into).collect();
+        author_uniform_token_array(self.prim.stage(), self.prim.path(), A_JOINT_NAMES, tokens)?;
+        Ok(self)
+    }
+
+    /// Set `bindTransforms` — bind-pose transforms in **world space**,
+    /// in joint order. Each matrix is row-major flat `[f64; 16]`.
+    pub fn set_bind_transforms(self, transforms: impl Into<Vec<[f64; 16]>>) -> Result<Self> {
+        author_uniform_matrix4d_array(
+            self.prim.stage(),
+            self.prim.path(),
+            A_BIND_TRANSFORMS,
+            transforms.into(),
+        )?;
+        Ok(self)
+    }
+
+    /// Set `restTransforms` — rest-pose transforms in **local space**
+    /// (parent-relative), in joint order. Used as a fallback for any
+    /// joint missing from the bound SkelAnimation's joint set.
+    pub fn set_rest_transforms(self, transforms: impl Into<Vec<[f64; 16]>>) -> Result<Self> {
+        author_uniform_matrix4d_array(
+            self.prim.stage(),
+            self.prim.path(),
+            A_REST_TRANSFORMS,
+            transforms.into(),
+        )?;
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    fn identity() -> [f64; 16] {
+        let mut m = [0.0; 16];
+        m[0] = 1.0;
+        m[5] = 1.0;
+        m[10] = 1.0;
+        m[15] = 1.0;
+        m
+    }
+
+    fn translated(y: f64) -> [f64; 16] {
+        let mut m = identity();
+        m[13] = y;
+        m
+    }
+
+    #[test]
+    fn define_skeleton_writes_all_spec_arrays() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skeleton(&stage, sdf::path("/Rig")?)?
+            .set_joints(["Root", "Root/Hip", "Root/Hip/Knee"])?
+            .set_joint_names(["root", "hip", "knee"])?
+            .set_bind_transforms(vec![identity(), translated(1.0), translated(2.0)])?
+            .set_rest_transforms(vec![identity(), translated(1.0), translated(1.0)])?;
+
+        let rig = sdf::path("/Rig")?;
+        assert_eq!(stage.type_name(&rig)?.as_deref(), Some(T_SKELETON));
+
+        // Joints as uniform token[] default value.
+        let joints = stage.field::<sdf::Value>("/Rig.joints", sdf::FieldKey::Default)?;
+        assert_eq!(
+            joints,
+            Some(sdf::Value::TokenVec(vec![
+                "Root".into(),
+                "Root/Hip".into(),
+                "Root/Hip/Knee".into(),
+            ])),
+        );
+        assert_eq!(
+            stage.field::<sdf::Value>("/Rig.joints", sdf::FieldKey::Variability)?,
+            Some(sdf::Value::Variability(sdf::Variability::Uniform)),
+        );
+
+        // jointNames carried per spec.
+        let names = stage.field::<sdf::Value>("/Rig.jointNames", sdf::FieldKey::Default)?;
+        assert_eq!(
+            names,
+            Some(sdf::Value::TokenVec(vec!["root".into(), "hip".into(), "knee".into()])),
+        );
+
+        // bindTransforms / restTransforms hold matrix4d[].
+        let bind = stage.field::<sdf::Value>("/Rig.bindTransforms", sdf::FieldKey::Default)?;
+        let rest = stage.field::<sdf::Value>("/Rig.restTransforms", sdf::FieldKey::Default)?;
+        match bind {
+            Some(sdf::Value::Matrix4dVec(v)) => {
+                assert_eq!(v.len(), 3);
+                assert_eq!(v[1][13], 1.0);
+            }
+            other => panic!("expected matrix4d[] for bindTransforms, got {other:?}"),
+        }
+        match rest {
+            Some(sdf::Value::Matrix4dVec(v)) => assert_eq!(v.len(), 3),
+            other => panic!("expected matrix4d[] for restTransforms, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn jointnames_are_optional() -> Result<()> {
+        // The schema marks jointNames as optional — author a Skeleton
+        // without it and confirm it doesn't appear.
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        define_skeleton(&stage, sdf::path("/Rig")?)?
+            .set_joints(["A", "B"])?
+            .set_bind_transforms(vec![identity(), identity()])?;
+
+        assert!(stage
+            .field::<sdf::Value>("/Rig.jointNames", sdf::FieldKey::Default)?
+            .is_none());
+        Ok(())
+    }
+}

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -68,6 +68,7 @@ pub mod tokens;
 
 mod anim_mapper;
 mod anim_query;
+mod author;
 mod binding;
 mod read;
 mod skeleton_query;
@@ -78,6 +79,7 @@ mod types;
 
 pub use anim_mapper::{AnimMapper, MISSING};
 pub use anim_query::{JointTransformComponents, SkelAnimQuery};
+pub use author::define_skel_root;
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{
     find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -79,7 +79,7 @@ mod types;
 
 pub use anim_mapper::{AnimMapper, MISSING};
 pub use anim_query::{JointTransformComponents, SkelAnimQuery};
-pub use author::define_skel_root;
+pub use author::{define_skel_root, define_skeleton, SkeletonAuthor};
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{
     find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -80,8 +80,8 @@ mod types;
 pub use anim_mapper::{AnimMapper, MISSING};
 pub use anim_query::{JointTransformComponents, SkelAnimQuery};
 pub use author::{
-    define_blend_shape, define_skel_animation, define_skel_root, define_skeleton, BlendShapeAuthor,
-    SkelAnimationAuthor, SkeletonAuthor,
+    apply_skel_binding, define_blend_shape, define_skel_animation, define_skel_root, define_skeleton, BlendShapeAuthor,
+    SkelAnimationAuthor, SkelBindingAuthor, SkeletonAuthor,
 };
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -79,7 +79,10 @@ mod types;
 
 pub use anim_mapper::{AnimMapper, MISSING};
 pub use anim_query::{JointTransformComponents, SkelAnimQuery};
-pub use author::{define_skel_animation, define_skel_root, define_skeleton, SkelAnimationAuthor, SkeletonAuthor};
+pub use author::{
+    define_blend_shape, define_skel_animation, define_skel_root, define_skeleton, BlendShapeAuthor,
+    SkelAnimationAuthor, SkeletonAuthor,
+};
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{
     find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,

--- a/src/schemas/skel/mod.rs
+++ b/src/schemas/skel/mod.rs
@@ -79,7 +79,7 @@ mod types;
 
 pub use anim_mapper::{AnimMapper, MISSING};
 pub use anim_query::{JointTransformComponents, SkelAnimQuery};
-pub use author::{define_skel_root, define_skeleton, SkeletonAuthor};
+pub use author::{define_skel_animation, define_skel_root, define_skeleton, SkelAnimationAuthor, SkeletonAuthor};
 pub use binding::{discover_bindings, discover_skeletons, find_skel_roots, SkelBinding};
 pub use read::{
     find_skel_prims, read_blend_shape, read_inherited_animation_source, read_inherited_skeleton, read_skel_animation,

--- a/src/schemas/skel/tokens.rs
+++ b/src/schemas/skel/tokens.rs
@@ -19,6 +19,7 @@ pub const A_EXTENT: &str = "extent";
 
 // Skeleton attribute names.
 pub const A_JOINTS: &str = "joints";
+pub const A_JOINT_NAMES: &str = "jointNames";
 pub const A_BIND_TRANSFORMS: &str = "bindTransforms";
 pub const A_REST_TRANSFORMS: &str = "restTransforms";
 

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -40,7 +40,7 @@ pub struct Prim<'s> {
 }
 
 impl<'s> Prim<'s> {
-    pub(super) fn new(stage: &'s Stage, path: sdf::Path) -> Self {
+    pub(crate) fn new(stage: &'s Stage, path: sdf::Path) -> Self {
         Self { stage, path }
     }
 
@@ -152,6 +152,23 @@ impl<'s> Prim<'s> {
             })
         })?;
         self.stage.create_relationship(rel_path)
+    }
+
+    /// Author a relationship `name` with the given target paths and the
+    /// schema-authoring convention `custom = false`. Shortcut for
+    /// `create_relationship(name) + set_custom(false) + set_targets`.
+    pub fn author_relationship_targets<I, P>(
+        &self,
+        name: &str,
+        targets: I,
+    ) -> Result<Relationship<'s>, StageAuthoringError>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<sdf::Path>,
+    {
+        self.create_relationship(name)?
+            .set_custom(false)?
+            .set_targets(targets.into_iter().map(Into::into))
     }
 
     /// Borrow the prim spec at `self.path` on the edit target's layer, apply

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -283,14 +283,29 @@ impl<'s> Attribute<'s> {
     /// above (`set_variability`, `set_custom`, `set_color_space`) cover the
     /// common cases — reach for this one when the schema requires a custom
     /// field key not represented by [`sdf::FieldKey`].
-    pub fn set_metadata(
-        self,
-        key: impl Into<String>,
-        value: impl Into<sdf::Value>,
-    ) -> Result<Self, StageAuthoringError> {
-        let key = key.into();
+    ///
+    /// `key` is `&'static str` so the change-tracking layer can record it
+    /// without copying; pass a `pub const FOO: &str = "..."` token rather than
+    /// a runtime-built string.
+    pub fn set_metadata(self, key: &'static str, value: impl Into<sdf::Value>) -> Result<Self, StageAuthoringError> {
         let value = value.into();
-        self.edit(|spec| spec.add(key, value))
+        let path = self.path.clone();
+        self.stage.with_target_layer(|layer| {
+            let data = layer.writable_data_mut()?;
+            match data.spec_mut(&path).and_then(|s| s.as_attr_mut()) {
+                Some(mut spec) => {
+                    spec.add(key, value);
+                    let mut cl = sdf::ChangeList::new();
+                    cl.entry_mut(&path).info_changed.insert(key);
+                    Ok(cl)
+                }
+                None => Err(sdf::AuthoringError::InvalidPath {
+                    path: path.clone(),
+                    reason: "no attribute spec at path on the edit target layer",
+                }),
+            }
+        })?;
+        Ok(self)
     }
 
     /// Composed default value, if any layer authored one.

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -274,6 +274,25 @@ impl<'s> Attribute<'s> {
         self.edit(&[sdf::FieldKey::ColorSpace], |spec| spec.set_color_space(color_space))
     }
 
+    /// Author a generic metadata field on the attribute spec. Mirrors C++
+    /// `UsdAttribute::SetMetadata(name, value)`.
+    ///
+    /// Used for fields the schema layers on top of the core attribute
+    /// metadata (e.g. UsdSkel's `weight` on `inbetweens:NAME`, UsdGeom's
+    /// `elementSize` / `interpolation` on primvars). The dedicated setters
+    /// above (`set_variability`, `set_custom`, `set_color_space`) cover the
+    /// common cases — reach for this one when the schema requires a custom
+    /// field key not represented by [`sdf::FieldKey`].
+    pub fn set_metadata(
+        self,
+        key: impl Into<String>,
+        value: impl Into<sdf::Value>,
+    ) -> Result<Self, StageAuthoringError> {
+        let key = key.into();
+        let value = value.into();
+        self.edit(|spec| spec.add(key, value))
+    }
+
     /// Composed default value, if any layer authored one.
     //
     // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -171,6 +171,38 @@ impl<'s> Prim<'s> {
             .set_targets(targets.into_iter().map(Into::into))
     }
 
+    /// Append `value` to the `uniform token[]` attribute named `name` on this
+    /// prim, preserving insertion order. Reads the composed default across
+    /// layers (so weaker-layer opinions get materialised into the edit target's
+    /// new value), de-duplicates, and writes back via `create_attribute`.
+    ///
+    /// Returns `true` when `value` was appended, `false` when it was already
+    /// present (or the attribute is bound to a non-token-array variant that
+    /// can't be flattened).
+    ///
+    /// Useful for ordered token stacks like `xformOpOrder` or `apiSchemas`.
+    pub fn append_to_uniform_token_array(&self, name: &str, value: impl Into<String>) -> anyhow::Result<bool> {
+        let value = value.into();
+        let attr_path = self.path.append_property(name)?;
+        let existing: Vec<String> = match self.stage.field::<sdf::Value>(&attr_path, sdf::FieldKey::Default)? {
+            Some(sdf::Value::TokenVec(v) | sdf::Value::StringVec(v)) => v,
+            Some(sdf::Value::TokenListOp(op)) => op.flatten(),
+            Some(sdf::Value::StringListOp(op)) => op.flatten(),
+            _ => Vec::new(),
+        };
+        if existing.iter().any(|t| t == &value) {
+            return Ok(false);
+        }
+        let mut updated = existing;
+        updated.push(value);
+        self.stage
+            .create_attribute(attr_path, "token[]")?
+            .set_variability(sdf::Variability::Uniform)?
+            .set_custom(false)?
+            .set(sdf::Value::TokenVec(updated))?;
+        Ok(true)
+    }
+
     /// Borrow the prim spec at `self.path` on the edit target's layer, apply
     /// `f`, and return `self` for chaining. `fields` names the metadata keys
     /// the closure intends to author so the cache invalidator can classify


### PR DESCRIPTION
Those are basically a copy/port of [bevy_openusd](https://github.com/bresilla/bevy_openusd). I tried to clean up and make it fit the structure we are building according to Pixar's spec and CPP implementation.

Authoring counterpart to the existing readers for all four schema families, behind the same `skel` / `lux` / `physics` / `geom` feature flags. Mirrors every authored attribute and applied-API field in `usdSkel/schema.usda`, `usdLux/schema.usda`, `usdPhysics/schema.usda`, and `usdGeom/schema.usda` that the existing readers cover.

Each family ships its `define_*` (typed prims) and `apply_*` (applied APIs) helpers behind a feature flag, chainable, with token-allowed values exposed as enums where the spec defines them. Where attributes repeat across prim types (LightAPI across the 8 light prims, PhysicsJoint across the 5 joint types), the shared setters live on a trait so chaining works uniformly.

One small public-API addition: `Attribute::set_metadata(key, value)`, mirroring C++ `UsdAttribute::SetMetadata`. Needed for schema-defined property metadata (Inbetween `weight`, primvar `elementSize` / `interpolation`) that don't fit the existing dedicated setters.

Skipped: registry-fallback fields (LightAPI's `shaderId` / `materialSyncMode`), light linking (CollectionAPI, separate family), MeshLightAPI / VolumeLightAPI (one-line `add_applied_schema` calls), LightFilter typed prim, plugin lights, UsdGeom subdiv-tag attributes.

70 unit tests including full-scene roundtrips per family. Every commit builds with `--all-features`. fmt and clippy clean.