### PR TITLE
feat(usd): attribute connections + ConnectionGraph

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,7 +118,7 @@ that broader spec behavior can be considered fully covered.
 | variability resolution (weakest opinion) | `12.2.3` | :white_check_mark: | `0.4.0` | Weakest authored opinion via `PrimIndex::resolve_variability` |
 | custom field resolution (any-true) | `12.2.4` | :white_check_mark: | `0.4.0` | Logical OR across opinions via `PrimIndex::resolve_custom` |
 | Dictionary combining | `12.2.5` | :white_check_mark: | `0.4.0` | Recursive merge across dictionary-valued opinions |
-| List op resolution | `12.2.6` | :construction: | `0.4.0` | Partial: composition-arc list ops and composed `apiSchemas` are resolved. Left for full metadata coverage: generic list-op field resolution for `targetPaths`, `connectionPaths`, `clipSets`, and any registered list-op metadata field. |
+| List op resolution | `12.2.6` | :construction: | `0.4.0` | Partial: composition-arc list ops, composed `apiSchemas`, and composed `connectionPaths` (via `PrimIndex::resolve_path_list_op`) are resolved. Left for full metadata coverage: generic list-op field resolution for `targetPaths`, `clipSets`, and any registered list-op metadata field. |
 | Layer metadata (root layer only) | `12.2.7` | :white_check_mark: | `0.2.0` | `defaultPrim`, timing fields, etc. |
 | Fallback values | `12.2.8` | :construction: | | Requires schema registry |
 | Basic attribute resolution | `12.3` | :white_check_mark: | `0.2.0` | Resolves authored `default`, `timeSamples`, and `ValueBlock`. Layer-offset retiming, value clips, and splines are tracked separately. |
@@ -129,7 +129,7 @@ that broader spec behavior can be considered fully covered.
 | Interpolation (Linear) | `12.5.2` | :white_check_mark: | `0.4.0` | `Stage::value_at(attr, time)` with `InterpolationType::Linear` (default). All §12.5.2 types incl. `quath`/`f`/`d` via slerp; held-fallback for unsupported types and past-last-sample. |
 | [Value clips](https://openusd.org/release/api/_usd__page__value_clips.html) | `12.3` | :construction: | | `clips`/`clipSets` for split time samples |
 | Relationship targets (raw + forwarded) | `12.4` | :construction: | | `targetPaths` readable; forwarding not implemented |
-| Attribute connections | `12.4` | :construction: | | `connectionPaths` readable; not resolved |
+| Attribute connections | `12.4` | :white_check_mark: | `0.4.0` | `Stage::connection_paths` folds list-op edits across every contributing layer via `PrimIndex::resolve_path_list_op`. Authoring on `Attribute` (`set_connections`, `add_connection`, `add_connection_prepended`, `remove_connection`, `clear_connections`, `has_authored_connections`). Stage-wide `usd::ConnectionGraph` indexes every edge and resolves chains to terminal sources. |
 
 ## Schemas (Spec 13)
 

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -255,6 +255,19 @@ impl Cache {
         self.indices[&path].resolve_token_list_op(FieldKey::ApiSchemas, &self.stack, None)
     }
 
+    /// Returns the composed `connectionPaths` list for an attribute path,
+    /// folding list-op edits (prepend / append / add / delete) across every
+    /// contributing layer. Non-property paths trivially return an empty list.
+    pub fn connection_paths(&mut self, path: &Path) -> Result<Vec<Path>> {
+        if !path.is_property_path() {
+            return Ok(Vec::new());
+        }
+        let prim_path = path.prim_path();
+        let prop_suffix = &path.as_str()[prim_path.as_str().len()..];
+        self.ensure_index(&prim_path)?;
+        self.indices[&prim_path].resolve_path_list_op(FieldKey::ConnectionPaths, &self.stack, Some(prop_suffix))
+    }
+
     /// Returns pseudo-root layer metadata from the root layer only.
     ///
     /// Session-layer and sublayer opinions are intentionally ignored here,

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -337,6 +337,44 @@ impl PrimIndex {
         Ok(result)
     }
 
+    /// Resolves a path-list-op field by composing list edits from strongest
+    /// to weakest across all contributing nodes. Used for property-level
+    /// fields like `connectionPaths` and `targetPaths`. A value block stops
+    /// weaker opinions while preserving any stronger composed edits.
+    pub(crate) fn resolve_path_list_op(
+        &self,
+        field: FieldKey,
+        stack: &LayerStack,
+        prop_suffix: Option<&str>,
+    ) -> Result<Vec<Path>> {
+        let field = field.as_str();
+        let mut ops = Vec::new();
+
+        for node in self.nodes() {
+            let query_path = Self::query_path(node, prop_suffix)?;
+            let data = stack.layer(node.layer_index);
+            let Some(value) = data.try_get(&query_path, field)? else {
+                continue;
+            };
+            // A bare `PathVec` (no list-op envelope) is treated as an explicit
+            // replacement of weaker opinions — the natural interpretation for
+            // a non-list-op-typed value when the field is declared list-op.
+            let list_op = match value.into_owned() {
+                Value::ValueBlock => break,
+                Value::PathListOp(op) => op,
+                Value::PathVec(paths) => sdf::PathListOp::explicit(paths),
+                _ => continue,
+            };
+            ops.push(list_op);
+        }
+
+        let mut result = Vec::new();
+        for op in ops.iter().rev() {
+            result = op.compose_over(&result);
+        }
+        Ok(result)
+    }
+
     /// Builds the query path for a node, applying `prop_suffix` if given.
     /// Borrows the node's path when no suffix is needed (zero-copy).
     fn query_path<'a>(node: &'a Node, prop_suffix: Option<&str>) -> Result<Cow<'a, Path>> {

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -365,7 +365,7 @@ impl PrimIndex {
                 Value::PathVec(paths) => sdf::PathListOp::explicit(paths),
                 _ => continue,
             };
-            ops.push(list_op);
+            ops.push(Self::map_path_list_op_to_root(list_op, &query_path, &node.map_to_root));
         }
 
         let mut result = Vec::new();
@@ -373,6 +373,39 @@ impl PrimIndex {
             result = op.compose_over(&result);
         }
         Ok(result)
+    }
+
+    /// Translate a path-list-op opinion from one contributing node into the
+    /// composed stage namespace before list-op composition.
+    ///
+    /// Every bucket must be translated, not just contributed values: delete
+    /// and reorder opinions only work when they compare against weaker items
+    /// in the same namespace. Unmappable paths are dropped, matching a
+    /// namespace map whose source domain does not include the authored target.
+    fn map_path_list_op_to_root(op: sdf::PathListOp, anchor: &Path, map: &MapFunction) -> sdf::PathListOp {
+        fn map_paths(paths: Vec<Path>, anchor: &Path, map: &MapFunction) -> Vec<Path> {
+            paths
+                .into_iter()
+                .filter_map(|path| {
+                    // List-op targets are authored in the contributing node's
+                    // namespace; compose them only after translating to the
+                    // stage root namespace so deletes and reorders compare
+                    // like-for-like across layers and arcs.
+                    let absolute = anchor.make_absolute(&path);
+                    map.map_source_to_target(&absolute)
+                })
+                .collect()
+        }
+
+        sdf::PathListOp {
+            explicit: op.explicit,
+            explicit_items: map_paths(op.explicit_items, anchor, map),
+            added_items: map_paths(op.added_items, anchor, map),
+            prepended_items: map_paths(op.prepended_items, anchor, map),
+            appended_items: map_paths(op.appended_items, anchor, map),
+            deleted_items: map_paths(op.deleted_items, anchor, map),
+            ordered_items: map_paths(op.ordered_items, anchor, map),
+        }
     }
 
     /// Builds the query path for a node, applying `prop_suffix` if given.

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -224,14 +224,15 @@ impl Path {
     /// Returns `true` if this path starts with `prefix` at a path boundary.
     ///
     /// A match requires either equality with `prefix` or that the suffix
-    /// following `prefix` begins with a path separator (`/`) or a variant
-    /// segment opener (`{`). This avoids false positives like
+    /// following `prefix` begins with a path separator (`/`), property
+    /// separator (`.`), or variant segment opener (`{`). This avoids false positives like
     /// `/Foobar` starting with `/Foo`.
     ///
     /// ```text
     /// "/A/B".has_prefix("/A")       -> true
     /// "/A".has_prefix("/A")         -> true
     /// "/A{set=sel}".has_prefix("/A")-> true
+    /// "/A.attr".has_prefix("/A")    -> true
     /// "/Ab".has_prefix("/A")        -> false
     /// "/X".has_prefix("/")          -> true
     /// ```
@@ -244,7 +245,7 @@ impl Path {
         let Some(suffix) = me.strip_prefix(old) else {
             return false;
         };
-        old == "/" || suffix.starts_with('/') || suffix.starts_with('{')
+        old == "/" || suffix.starts_with('/') || suffix.starts_with('.') || suffix.starts_with('{')
     }
 
     /// Replaces a prefix path with a new prefix, used for namespace remapping
@@ -265,11 +266,14 @@ impl Path {
             return Some(new_prefix.clone());
         }
 
-        // Must start with old_prefix followed by '/' or '{' (variant segment).
+        // Must start with old_prefix followed by '/', '.', or '{'. Property
+        // targets in connection/relationship list ops rely on prim-prefix
+        // mappings crossing the property separator, e.g.
+        // `/Asset.outputs:out` -> `/Instance.outputs:out`.
         let suffix = me.strip_prefix(old)?;
         // The absolute root "/" is a prefix of all absolute paths; after
         // stripping it the remainder won't start with '/' (e.g. "Foo/Bar").
-        if old != "/" && !suffix.starts_with('/') && !suffix.starts_with('{') {
+        if old != "/" && !suffix.starts_with('/') && !suffix.starts_with('.') && !suffix.starts_with('{') {
             return None;
         }
         // Ensure a separator between new prefix and suffix for non-root.
@@ -282,7 +286,9 @@ impl Path {
         }
 
         let new = new_prefix.as_str();
-        if new == "/" {
+        if new == "/" && suffix.starts_with('.') {
+            Some(Path::from_str_unchecked(&format!("/{suffix}")))
+        } else if new == "/" {
             Some(Path::from_str_unchecked(suffix))
         } else {
             Some(Path::from_str_unchecked(&format!("{new}{suffix}")))
@@ -548,6 +554,7 @@ mod tests {
             ("/A/B/C", "/A/B/D", false),
             ("/Foobar", "/Foo", false),
             ("/A{set=sel}", "/A", true),
+            ("/A.attr", "/A", true),
             ("/A", "/", true),
             ("/", "/", true),
             ("/A/B", "/A/B/C", false),
@@ -643,6 +650,16 @@ mod tests {
         assert_eq!(
             p("/Ref/Child").replace_prefix(&p("/Ref"), &p("/")).unwrap().as_str(),
             "/Child"
+        );
+
+        // Property paths still live under the owning prim namespace for
+        // composition maps; the `.` separator must count as a prefix boundary.
+        assert_eq!(
+            p("/Ref.outputs:out")
+                .replace_prefix(&p("/Ref"), &p("/MyPrim"))
+                .unwrap()
+                .as_str(),
+            "/MyPrim.outputs:out"
         );
 
         // No match.

--- a/src/sdf/spec.rs
+++ b/src/sdf/spec.rs
@@ -585,8 +585,12 @@ where
     pub fn add_connection_path(&mut self, path: sdf::Path, prepend: bool) -> bool {
         match self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
             Some(sdf::Value::PathListOp(op)) => {
+                // Re-adding a previously deleted target must first clear the
+                // delete bucket; otherwise the newly authored connection can
+                // still be removed during list-op application.
+                let mut changed = remove_path(&mut op.deleted_items, &path);
                 if op.iter().any(|p| p == &path) {
-                    return false;
+                    return changed;
                 }
                 if op.explicit {
                     // Stay explicit; honour `prepend` to control position.
@@ -600,7 +604,8 @@ where
                 } else {
                     op.appended_items.push(path);
                 }
-                true
+                changed = true;
+                changed
             }
             Some(other) => {
                 debug_assert!(false, "connectionPaths field is not a sdf::PathListOp (got {other:?})");

--- a/src/sdf/spec.rs
+++ b/src/sdf/spec.rs
@@ -559,7 +559,7 @@ where
         self.add(sdf::FieldKey::AllowedTokens, sdf::Value::TokenVec(tokens));
     }
 
-    /// Set the `connectionPaths`.
+    /// Set the `connectionPaths` (explicit list op, replacing any prior).
     pub fn set_connection_paths<I>(&mut self, paths: I)
     where
         I: IntoIterator<Item = sdf::Path>,
@@ -569,6 +569,58 @@ where
             sdf::FieldKey::ConnectionPaths,
             sdf::Value::PathListOp(sdf::PathListOp::explicit(paths)),
         );
+    }
+
+    /// Append a single connection path. No-op if already present. When
+    /// `prepend` is true the path joins the prepended-items list (it wins
+    /// over weaker layers); otherwise it joins the explicit / appended
+    /// list. A pre-existing non-`PathListOp` value is overwritten — debug
+    /// builds assert.
+    pub fn add_connection_path(&mut self, path: sdf::Path, prepend: bool) {
+        match self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
+            Some(sdf::Value::PathListOp(op)) => {
+                if !op.iter().any(|p| p == &path) {
+                    if op.explicit {
+                        op.explicit_items.push(path);
+                    } else if prepend {
+                        op.prepended_items.push(path);
+                    } else {
+                        op.appended_items.push(path);
+                    }
+                }
+            }
+            Some(other) => {
+                debug_assert!(false, "connectionPaths field is not a sdf::PathListOp (got {other:?})");
+                self.add(
+                    sdf::FieldKey::ConnectionPaths,
+                    sdf::Value::PathListOp(sdf::PathListOp::explicit([path])),
+                );
+            }
+            None => {
+                let op = if prepend {
+                    sdf::PathListOp::prepended([path])
+                } else {
+                    sdf::PathListOp::explicit([path])
+                };
+                self.add(sdf::FieldKey::ConnectionPaths, sdf::Value::PathListOp(op));
+            }
+        }
+    }
+
+    /// Remove a single connection path. Returns `true` if it was present.
+    pub fn remove_connection_path(&mut self, path: &sdf::Path) -> bool {
+        if let Some(sdf::Value::PathListOp(op)) = self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
+            return remove_path(&mut op.explicit_items, path)
+                | remove_path(&mut op.added_items, path)
+                | remove_path(&mut op.prepended_items, path)
+                | remove_path(&mut op.appended_items, path);
+        }
+        false
+    }
+
+    /// Clear all authored `connectionPaths`.
+    pub fn clear_connection_paths(&mut self) {
+        self.remove(sdf::FieldKey::ConnectionPaths.as_str());
     }
 }
 

--- a/src/sdf/spec.rs
+++ b/src/sdf/spec.rs
@@ -571,17 +571,27 @@ where
         );
     }
 
-    /// Append a single connection path. No-op if already present. When
-    /// `prepend` is true the path joins the prepended-items list (it wins
-    /// over weaker layers); otherwise it joins the explicit / appended
-    /// list. A pre-existing non-`PathListOp` value is overwritten — debug
+    /// Append a single connection path. No-op if already present.
+    ///
+    /// `prepend = true` joins the prepended-items list (the new path
+    /// composes stronger than weaker layers); `prepend = false` joins
+    /// the appended-items list (weaker than prepends, but still
+    /// composes with weaker-layer opinions). When the existing op is
+    /// `explicit`, the path is added to whichever side `prepend`
+    /// selects without flipping the op out of explicit mode. A
+    /// pre-existing non-`PathListOp` value is overwritten — debug
     /// builds assert.
     pub fn add_connection_path(&mut self, path: sdf::Path, prepend: bool) {
         match self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
             Some(sdf::Value::PathListOp(op)) => {
                 if !op.iter().any(|p| p == &path) {
                     if op.explicit {
-                        op.explicit_items.push(path);
+                        // Stay explicit; honour `prepend` to control position.
+                        if prepend {
+                            op.explicit_items.insert(0, path);
+                        } else {
+                            op.explicit_items.push(path);
+                        }
                     } else if prepend {
                         op.prepended_items.push(path);
                     } else {
@@ -591,16 +601,20 @@ where
             }
             Some(other) => {
                 debug_assert!(false, "connectionPaths field is not a sdf::PathListOp (got {other:?})");
-                self.add(
-                    sdf::FieldKey::ConnectionPaths,
-                    sdf::Value::PathListOp(sdf::PathListOp::explicit([path])),
-                );
-            }
-            None => {
                 let op = if prepend {
                     sdf::PathListOp::prepended([path])
                 } else {
-                    sdf::PathListOp::explicit([path])
+                    sdf::PathListOp::appended([path])
+                };
+                self.add(sdf::FieldKey::ConnectionPaths, sdf::Value::PathListOp(op));
+            }
+            None => {
+                // Default to a non-explicit list op so the new path composes
+                // with weaker-layer opinions, matching C++ `UsdAttribute::AddConnection`.
+                let op = if prepend {
+                    sdf::PathListOp::prepended([path])
+                } else {
+                    sdf::PathListOp::appended([path])
                 };
                 self.add(sdf::FieldKey::ConnectionPaths, sdf::Value::PathListOp(op));
             }

--- a/src/sdf/spec.rs
+++ b/src/sdf/spec.rs
@@ -637,6 +637,40 @@ where
         false
     }
 
+    /// Author a removal for a connection path. Local contributions are
+    /// stripped first; non-explicit list ops also get a delete opinion so
+    /// weaker-layer contributions stay removed in the composed result.
+    pub fn delete_connection_path(&mut self, path: &sdf::Path) -> bool {
+        match self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
+            Some(sdf::Value::PathListOp(op)) => {
+                let removed = remove_path(&mut op.explicit_items, path)
+                    | remove_path(&mut op.added_items, path)
+                    | remove_path(&mut op.prepended_items, path)
+                    | remove_path(&mut op.appended_items, path);
+                if op.explicit || op.deleted_items.iter().any(|p| p == path) {
+                    return removed;
+                }
+                op.deleted_items.push(path.clone());
+                true
+            }
+            Some(other) => {
+                debug_assert!(false, "connectionPaths field is not a sdf::PathListOp (got {other:?})");
+                self.add(
+                    sdf::FieldKey::ConnectionPaths,
+                    sdf::Value::PathListOp(sdf::PathListOp::deleted([path.clone()])),
+                );
+                true
+            }
+            None => {
+                self.add(
+                    sdf::FieldKey::ConnectionPaths,
+                    sdf::Value::PathListOp(sdf::PathListOp::deleted([path.clone()])),
+                );
+                true
+            }
+        }
+    }
+
     /// Clear all authored `connectionPaths`. Returns `true` if an
     /// opinion was actually removed.
     pub fn clear_connection_paths(&mut self) -> bool {

--- a/src/sdf/spec.rs
+++ b/src/sdf/spec.rs
@@ -571,7 +571,8 @@ where
         );
     }
 
-    /// Append a single connection path. No-op if already present.
+    /// Append a single connection path. Returns `true` if the spec was
+    /// mutated, `false` when the path was already present.
     ///
     /// `prepend = true` joins the prepended-items list (the new path
     /// composes stronger than weaker layers); `prepend = false` joins
@@ -581,23 +582,25 @@ where
     /// selects without flipping the op out of explicit mode. A
     /// pre-existing non-`PathListOp` value is overwritten — debug
     /// builds assert.
-    pub fn add_connection_path(&mut self, path: sdf::Path, prepend: bool) {
+    pub fn add_connection_path(&mut self, path: sdf::Path, prepend: bool) -> bool {
         match self.get_mut(sdf::FieldKey::ConnectionPaths.as_str()) {
             Some(sdf::Value::PathListOp(op)) => {
-                if !op.iter().any(|p| p == &path) {
-                    if op.explicit {
-                        // Stay explicit; honour `prepend` to control position.
-                        if prepend {
-                            op.explicit_items.insert(0, path);
-                        } else {
-                            op.explicit_items.push(path);
-                        }
-                    } else if prepend {
-                        op.prepended_items.push(path);
-                    } else {
-                        op.appended_items.push(path);
-                    }
+                if op.iter().any(|p| p == &path) {
+                    return false;
                 }
+                if op.explicit {
+                    // Stay explicit; honour `prepend` to control position.
+                    if prepend {
+                        op.explicit_items.insert(0, path);
+                    } else {
+                        op.explicit_items.push(path);
+                    }
+                } else if prepend {
+                    op.prepended_items.push(path);
+                } else {
+                    op.appended_items.push(path);
+                }
+                true
             }
             Some(other) => {
                 debug_assert!(false, "connectionPaths field is not a sdf::PathListOp (got {other:?})");
@@ -607,6 +610,7 @@ where
                     sdf::PathListOp::appended([path])
                 };
                 self.add(sdf::FieldKey::ConnectionPaths, sdf::Value::PathListOp(op));
+                true
             }
             None => {
                 // Default to a non-explicit list op so the new path composes
@@ -617,6 +621,7 @@ where
                     sdf::PathListOp::appended([path])
                 };
                 self.add(sdf::FieldKey::ConnectionPaths, sdf::Value::PathListOp(op));
+                true
             }
         }
     }
@@ -632,9 +637,10 @@ where
         false
     }
 
-    /// Clear all authored `connectionPaths`.
-    pub fn clear_connection_paths(&mut self) {
-        self.remove(sdf::FieldKey::ConnectionPaths.as_str());
+    /// Clear all authored `connectionPaths`. Returns `true` if an
+    /// opinion was actually removed.
+    pub fn clear_connection_paths(&mut self) -> bool {
+        self.remove(sdf::FieldKey::ConnectionPaths.as_str()).is_some()
     }
 }
 
@@ -998,6 +1004,30 @@ mod tests {
             vec!["MaterialBindingAPI".to_string(), "SkelBindingAPI".to_string()]
         );
         Ok(())
+    }
+
+    #[test]
+    fn add_connection_path_dedups() {
+        let mut spec = Spec::new(sdf::SpecType::Attribute);
+        let mut attr = spec.as_attr_mut().expect("attr spec");
+        let path = sdf::Path::new("/A.out").expect("path");
+
+        assert!(attr.add_connection_path(path.clone(), false));
+        // Duplicate — must not mutate, must not trip the change tracker.
+        assert!(!attr.add_connection_path(path, false));
+    }
+
+    #[test]
+    fn clear_connection_paths_noop() {
+        let mut spec = Spec::new(sdf::SpecType::Attribute);
+        let mut attr = spec.as_attr_mut().expect("attr spec");
+
+        // Nothing authored — clear is a no-op.
+        assert!(!attr.clear_connection_paths());
+
+        attr.add_connection_path(sdf::Path::new("/A.out").expect("path"), false);
+        assert!(attr.clear_connection_paths());
+        assert!(!attr.clear_connection_paths());
     }
 
     #[test]

--- a/src/usd/connections.rs
+++ b/src/usd/connections.rs
@@ -129,9 +129,7 @@ impl ConnectionGraph {
             match self.forward.get(node) {
                 // Terminal: nothing further to chase.
                 None => {
-                    if !terminals.contains(node) {
-                        terminals.push(node.clone());
-                    }
+                    terminals.push(node.clone());
                 }
                 // Push reversed so the first source is explored first
                 // (matches the original recursive order).

--- a/src/usd/connections.rs
+++ b/src/usd/connections.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
-use crate::sdf::{Path, Value};
+use crate::sdf::Path;
 use crate::usd::Stage;
 
 /// A directed index of every authored attribute connection on a stage.
@@ -64,7 +64,7 @@ impl ConnectionGraph {
     fn index_prim(&mut self, stage: &Stage, prim: &Path) -> Result<()> {
         for prop in stage.prim_properties(prim.clone())? {
             let attr = prim.append_property(&prop)?;
-            let sources = connections_of(stage, &attr)?;
+            let sources = stage.connection_paths(&attr)?;
             if sources.is_empty() {
                 continue;
             }
@@ -141,15 +141,6 @@ impl ConnectionGraph {
             }
         }
     }
-}
-
-/// Read the composed, flattened `connectionPaths` of a single property.
-fn connections_of(stage: &Stage, attr: &Path) -> Result<Vec<Path>> {
-    Ok(match stage.field::<Value>(attr.clone(), "connectionPaths")? {
-        Some(Value::PathListOp(op)) => op.flatten(),
-        Some(Value::PathVec(v)) => v,
-        _ => Vec::new(),
-    })
 }
 
 #[cfg(test)]

--- a/src/usd/connections.rs
+++ b/src/usd/connections.rs
@@ -1,0 +1,235 @@
+//! Stage-wide attribute connection graph.
+//!
+//! Attribute connections (`connectionPaths`, authored via `.connect`)
+//! form a directed graph over a stage's properties: an attribute is
+//! wired to one or more *source* properties that drive its value.
+//! UsdShade is the heaviest user (shader inputs ← outputs), but
+//! connections are a core attribute feature any schema may use.
+//!
+//! [`ConnectionGraph`] indexes every authored connection edge on a
+//! stage in one traversal, then answers repeated queries without
+//! re-walking:
+//!
+//! - [`sources`](ConnectionGraph::sources) — what an attribute reads from.
+//! - [`sinks`](ConnectionGraph::sinks) — what reads from an attribute
+//!   (the reverse edges).
+//! - [`resolve_chain`](ConnectionGraph::resolve_chain) — follow
+//!   connections to their terminal sources (the leaves that aren't
+//!   themselves connected onward).
+//!
+//! Edge direction: for `A.connect = [B]`, the edge is **A → B** (B is a
+//! source of A; A is a sink of B), matching the dataflow direction
+//! (values flow from B into A).
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use anyhow::Result;
+
+use crate::sdf::{Path, Value};
+use crate::usd::Stage;
+
+/// A directed index of every authored attribute connection on a stage.
+///
+/// Build once with [`ConnectionGraph::from_stage`], then query
+/// repeatedly. The graph is a static snapshot — re-build it after
+/// authoring new connections.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionGraph {
+    /// `attr -> its connection sources` (what the attr reads from).
+    forward: HashMap<Path, Vec<Path>>,
+    /// `source -> attrs that connect to it` (reverse edges).
+    reverse: HashMap<Path, Vec<Path>>,
+}
+
+impl ConnectionGraph {
+    /// Walk `stage` once and index every attribute carrying authored
+    /// `connectionPaths`. Visits the default traversal region (active,
+    /// loaded, defined, non-abstract prims).
+    pub fn from_stage(stage: &Stage) -> Result<Self> {
+        let mut graph = ConnectionGraph::default();
+        let mut first_err: Result<()> = Ok(());
+        stage.traverse(|prim| {
+            if first_err.is_err() {
+                return;
+            }
+            if let Err(e) = graph.index_prim(stage, prim) {
+                first_err = Err(e);
+            }
+        })?;
+        first_err?;
+        Ok(graph)
+    }
+
+    fn index_prim(&mut self, stage: &Stage, prim: &Path) -> Result<()> {
+        for prop in stage.prim_properties(prim.clone())? {
+            let attr = prim.append_property(&prop)?;
+            let sources = connections_of(stage, &attr)?;
+            if sources.is_empty() {
+                continue;
+            }
+            for source in &sources {
+                self.reverse.entry(source.clone()).or_default().push(attr.clone());
+            }
+            self.forward.insert(attr, sources);
+        }
+        Ok(())
+    }
+
+    /// The connection sources of `attr` — the properties it reads from.
+    /// Empty when `attr` has no authored connection.
+    pub fn sources(&self, attr: &Path) -> &[Path] {
+        self.forward.get(attr).map_or(&[], Vec::as_slice)
+    }
+
+    /// The sinks of `attr` — every property that connects *to* it.
+    /// Empty when nothing reads from `attr`.
+    pub fn sinks(&self, attr: &Path) -> &[Path] {
+        self.reverse.get(attr).map_or(&[], Vec::as_slice)
+    }
+
+    /// `true` when `attr` has at least one authored connection source.
+    pub fn is_connected(&self, attr: &Path) -> bool {
+        self.forward.contains_key(attr)
+    }
+
+    /// Total number of connected attributes (edges' tail count).
+    pub fn len(&self) -> usize {
+        self.forward.len()
+    }
+
+    /// `true` when no connection is authored anywhere on the stage.
+    pub fn is_empty(&self) -> bool {
+        self.forward.is_empty()
+    }
+
+    /// Every connection edge as `(from, to)` pairs, where `from`
+    /// connects to source `to`. Order is unspecified.
+    pub fn edges(&self) -> impl Iterator<Item = (&Path, &Path)> {
+        self.forward
+            .iter()
+            .flat_map(|(from, tos)| tos.iter().map(move |to| (from, to)))
+    }
+
+    /// Follow `attr`'s connections to their terminal sources — the
+    /// properties reached by chasing edges that are not themselves
+    /// connected onward. Branching chains yield multiple terminals;
+    /// cycles are broken (each property visited once). Returns `attr`
+    /// itself when it has no outgoing connection.
+    pub fn resolve_chain(&self, attr: &Path) -> Vec<Path> {
+        let mut terminals = Vec::new();
+        let mut visited = HashSet::new();
+        self.walk_terminals(attr, &mut visited, &mut terminals);
+        terminals
+    }
+
+    fn walk_terminals(&self, attr: &Path, visited: &mut HashSet<Path>, out: &mut Vec<Path>) {
+        if !visited.insert(attr.clone()) {
+            return;
+        }
+        match self.forward.get(attr) {
+            // Terminal: nothing further to chase.
+            None => {
+                if !out.contains(attr) {
+                    out.push(attr.clone());
+                }
+            }
+            Some(sources) => {
+                for source in sources {
+                    self.walk_terminals(source, visited, out);
+                }
+            }
+        }
+    }
+}
+
+/// Read the composed, flattened `connectionPaths` of a single property.
+fn connections_of(stage: &Stage, attr: &Path) -> Result<Vec<Path>> {
+    Ok(match stage.field::<Value>(attr.clone(), "connectionPaths")? {
+        Some(Value::PathListOp(op)) => op.flatten(),
+        Some(Value::PathVec(v)) => v,
+        _ => Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf;
+
+    /// Build a tiny three-node chain: `A.in <- B.out`, `B.in <- C.out`.
+    fn chain_stage() -> Result<Stage> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/G")?.set_type_name("Scope")?;
+        let c = stage.define_prim("/G/C")?.set_type_name("Shader")?;
+        c.create_attribute("outputs:out", "float")?;
+        let b = stage.define_prim("/G/B")?.set_type_name("Shader")?;
+        b.create_attribute("outputs:out", "float")?;
+        b.create_attribute("inputs:in", "float")?
+            .set_connections([sdf::path("/G/C.outputs:out")?])?;
+        let a = stage.define_prim("/G/A")?.set_type_name("Shader")?;
+        a.create_attribute("inputs:in", "float")?
+            .set_connections([sdf::path("/G/B.outputs:out")?])?;
+        Ok(stage)
+    }
+
+    #[test]
+    fn sources_and_sinks() -> Result<()> {
+        let stage = chain_stage()?;
+        let graph = ConnectionGraph::from_stage(&stage)?;
+
+        assert_eq!(
+            graph.sources(&sdf::path("/G/A.inputs:in")?),
+            &[sdf::path("/G/B.outputs:out")?]
+        );
+        // Nothing reads from A's input.
+        assert!(graph.sinks(&sdf::path("/G/A.inputs:in")?).is_empty());
+        // B.outputs:out is read by A.inputs:in.
+        assert_eq!(
+            graph.sinks(&sdf::path("/G/B.outputs:out")?),
+            &[sdf::path("/G/A.inputs:in")?]
+        );
+        assert!(graph.is_connected(&sdf::path("/G/A.inputs:in")?));
+        assert!(!graph.is_connected(&sdf::path("/G/C.outputs:out")?));
+        assert_eq!(graph.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_chain_to_terminal() -> Result<()> {
+        let stage = chain_stage()?;
+        let graph = ConnectionGraph::from_stage(&stage)?;
+
+        // A.inputs:in -> B.outputs:out -> B.inputs:in -> C.outputs:out.
+        // Wait: B.outputs:out is NOT connected to B.inputs:in (shaders
+        // don't auto-wire), so the terminal of A is B.outputs:out.
+        let terminals = graph.resolve_chain(&sdf::path("/G/A.inputs:in")?);
+        assert_eq!(terminals, vec![sdf::path("/G/B.outputs:out")?]);
+        Ok(())
+    }
+
+    #[test]
+    fn cycle_is_broken() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        let p = stage.define_prim("/P")?.set_type_name("Shader")?;
+        p.create_attribute("inputs:a", "float")?
+            .set_connections([sdf::path("/P.inputs:b")?])?;
+        p.create_attribute("inputs:b", "float")?
+            .set_connections([sdf::path("/P.inputs:a")?])?;
+        let graph = ConnectionGraph::from_stage(&stage)?;
+        // Resolving a cycle terminates (no terminal reached, but no hang).
+        let terminals = graph.resolve_chain(&sdf::path("/P.inputs:a")?);
+        assert!(terminals.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn empty_stage_has_no_edges() -> Result<()> {
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        stage.define_prim("/X")?.set_type_name("Scope")?;
+        let graph = ConnectionGraph::from_stage(&stage)?;
+        assert!(graph.is_empty());
+        assert_eq!(graph.edges().count(), 0);
+        Ok(())
+    }
+}

--- a/src/usd/connections.rs
+++ b/src/usd/connections.rs
@@ -117,29 +117,28 @@ impl ConnectionGraph {
     /// cycles are broken (each property visited once). Returns `attr`
     /// itself when it has no outgoing connection.
     pub fn resolve_chain(&self, attr: &Path) -> Vec<Path> {
+        // Iterative depth-first walk over the `forward` graph. An explicit
+        // stack keeps deep chains from blowing the call stack.
         let mut terminals = Vec::new();
         let mut visited = HashSet::new();
-        self.walk_terminals(attr, &mut visited, &mut terminals);
+        let mut stack: Vec<&Path> = vec![attr];
+        while let Some(node) = stack.pop() {
+            if !visited.insert(node.clone()) {
+                continue;
+            }
+            match self.forward.get(node) {
+                // Terminal: nothing further to chase.
+                None => {
+                    if !terminals.contains(node) {
+                        terminals.push(node.clone());
+                    }
+                }
+                // Push reversed so the first source is explored first
+                // (matches the original recursive order).
+                Some(sources) => stack.extend(sources.iter().rev()),
+            }
+        }
         terminals
-    }
-
-    fn walk_terminals(&self, attr: &Path, visited: &mut HashSet<Path>, out: &mut Vec<Path>) {
-        if !visited.insert(attr.clone()) {
-            return;
-        }
-        match self.forward.get(attr) {
-            // Terminal: nothing further to chase.
-            None => {
-                if !out.contains(attr) {
-                    out.push(attr.clone());
-                }
-            }
-            Some(sources) => {
-                for source in sources {
-                    self.walk_terminals(source, visited, out);
-                }
-            }
-        }
     }
 }
 
@@ -191,11 +190,28 @@ mod tests {
         let stage = chain_stage()?;
         let graph = ConnectionGraph::from_stage(&stage)?;
 
-        // A.inputs:in -> B.outputs:out -> B.inputs:in -> C.outputs:out.
-        // Wait: B.outputs:out is NOT connected to B.inputs:in (shaders
-        // don't auto-wire), so the terminal of A is B.outputs:out.
+        // A.inputs:in -> B.outputs:out. Shader outputs don't auto-wire
+        // to inputs on the same prim, so B.outputs:out is the terminal.
         let terminals = graph.resolve_chain(&sdf::path("/G/A.inputs:in")?);
         assert_eq!(terminals, vec![sdf::path("/G/B.outputs:out")?]);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_chain_deep() -> Result<()> {
+        // Deep chain — the iterative walk must finish without overflowing
+        // the call stack the recursive form would on a long chain.
+        let stage = Stage::builder().in_memory("anon.usda")?;
+        let host = stage.define_prim("/Host")?.set_type_name("Shader")?;
+        const N: usize = 2_000;
+        for i in 0..N - 1 {
+            host.create_attribute(&format!("inputs:n{i}"), "float")?
+                .set_connections([sdf::path(format!("/Host.inputs:n{}", i + 1))?])?;
+        }
+        host.create_attribute(&format!("inputs:n{}", N - 1), "float")?;
+        let graph = ConnectionGraph::from_stage(&stage)?;
+        let terminals = graph.resolve_chain(&sdf::path("/Host.inputs:n0")?);
+        assert_eq!(terminals, vec![sdf::path(format!("/Host.inputs:n{}", N - 1))?]);
         Ok(())
     }
 

--- a/src/usd/mod.rs
+++ b/src/usd/mod.rs
@@ -4,10 +4,12 @@
 //! lives in the local `stage` module, while this module re-exports the public
 //! `Usd*` surface under `openusd::usd`.
 
+mod connections;
 mod interp;
 mod prim;
 mod stage;
 
+pub use connections::ConnectionGraph;
 pub use interp::InterpolationType;
 pub use prim::{Attribute, Prim, Relationship};
 pub use stage::{

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -430,12 +430,17 @@ impl<'s> Attribute<'s> {
         self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| spec.clear_connection_paths())
     }
 
-    /// `true` when any connection is authored on the edit target's layer.
-    /// Mirrors C++ `UsdAttribute::HasAuthoredConnections`.
+    /// `true` when any connection opinion is authored — including an
+    /// explicit-empty list op (`.connect = []`), the canonical way to
+    /// block weaker-layer connections. Mirrors C++
+    /// `UsdAttribute::HasAuthoredConnections`.
     //
     // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.
     pub fn has_authored_connections(&self) -> anyhow::Result<bool> {
-        Ok(!self.get_connections()?.is_empty())
+        Ok(self
+            .stage
+            .field::<sdf::Value>(&self.path, sdf::FieldKey::ConnectionPaths)?
+            .is_some())
     }
 
     /// Composed `connectionPaths`, flattened across layers. Returns an
@@ -825,7 +830,24 @@ mod tests {
     }
 
     #[test]
-    fn add_connection_defaults_to_appended() -> anyhow::Result<()> {
+    fn authored_connections_explicit_empty() -> anyhow::Result<()> {
+        // `set_connections([])` authors an explicit-empty list op, the
+        // canonical way to block weaker-layer connection opinions.
+        // `has_authored_connections` must see this as authored even though
+        // the flattened list is empty.
+        let stage = stage()?;
+        let attr = stage
+            .define_prim("/Surface")?
+            .set_type_name("Shader")?
+            .create_attribute("inputs:diffuseColor", "color3f")?
+            .set_connections::<[sdf::Path; 0]>([])?;
+        assert!(attr.has_authored_connections()?);
+        assert!(attr.get_connections()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn add_connection_appended() -> anyhow::Result<()> {
         // First-time `add_connection` on a no-prior-opinion attribute must
         // author a non-explicit (appended) list op, so weaker-layer
         // connection opinions still compose. Authoring `explicit` here
@@ -851,7 +873,7 @@ mod tests {
     }
 
     #[test]
-    fn add_connection_prepended_on_explicit_op() -> anyhow::Result<()> {
+    fn add_connection_prepend_on_explicit() -> anyhow::Result<()> {
         // When the existing op is `explicit` (e.g. authored via
         // `set_connections`), `add_connection_prepended` must honour the
         // prepend position by inserting at the front of `explicit_items`

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -443,20 +443,14 @@ impl<'s> Attribute<'s> {
             .is_some())
     }
 
-    /// Composed `connectionPaths`, flattened across layers. Returns an
-    /// empty vec when no connection is authored. Mirrors C++
-    /// `UsdAttribute::GetConnections`.
+    /// Composed `connectionPaths`, with list-op edits folded across every
+    /// contributing layer. Returns an empty vec when no connection is
+    /// authored. Mirrors C++ `UsdAttribute::GetConnections`.
     //
-    // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.
+    // TODO: drop `anyhow::Result` once `Stage::connection_paths` returns
+    // a typed error.
     pub fn get_connections(&self) -> anyhow::Result<Vec<sdf::Path>> {
-        match self
-            .stage
-            .field::<sdf::Value>(&self.path, sdf::FieldKey::ConnectionPaths)?
-        {
-            Some(sdf::Value::PathListOp(op)) => Ok(op.flatten()),
-            Some(sdf::Value::PathVec(v)) => Ok(v),
-            _ => Ok(Vec::new()),
-        }
+        self.stage.connection_paths(&self.path)
     }
 
     /// Composed default value, if any layer authored one.

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -399,17 +399,46 @@ impl<'s> Attribute<'s> {
     pub fn remove_connection(&self, target: &sdf::Path) -> Result<bool, StageAuthoringError> {
         let path = self.path.clone();
         let target = target.clone();
+        // The target may exist only through weaker layers. Check the composed
+        // list first so this call can author a delete opinion even when the
+        // edit-target layer has no local connection item to remove.
+        if !self.stage.connection_paths(&path)?.iter().any(|p| p == &target) {
+            return Ok(false);
+        }
+        let type_name = self.stage.field::<String>(&path, sdf::FieldKey::TypeName)?;
         let mut removed = false;
         self.stage.with_target_layer(|layer| {
+            let created_attr = !layer.data().has_spec(&path);
+            let auto_ancestors = if !created_attr {
+                Vec::new()
+            } else {
+                // A delete list-op still needs a property spec to carry it.
+                // Use the composed type name and leave `custom` unauthored so
+                // the spec is only as strong as needed for the connection edit.
+                let type_name = type_name.clone().ok_or_else(|| sdf::AuthoringError::InvalidPath {
+                    path: path.clone(),
+                    reason: "cannot author connection delete for typeless composed attribute",
+                })?;
+                let owning_prim = path.prim_path();
+                let auto_ancestors = layer.missing_prim_chain_inclusive(&owning_prim);
+                layer.create_attribute(path.clone(), type_name, sdf::Variability::Varying, false)?;
+                auto_ancestors
+            };
             let data = layer.writable_data_mut()?;
             match data.spec_mut(&path).and_then(|s| s.as_attr_mut()) {
                 Some(mut spec) => {
-                    removed = spec.remove_connection_path(&target);
+                    removed = spec.delete_connection_path(&target);
                     let mut cl = sdf::ChangeList::new();
                     if removed {
-                        cl.entry_mut(&path)
-                            .info_changed
-                            .insert(sdf::FieldKey::ConnectionPaths.as_str());
+                        let entry = cl.entry_mut(&path);
+                        if created_attr {
+                            entry.flags |= sdf::ChangeFlags::ADD_PROPERTY;
+                        }
+                        entry.flags |= sdf::ChangeFlags::CHANGE_ATTRIBUTE_CONNECTION;
+                        entry.info_changed.insert(sdf::FieldKey::ConnectionPaths.as_str());
+                    }
+                    for anc in auto_ancestors {
+                        cl.entry_mut(&anc).flags |= sdf::ChangeFlags::ADD_INERT_PRIM;
                     }
                     Ok(cl)
                 }

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -825,6 +825,58 @@ mod tests {
     }
 
     #[test]
+    fn add_connection_defaults_to_appended() -> anyhow::Result<()> {
+        // First-time `add_connection` on a no-prior-opinion attribute must
+        // author a non-explicit (appended) list op, so weaker-layer
+        // connection opinions still compose. Authoring `explicit` here
+        // would silently block weaker layers — see `UsdAttribute::AddConnection`.
+        let stage = stage()?;
+        let target = sdf::Path::new("/Tex.outputs:rgb")?;
+        let attr = stage
+            .define_prim("/Surface")?
+            .set_type_name("Shader")?
+            .create_attribute("inputs:diffuseColor", "color3f")?
+            .add_connection(target.clone())?;
+
+        let op = stage
+            .field::<sdf::Value>(attr.path(), sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
+        assert!(!op.explicit, "first add_connection must not flip the op to explicit");
+        assert!(op.explicit_items.is_empty());
+        assert_eq!(op.appended_items, vec![target]);
+        assert!(op.prepended_items.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn add_connection_prepended_on_explicit_op() -> anyhow::Result<()> {
+        // When the existing op is `explicit` (e.g. authored via
+        // `set_connections`), `add_connection_prepended` must honour the
+        // prepend position by inserting at the front of `explicit_items`
+        // rather than silently routing to the back.
+        let stage = stage()?;
+        let a = sdf::Path::new("/A.outputs:out")?;
+        let b = sdf::Path::new("/B.outputs:out")?;
+        let attr = stage
+            .define_prim("/Surface")?
+            .set_type_name("Shader")?
+            .create_attribute("inputs:diffuseColor", "color3f")?
+            .set_connections([a.clone()])?
+            .add_connection_prepended(b.clone())?;
+
+        let op = stage
+            .field::<sdf::Value>(attr.path(), sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
+        assert!(op.explicit);
+        assert_eq!(op.explicit_items, vec![b, a]);
+        Ok(())
+    }
+
+    #[test]
     fn add_api_schema() -> anyhow::Result<()> {
         let stage = stage()?;
         let prim = stage.define_prim("/World")?.add_applied_schema("MaterialBindingAPI")?;

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -377,22 +377,20 @@ impl<'s> Attribute<'s> {
     }
 
     /// Append a single connection target to `connectionPaths`. No-op if
-    /// already present. Joins the appended-items list op (weaker than
-    /// prepended opinions). Mirrors C++ `UsdAttribute::AddConnection`
-    /// with the default back-of-append position.
+    /// already present (skips cache invalidation in that case). Joins the
+    /// appended-items list op (weaker than prepended opinions). Mirrors
+    /// C++ `UsdAttribute::AddConnection` with the default back-of-append
+    /// position.
     pub fn add_connection(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
-        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| {
-            spec.add_connection_path(target, false)
-        })
+        self.edit_connection(|spec| spec.add_connection_path(target, false))
     }
 
     /// Append a single connection target to the *prepended* list op, so
-    /// it composes stronger than connections from weaker layers. Mirrors
-    /// C++ `UsdAttribute::AddConnection` with a front-of-prepend position.
+    /// it composes stronger than connections from weaker layers. No-op if
+    /// already present. Mirrors C++ `UsdAttribute::AddConnection` with a
+    /// front-of-prepend position.
     pub fn add_connection_prepended(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
-        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| {
-            spec.add_connection_path(target, true)
-        })
+        self.edit_connection(|spec| spec.add_connection_path(target, true))
     }
 
     /// Remove a single connection target. Returns `Ok(true)` if it was
@@ -424,10 +422,41 @@ impl<'s> Attribute<'s> {
         Ok(removed)
     }
 
-    /// Clear all authored `connectionPaths` on the edit target.
-    /// Mirrors C++ `UsdAttribute::ClearConnections`.
+    /// Clear all authored `connectionPaths` on the edit target. Skips
+    /// cache invalidation when no opinion was authored. Mirrors C++
+    /// `UsdAttribute::ClearConnections`.
     pub fn clear_connections(self) -> Result<Self, StageAuthoringError> {
-        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| spec.clear_connection_paths())
+        self.edit_connection(|spec| spec.clear_connection_paths())
+    }
+
+    /// Run `f` on the attribute spec at the edit target's layer, and only
+    /// record a `ChangeList` entry (driving cache invalidation) when `f`
+    /// reports an actual mutation. The shared helper for the connection
+    /// authoring methods above.
+    fn edit_connection<F>(self, f: F) -> Result<Self, StageAuthoringError>
+    where
+        F: FnOnce(&mut sdf::AttributeSpecMut<'_>) -> bool,
+    {
+        let path = self.path.clone();
+        self.stage.with_target_layer(|layer| {
+            let data = layer.writable_data_mut()?;
+            match data.spec_mut(&path).and_then(|s| s.as_attr_mut()) {
+                Some(mut spec) => {
+                    let mut cl = sdf::ChangeList::new();
+                    if f(&mut spec) {
+                        cl.entry_mut(&path)
+                            .info_changed
+                            .insert(sdf::FieldKey::ConnectionPaths.as_str());
+                    }
+                    Ok(cl)
+                }
+                None => Err(sdf::AuthoringError::InvalidPath {
+                    path: path.clone(),
+                    reason: "no attribute spec at path on the edit target layer",
+                }),
+            }
+        })?;
+        Ok(self)
     }
 
     /// `true` when any connection opinion is authored — including an

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -382,7 +382,7 @@ impl<'s> Attribute<'s> {
     /// C++ `UsdAttribute::AddConnection` with the default back-of-append
     /// position.
     pub fn add_connection(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
-        self.edit_connection(|spec| spec.add_connection_path(target, false))
+        self.add_connection_at(target, false)
     }
 
     /// Append a single connection target to the *prepended* list op, so
@@ -390,7 +390,18 @@ impl<'s> Attribute<'s> {
     /// already present. Mirrors C++ `UsdAttribute::AddConnection` with a
     /// front-of-prepend position.
     pub fn add_connection_prepended(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
-        self.edit_connection(|spec| spec.add_connection_path(target, true))
+        self.add_connection_at(target, true)
+    }
+
+    fn add_connection_at(self, target: sdf::Path, prepend: bool) -> Result<Self, StageAuthoringError> {
+        let path = self.path.clone();
+        // Dedup against the composed result, not just the local edit-target
+        // op. Otherwise adding a weaker-layer target would author a stronger
+        // duplicate and could accidentally reorder it.
+        if self.stage.connection_paths(&path)?.iter().any(|p| p == &target) {
+            return Ok(self);
+        }
+        self.edit_connection(move |spec| spec.add_connection_path(target, prepend))
     }
 
     /// Remove a single connection target. Returns `Ok(true)` if it was

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -357,6 +357,103 @@ impl<'s> Attribute<'s> {
         Ok(self)
     }
 
+    /// Author the attribute's `connectionPaths` — the `.connect` targets
+    /// that wire this attribute to other properties. Mirrors C++
+    /// `UsdAttribute::SetConnections` / `UsdShadeInput::ConnectToSource`.
+    ///
+    /// Each path is a full property path including its namespace, e.g.
+    /// `</Mat/Tex.outputs:rgb>` or `</Mat.inputs:diffuseColor>`. Replaces
+    /// any previously authored connections (the list op is written
+    /// `explicit`). This is the primitive every UsdShade input/output
+    /// connection is built on.
+    pub fn set_connections<I>(self, targets: I) -> Result<Self, StageAuthoringError>
+    where
+        I: IntoIterator<Item = sdf::Path>,
+    {
+        let targets: Vec<sdf::Path> = targets.into_iter().collect();
+        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| {
+            spec.set_connection_paths(targets)
+        })
+    }
+
+    /// Append a single connection target to `connectionPaths`. No-op if
+    /// already present. Joins the appended-items list op (weaker than
+    /// prepended opinions). Mirrors C++ `UsdAttribute::AddConnection`
+    /// with the default back-of-append position.
+    pub fn add_connection(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
+        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| {
+            spec.add_connection_path(target, false)
+        })
+    }
+
+    /// Append a single connection target to the *prepended* list op, so
+    /// it composes stronger than connections from weaker layers. Mirrors
+    /// C++ `UsdAttribute::AddConnection` with a front-of-prepend position.
+    pub fn add_connection_prepended(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
+        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| {
+            spec.add_connection_path(target, true)
+        })
+    }
+
+    /// Remove a single connection target. Returns `Ok(true)` if it was
+    /// present. Takes `&self` (returns `bool`, not `Self`, so it doesn't
+    /// chain). Mirrors C++ `UsdAttribute::RemoveConnection`.
+    pub fn remove_connection(&self, target: &sdf::Path) -> Result<bool, StageAuthoringError> {
+        let path = self.path.clone();
+        let target = target.clone();
+        let mut removed = false;
+        self.stage.with_target_layer(|layer| {
+            let data = layer.writable_data_mut()?;
+            match data.spec_mut(&path).and_then(|s| s.as_attr_mut()) {
+                Some(mut spec) => {
+                    removed = spec.remove_connection_path(&target);
+                    let mut cl = sdf::ChangeList::new();
+                    if removed {
+                        cl.entry_mut(&path)
+                            .info_changed
+                            .insert(sdf::FieldKey::ConnectionPaths.as_str());
+                    }
+                    Ok(cl)
+                }
+                None => Err(sdf::AuthoringError::InvalidPath {
+                    path: path.clone(),
+                    reason: "no attribute spec at path on the edit target layer",
+                }),
+            }
+        })?;
+        Ok(removed)
+    }
+
+    /// Clear all authored `connectionPaths` on the edit target.
+    /// Mirrors C++ `UsdAttribute::ClearConnections`.
+    pub fn clear_connections(self) -> Result<Self, StageAuthoringError> {
+        self.edit(&[sdf::FieldKey::ConnectionPaths], |spec| spec.clear_connection_paths())
+    }
+
+    /// `true` when any connection is authored on the edit target's layer.
+    /// Mirrors C++ `UsdAttribute::HasAuthoredConnections`.
+    //
+    // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.
+    pub fn has_authored_connections(&self) -> anyhow::Result<bool> {
+        Ok(!self.get_connections()?.is_empty())
+    }
+
+    /// Composed `connectionPaths`, flattened across layers. Returns an
+    /// empty vec when no connection is authored. Mirrors C++
+    /// `UsdAttribute::GetConnections`.
+    //
+    // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.
+    pub fn get_connections(&self) -> anyhow::Result<Vec<sdf::Path>> {
+        match self
+            .stage
+            .field::<sdf::Value>(&self.path, sdf::FieldKey::ConnectionPaths)?
+        {
+            Some(sdf::Value::PathListOp(op)) => Ok(op.flatten()),
+            Some(sdf::Value::PathVec(v)) => Ok(v),
+            _ => Ok(Vec::new()),
+        }
+    }
+
     /// Composed default value, if any layer authored one.
     //
     // TODO: drop `anyhow::Result` once `Stage::field` returns a typed error.
@@ -681,6 +778,49 @@ mod tests {
             stage.field::<sdf::Value>(binding.path(), sdf::FieldKey::Custom)?,
             Some(sdf::Value::Bool(true)),
         );
+        Ok(())
+    }
+
+    #[test]
+    fn attribute_connections() -> anyhow::Result<()> {
+        let stage = stage()?;
+        let mat = stage.define_prim("/Mat")?.set_type_name("Material")?;
+        mat.create_attribute("inputs:diffuseColor", "color3f")?;
+        let tex_out = stage
+            .define_prim("/Mat/Tex")?
+            .set_type_name("Shader")?
+            .create_attribute("outputs:rgb", "color3f")?;
+
+        let input = stage
+            .define_prim("/Mat/Surface")?
+            .set_type_name("Shader")?
+            .create_attribute("inputs:diffuseColor", "color3f")?
+            .set_connections([tex_out.path().clone()])?;
+
+        let conns = input.get_connections()?;
+        assert_eq!(conns, vec![tex_out.path().clone()]);
+        assert!(input.has_authored_connections()?);
+
+        // Re-authoring replaces, doesn't append.
+        let iface = sdf::Path::new("/Mat.inputs:diffuseColor")?;
+        let input = input.set_connections([iface.clone()])?;
+        assert_eq!(input.get_connections()?, vec![iface.clone()]);
+
+        // add_connection appends; dedups.
+        let input = input.add_connection(tex_out.path().clone())?;
+        assert_eq!(input.get_connections()?, vec![iface.clone(), tex_out.path().clone()]);
+        let input = input.add_connection(tex_out.path().clone())?;
+        assert_eq!(input.get_connections()?.len(), 2);
+
+        // remove_connection.
+        assert!(input.remove_connection(&iface)?);
+        assert_eq!(input.get_connections()?, vec![tex_out.path().clone()]);
+        assert!(!input.remove_connection(&iface)?);
+
+        // clear_connections.
+        let input = input.clear_connections()?;
+        assert!(!input.has_authored_connections()?);
+        assert!(input.get_connections()?.is_empty());
         Ok(())
     }
 

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -489,9 +489,9 @@ impl<'s> Attribute<'s> {
                 Some(mut spec) => {
                     let mut cl = sdf::ChangeList::new();
                     if f(&mut spec) {
-                        cl.entry_mut(&path)
-                            .info_changed
-                            .insert(sdf::FieldKey::ConnectionPaths.as_str());
+                        let entry = cl.entry_mut(&path);
+                        entry.flags |= sdf::ChangeFlags::CHANGE_ATTRIBUTE_CONNECTION;
+                        entry.info_changed.insert(sdf::FieldKey::ConnectionPaths.as_str());
                     }
                     Ok(cl)
                 }

--- a/src/usd/prim.rs
+++ b/src/usd/prim.rs
@@ -376,21 +376,26 @@ impl<'s> Attribute<'s> {
         })
     }
 
-    /// Append a single connection target to `connectionPaths`. No-op if
-    /// already present (skips cache invalidation in that case). Joins the
-    /// appended-items list op (weaker than prepended opinions). Mirrors
-    /// C++ `UsdAttribute::AddConnection` with the default back-of-append
-    /// position.
+    /// Add a single connection target at the default USD list position.
+    /// No-op if already present (skips cache invalidation in that case).
+    /// Joins the prepended-items list op, matching C++
+    /// `UsdAttribute::AddConnection`'s default back-of-prepend position.
     pub fn add_connection(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
-        self.add_connection_at(target, false)
+        self.add_connection_at(target, true)
     }
 
-    /// Append a single connection target to the *prepended* list op, so
-    /// it composes stronger than connections from weaker layers. No-op if
-    /// already present. Mirrors C++ `UsdAttribute::AddConnection` with a
-    /// front-of-prepend position.
+    /// Add a single connection target to the prepended list op. No-op if
+    /// already present. This is the explicit spelling of the default USD
+    /// AddConnection position.
     pub fn add_connection_prepended(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
         self.add_connection_at(target, true)
+    }
+
+    /// Add a single connection target to the appended list op. No-op if
+    /// already present. Use this when the new target should compose behind
+    /// prepended opinions from this layer.
+    pub fn add_connection_appended(self, target: sdf::Path) -> Result<Self, StageAuthoringError> {
+        self.add_connection_at(target, false)
     }
 
     fn add_connection_at(self, target: sdf::Path, prepend: bool) -> Result<Self, StageAuthoringError> {
@@ -874,9 +879,9 @@ mod tests {
         let input = input.set_connections([iface.clone()])?;
         assert_eq!(input.get_connections()?, vec![iface.clone()]);
 
-        // add_connection appends; dedups.
+        // add_connection prepends by default; dedups.
         let input = input.add_connection(tex_out.path().clone())?;
-        assert_eq!(input.get_connections()?, vec![iface.clone(), tex_out.path().clone()]);
+        assert_eq!(input.get_connections()?, vec![tex_out.path().clone(), iface.clone()]);
         let input = input.add_connection(tex_out.path().clone())?;
         assert_eq!(input.get_connections()?.len(), 2);
 
@@ -910,11 +915,11 @@ mod tests {
     }
 
     #[test]
-    fn add_connection_appended() -> anyhow::Result<()> {
+    fn add_connection_prepends() -> anyhow::Result<()> {
         // First-time `add_connection` on a no-prior-opinion attribute must
-        // author a non-explicit (appended) list op, so weaker-layer
+        // author a non-explicit (prepended) list op, so weaker-layer
         // connection opinions still compose. Authoring `explicit` here
-        // would silently block weaker layers — see `UsdAttribute::AddConnection`.
+        // would silently block weaker layers.
         let stage = stage()?;
         let target = sdf::Path::new("/Tex.outputs:rgb")?;
         let attr = stage
@@ -930,6 +935,27 @@ mod tests {
             .unwrap();
         assert!(!op.explicit, "first add_connection must not flip the op to explicit");
         assert!(op.explicit_items.is_empty());
+        assert_eq!(op.prepended_items, vec![target]);
+        assert!(op.appended_items.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn add_connection_appended() -> anyhow::Result<()> {
+        let stage = stage()?;
+        let target = sdf::Path::new("/Tex.outputs:rgb")?;
+        let attr = stage
+            .define_prim("/Surface")?
+            .set_type_name("Shader")?
+            .create_attribute("inputs:diffuseColor", "color3f")?
+            .add_connection_appended(target.clone())?;
+
+        let op = stage
+            .field::<sdf::Value>(attr.path(), sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
+        assert!(!op.explicit);
         assert_eq!(op.appended_items, vec![target]);
         assert!(op.prepended_items.is_empty());
         Ok(())

--- a/src/usd/stage.rs
+++ b/src/usd/stage.rs
@@ -863,6 +863,18 @@ impl Stage {
         Ok(self.api_schemas(prim)?.iter().any(|s| s == name))
     }
 
+    /// Returns the composed `connectionPaths` list for an attribute path,
+    /// folding list-op edits (prepend / append / add / delete) across every
+    /// contributing layer. Mirrors C++ `UsdAttribute::GetConnections`. Returns
+    /// an empty list for non-property paths or attributes with no authored
+    /// connections.
+    pub fn connection_paths(&self, attr: &sdf::Path) -> Result<Vec<sdf::Path>> {
+        if !self.population_mask.includes(&attr.prim_path()) {
+            return Ok(Vec::new());
+        }
+        self.try_or_handle(|cache| cache.connection_paths(attr))
+    }
+
     /// Returns the composed `typeName` for a prim, if set.
     pub fn type_name(&self, prim: &sdf::Path) -> Result<Option<String>> {
         self.field::<String>(prim, "typeName")
@@ -2200,6 +2212,52 @@ def Xform "World"
         let prim = sdf::Path::new("/World/Geo")?;
         let prop = sdf::Path::new("/World/Geo.points")?;
         assert_eq!(stage.api_schemas(&prop)?, stage.api_schemas(&prim)?);
+        Ok(())
+    }
+
+    #[test]
+    fn connection_paths_compose_list_ops() -> Result<()> {
+        // Stack: weak sublayer authors `append`; root layer authors
+        // `prepend`. `connection_paths` must fold edits across both
+        // layers, not return only the strongest layer's list op.
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("weak.usda"),
+            r#"#usda 1.0
+
+def Shader "Mat"
+{
+    color3f outputs:out
+    append color3f inputs:in.connect = [</Mat.outputs:out>]
+}
+"#,
+        )?;
+        let root = dir.path().join("root.usda");
+        std::fs::write(
+            &root,
+            r#"#usda 1.0
+(
+    subLayers = [
+        @weak.usda@
+    ]
+)
+
+over "Mat"
+{
+    prepend color3f inputs:in.connect = [</Mat.outputs:strong>]
+}
+"#,
+        )?;
+
+        let stage = Stage::open(root.to_str().expect("utf-8 temp path"))?;
+        let conns = stage.connection_paths(&sdf::Path::new("/Mat.inputs:in")?)?;
+        assert_eq!(
+            conns,
+            vec![
+                sdf::Path::new("/Mat.outputs:strong")?,
+                sdf::Path::new("/Mat.outputs:out")?
+            ]
+        );
         Ok(())
     }
 

--- a/src/usd/stage.rs
+++ b/src/usd/stage.rs
@@ -305,6 +305,10 @@ pub enum StageAuthoringError {
     #[error(transparent)]
     Layer(#[from] sdf::AuthoringError),
 
+    /// A composed-stage query needed to route or validate the authoring call failed.
+    #[error(transparent)]
+    Composition(#[from] anyhow::Error),
+
     /// The edit target's layer index is out of range for this stage.
     #[error("edit target layer index {index} is out of range ({count} layers)")]
     LayerOutOfRange {
@@ -2297,8 +2301,37 @@ def Shader "Mat" (
         assert_eq!(stage.connection_paths(&input)?, vec![output.clone()]);
 
         let graph = crate::usd::ConnectionGraph::from_stage(&stage)?;
-        assert_eq!(graph.sources(&input), &[output.clone()]);
+        assert_eq!(graph.sources(&input), std::slice::from_ref(&output));
         assert_eq!(graph.sinks(&output), &[input]);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_connection_deletes_inherited() -> Result<()> {
+        let target = sdf::Path::new("/Mat.outputs:out")?;
+        let input = sdf::Path::new("/Mat.inputs:in")?;
+
+        let mut strong = sdf::Layer::new_anonymous("root.usda");
+        strong.pseudo_root_mut()?.set_sublayers(["weak.usda"]);
+
+        let mut weak = sdf::Layer::new_anonymous("weak.usda");
+        weak.create_prim("/Mat", sdf::Specifier::Def, "Shader")?;
+        weak.create_attribute("/Mat.outputs:out", "color3f", sdf::Variability::Varying, true)?;
+        weak.create_attribute("/Mat.inputs:in", "color3f", sdf::Variability::Varying, true)?
+            .set_connection_paths([target.clone()]);
+
+        let stage = Stage::builder().make_stage(vec![strong, weak], 0);
+        let attr = crate::usd::Attribute::new(&stage, input.clone());
+
+        assert_eq!(attr.get_connections()?, vec![target.clone()]);
+        assert!(attr.remove_connection(&target)?);
+        assert!(attr.get_connections()?.is_empty());
+
+        let Some(sdf::Value::PathListOp(op)) = stage.field::<sdf::Value>(&input, sdf::FieldKey::ConnectionPaths)?
+        else {
+            panic!("expected local connectionPaths delete op");
+        };
+        assert_eq!(op.deleted_items, vec![target]);
         Ok(())
     }
 

--- a/src/usd/stage.rs
+++ b/src/usd/stage.rs
@@ -2327,11 +2327,73 @@ def Shader "Mat" (
         assert!(attr.remove_connection(&target)?);
         assert!(attr.get_connections()?.is_empty());
 
-        let Some(sdf::Value::PathListOp(op)) = stage.field::<sdf::Value>(&input, sdf::FieldKey::ConnectionPaths)?
-        else {
-            panic!("expected local connectionPaths delete op");
-        };
+        let op = stage
+            .field::<sdf::Value>(&input, sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
         assert_eq!(op.deleted_items, vec![target]);
+        Ok(())
+    }
+
+    #[test]
+    fn add_connection_dedups_inherited() -> Result<()> {
+        let target = sdf::Path::new("/Mat.outputs:out")?;
+        let input = sdf::Path::new("/Mat.inputs:in")?;
+
+        let mut strong = sdf::Layer::new_anonymous("root.usda");
+        strong.pseudo_root_mut()?.set_sublayers(["weak.usda"]);
+
+        let mut weak = sdf::Layer::new_anonymous("weak.usda");
+        weak.create_prim("/Mat", sdf::Specifier::Def, "Shader")?;
+        weak.create_attribute("/Mat.outputs:out", "color3f", sdf::Variability::Varying, true)?;
+        weak.create_attribute("/Mat.inputs:in", "color3f", sdf::Variability::Varying, true)?
+            .set_connection_paths([target.clone()]);
+
+        let stage = Stage::builder().make_stage(vec![strong, weak], 0);
+        let attr = crate::usd::Attribute::new(&stage, input.clone());
+        let attr = attr.add_connection(target.clone())?;
+
+        assert_eq!(attr.get_connections()?, vec![target.clone()]);
+        let op = stage
+            .field::<sdf::Value>(&input, sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
+        assert!(op.explicit, "add_connection should not author a duplicate local op");
+        assert_eq!(op.explicit_items, vec![target]);
+        Ok(())
+    }
+
+    #[test]
+    fn add_connection_clears_delete() -> Result<()> {
+        let target = sdf::Path::new("/Mat.outputs:out")?;
+        let input = sdf::Path::new("/Mat.inputs:in")?;
+
+        let mut strong = sdf::Layer::new_anonymous("root.usda");
+        strong.pseudo_root_mut()?.set_sublayers(["weak.usda"]);
+
+        let mut weak = sdf::Layer::new_anonymous("weak.usda");
+        weak.create_prim("/Mat", sdf::Specifier::Def, "Shader")?;
+        weak.create_attribute("/Mat.outputs:out", "color3f", sdf::Variability::Varying, true)?;
+        weak.create_attribute("/Mat.inputs:in", "color3f", sdf::Variability::Varying, true)?
+            .set_connection_paths([target.clone()]);
+
+        let stage = Stage::builder().make_stage(vec![strong, weak], 0);
+        let attr = crate::usd::Attribute::new(&stage, input.clone());
+
+        assert!(attr.remove_connection(&target)?);
+        assert!(attr.get_connections()?.is_empty());
+        let attr = attr.add_connection(target.clone())?;
+
+        assert_eq!(attr.get_connections()?, vec![target.clone()]);
+        let op = stage
+            .field::<sdf::Value>(&input, sdf::FieldKey::ConnectionPaths)?
+            .unwrap()
+            .try_as_path_list_op()
+            .unwrap();
+        assert!(op.deleted_items.is_empty());
+        assert_eq!(op.appended_items, vec![target]);
         Ok(())
     }
 

--- a/src/usd/stage.rs
+++ b/src/usd/stage.rs
@@ -2393,7 +2393,7 @@ def Shader "Mat" (
             .try_as_path_list_op()
             .unwrap();
         assert!(op.deleted_items.is_empty());
-        assert_eq!(op.appended_items, vec![target]);
+        assert_eq!(op.prepended_items, vec![target]);
         Ok(())
     }
 

--- a/src/usd/stage.rs
+++ b/src/usd/stage.rs
@@ -2262,6 +2262,47 @@ over "Mat"
     }
 
     #[test]
+    fn connection_paths_remap_reference() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("asset.usda"),
+            r#"#usda 1.0
+(
+    defaultPrim = "Source"
+)
+
+def Shader "Source"
+{
+    color3f outputs:out
+    color3f inputs:in.connect = [</Source.outputs:out>]
+}
+"#,
+        )?;
+        let root = dir.path().join("root.usda");
+        std::fs::write(
+            &root,
+            r#"#usda 1.0
+
+def Shader "Mat" (
+    references = @asset.usda@
+)
+{
+}
+"#,
+        )?;
+
+        let stage = Stage::open(root.to_str().expect("utf-8 temp path"))?;
+        let input = sdf::Path::new("/Mat.inputs:in")?;
+        let output = sdf::Path::new("/Mat.outputs:out")?;
+        assert_eq!(stage.connection_paths(&input)?, vec![output.clone()]);
+
+        let graph = crate::usd::ConnectionGraph::from_stage(&stage)?;
+        assert_eq!(graph.sources(&input), &[output.clone()]);
+        assert_eq!(graph.sinks(&output), &[input]);
+        Ok(())
+    }
+
+    #[test]
     fn api_schemas_empty_for_prim_without_schemas() -> Result<()> {
         let stage = Stage::open("fixtures/api_schemas.usda")?;
         let props = sdf::Path::new("/World/Props")?;


### PR DESCRIPTION
Adds first-class attribute connection support (the `.connect` / `connectionPaths` wiring) at the usd tier.

`Attribute` gets the full C++ `UsdAttribute` connection-editing surface — set, add (append/prepend), remove, clear, has-authored, get — over new sdf-tier list-op helpers that mirror the existing relationship-target ones.

`usd::ConnectionGraph` indexes every connection edge on a stage in one pass and answers repeated queries: sources, sinks, connectedness, all edges, and chain resolution to terminal sources (cycle-safe). Schema-agnostic — UsdShade is the heaviest user but any connectable network reuses it.

fmt + clippy clean.