### PR TITLE
Add reusable Path APIs

### DIFF
--- a/src/pcp/change.rs
+++ b/src/pcp/change.rs
@@ -129,9 +129,10 @@ impl Changes {
             self.fanout_significant(cache, layer, path);
             // An opinion authored inside a variant (`/Prim{set=sel}/child`)
             // composes into the variant-stripped prim (`/Prim/child`). That
-            // composed cache key is not on the variant path's ancestor chain
-            // (`/Prim{set=sel}` → `/`), so fanning out from the variant path
-            // alone leaves a cached miss there stale; invalidate it too.
+            // composed cache key is not on the authored path's ancestor chain
+            // (`/Prim{set=sel}/child` → `/Prim{set=sel}` → `/Prim` → `/`), so
+            // fanning out from the variant path alone leaves a cached miss
+            // there stale; invalidate it too.
             let stripped = path.strip_all_variant_selections();
             if stripped != *path {
                 self.fanout_significant(cache, layer, &stripped);

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -878,7 +878,7 @@ impl<'a> IndexBuilder<'a> {
         // prefix equals the parent path, then remap by appending the child name.
         // This mirrors C++ behavior where each level only uses its direct
         // parent's arc mappings for descendant propagation.
-        let child_name = path.as_str().rsplit('/').next().unwrap_or("");
+        let child_name = path.name().unwrap_or("");
         if !child_name.is_empty() {
             let parent = path.parent();
             let ancestor_sites: Vec<_> = self
@@ -889,7 +889,7 @@ impl<'a> IndexBuilder<'a> {
                     // Map the parent path through this arc. Only arcs whose target
                     // prefix matches the parent will succeed.
                     let parent_in_source = a.map.map_target_to_source(parent.as_ref()?)?;
-                    let remapped = Path::new(&format!("{parent_in_source}/{child_name}")).ok()?;
+                    let remapped = parent_in_source.append_path(child_name).ok()?;
                     Some((remapped, a.layer_index, a.arc, a.map.clone()))
                 })
                 .collect();
@@ -1489,14 +1489,15 @@ impl<'a> IndexBuilder<'a> {
             // so pair it with its target-stack sublayer offset.
             if let Some(source_parent) = source.parent() {
                 if source_parent != Path::abs_root() {
-                    let child_name = source.as_str().rsplit('/').next().unwrap_or("");
+                    let child_name = source.name().unwrap_or("");
                     let parent_index = PrimIndex::build_with_context(&source_parent, self.stack, self.ctx)?;
                     let ancestor_sites: Vec<_> = parent_index
                         .nodes()
                         .iter()
                         .filter(|n| n.arc != ArcType::Root)
                         .filter_map(|n| {
-                            Path::new(&format!("{}/{child_name}", n.path))
+                            n.path
+                                .append_path(child_name)
                                 .ok()
                                 .map(|p| (p, n.layer_index, n.arc, n.path.clone()))
                         })

--- a/src/sdf/layer.rs
+++ b/src/sdf/layer.rs
@@ -11,8 +11,9 @@ use anyhow::Result;
 
 use super::schema::{ChildrenKey, FieldKey};
 use super::{
-    AbstractData, AttributeSpec, AttributeSpecMut, Data, LayerData, Path, PrimSpec, PrimSpecMut, PseudoRootSpec,
-    PseudoRootSpecMut, RelationshipSpec, RelationshipSpecMut, Spec, SpecError, SpecType, Specifier, Value, Variability,
+    AbstractData, AttributeSpec, AttributeSpecMut, Data, LayerData, Path, PathComponent, PrimSpec, PrimSpecMut,
+    PseudoRootSpec, PseudoRootSpecMut, RelationshipSpec, RelationshipSpecMut, Spec, SpecError, SpecType, Specifier,
+    Value, Variability,
 };
 use crate::{usda, usdc};
 
@@ -650,24 +651,16 @@ struct ChainElement {
     child_name: String,
 }
 
-/// A component of a prim path, yielded in root → leaf order by
-/// [`parse_prim_path`].
-enum PathToken<'a> {
-    /// A prim name registered under its parent's `primChildren`.
-    Prim(&'a str),
-    /// A `{set=sel}` variant selection on the current prim.
-    Variant { set: &'a str, selection: &'a str },
-}
-
-/// Parse and validate a prim path that may carry `{set=sel}` variant
-/// selections, invoking `emit` for each [`PathToken`] in root → leaf order.
+/// Validate that `target` is an authorable prim path and invoke `emit` for
+/// each of its components ([`Path::components`]) in root → leaf order.
 ///
-/// Validates that `target` is absolute, non-root, non-property and that every
-/// prim name, variant set name, and variant selection is a USD identifier.
-/// This is the single definition of the authorable prim-path grammar; both
-/// [`require_prim_path`] (validate only, no allocation) and [`namespace_chain`]
-/// (build the spec chain) drive it, so they cannot drift apart.
-fn parse_prim_path(target: &Path, mut emit: impl FnMut(PathToken<'_>)) -> Result<(), AuthoringError> {
+/// Adds the authoring rules on top of the shared prim-path grammar: `target`
+/// must be absolute, non-root, and non-property, every prim name and variant
+/// set / selection must be a USD identifier, and the whole path must parse (no
+/// malformed tail). Both [`require_prim_path`] (validate only, no allocation)
+/// and [`namespace_chain`] (build the spec chain) drive this, so they cannot
+/// drift apart.
+fn parse_prim_path(target: &Path, mut emit: impl FnMut(PathComponent<'_>)) -> Result<(), AuthoringError> {
     let invalid = |reason: &'static str| AuthoringError::InvalidPath {
         path: target.clone(),
         reason,
@@ -679,41 +672,27 @@ fn parse_prim_path(target: &Path, mut emit: impl FnMut(PathToken<'_>)) -> Result
         return Err(invalid("expected prim path, got property path"));
     }
 
-    let mut rest = &target.as_str()[1..];
-    while !rest.is_empty() {
-        // A prim name runs up to the next path separator or variant opener.
-        let end = rest.find(['/', '{']).unwrap_or(rest.len());
-        let name = &rest[..end];
-        if !Path::is_valid_identifier(name) {
-            return Err(invalid("prim path component is not a USD identifier"));
-        }
-        emit(PathToken::Prim(name));
-        rest = &rest[end..];
-
-        // Zero or more variant selections may follow the prim name.
-        while let Some(after_open) = rest.strip_prefix('{') {
-            let close = after_open
-                .find('}')
-                .ok_or_else(|| invalid("unterminated variant selection"))?;
-            let (set, selection) = after_open[..close]
-                .split_once('=')
-                .ok_or_else(|| invalid("variant selection is missing '='"))?;
-            if !Path::is_valid_identifier(set) {
-                return Err(invalid("variant set name is not a USD identifier"));
+    let mut components = target.components();
+    for component in components.by_ref() {
+        match component {
+            PathComponent::Prim(name) => {
+                if !Path::is_valid_identifier(name) {
+                    return Err(invalid("prim path component is not a USD identifier"));
+                }
             }
-            if selection.is_empty() || !Path::is_valid_identifier(selection) {
-                return Err(invalid("variant selection is not a USD identifier"));
+            PathComponent::Variant { set, selection } => {
+                if !Path::is_valid_identifier(set) {
+                    return Err(invalid("variant set name is not a USD identifier"));
+                }
+                if selection.is_empty() || !Path::is_valid_identifier(selection) {
+                    return Err(invalid("variant selection is not a USD identifier"));
+                }
             }
-            emit(PathToken::Variant { set, selection });
-            rest = &after_open[close + 1..];
         }
-
-        match rest.strip_prefix('/') {
-            Some(next) if !next.is_empty() => rest = next,
-            None if rest.is_empty() => {}
-            // A trailing or doubled separator (`Some("")`) or leftover junk.
-            _ => return Err(invalid("malformed prim path")),
-        }
+        emit(component);
+    }
+    if !components.remainder().is_empty() {
+        return Err(invalid("malformed prim path"));
     }
     Ok(())
 }
@@ -725,8 +704,8 @@ fn namespace_chain(target: &Path) -> Result<Vec<ChainElement>, AuthoringError> {
     let mut elems = Vec::new();
     let mut cursor = Path::abs_root();
 
-    parse_prim_path(target, |token| match token {
-        PathToken::Prim(name) => {
+    parse_prim_path(target, |component| match component {
+        PathComponent::Prim(name) => {
             let path = cursor.append_path(name).expect("name validated as an identifier");
             elems.push(ChainElement {
                 path: path.clone(),
@@ -736,7 +715,7 @@ fn namespace_chain(target: &Path) -> Result<Vec<ChainElement>, AuthoringError> {
             });
             cursor = path;
         }
-        PathToken::Variant { set, selection } => {
+        PathComponent::Variant { set, selection } => {
             elems.push(ChainElement {
                 path: cursor.append_variant_selection(set, ""),
                 spec_type: SpecType::VariantSet,
@@ -830,28 +809,17 @@ fn require_prim_leaf(path: &Path) -> Result<(), AuthoringError> {
 /// "points")`. Returns an error if `path` is not an absolute property path
 /// whose owning prim portion is itself a valid prim path.
 fn split_property_path(path: &Path) -> Result<(Path, String), AuthoringError> {
-    if !path.is_property_path() {
-        return Err(AuthoringError::InvalidPath {
-            path: path.clone(),
-            reason: "expected property path",
-        });
-    }
-    let prim_path = path.prim_path();
+    let (prim_path, suffix) = path.split_property().ok_or(AuthoringError::InvalidPath {
+        path: path.clone(),
+        reason: "expected property path",
+    })?;
     // Owning prim must be an absolute, non-root, non-property path — guards
     // against relative roots ("A.foo"), root-level properties ("/.foo"), and
     // paths whose `prim_path()` returned a structurally invalid string.
     require_prim_path(&prim_path)?;
-    let suffix = path
-        .as_str()
-        .strip_prefix(prim_path.as_str())
-        .and_then(|t| t.strip_prefix('.'))
-        .ok_or(AuthoringError::InvalidPath {
-            path: path.clone(),
-            reason: "malformed property path",
-        })?;
     // Property names are colon-separated identifiers — reject target/connection
     // brackets, embedded dots, and other syntax that would round-trip as garbage.
-    if suffix.is_empty() || !suffix.split(':').all(Path::is_valid_identifier) {
+    if !suffix.split(':').all(Path::is_valid_identifier) {
         return Err(AuthoringError::InvalidPath {
             path: path.clone(),
             reason: "property name must be a colon-separated identifier",

--- a/src/sdf/mod.rs
+++ b/src/sdf/mod.rs
@@ -22,7 +22,7 @@ pub use change::{ChangeEntry, ChangeFlags, ChangeList};
 pub use data::Data;
 pub use layer::{AuthoringError, Layer, LayerFormat};
 pub use ordering::apply_ordering;
-pub use path::{path, Path};
+pub use path::{path, Path, PathComponent, PathComponents};
 pub use schema::{ChildrenKey, FieldKey};
 pub use spec::{
     AttributeSpec, AttributeSpecMut, PrimSpec, PrimSpecMut, PseudoRootSpec, PseudoRootSpecMut, RelationshipSpec,

--- a/src/sdf/mod.rs
+++ b/src/sdf/mod.rs
@@ -22,7 +22,7 @@ pub use change::{ChangeEntry, ChangeFlags, ChangeList};
 pub use data::Data;
 pub use layer::{AuthoringError, Layer, LayerFormat};
 pub use ordering::apply_ordering;
-pub use path::{path, Path, PathComponent, PathComponents};
+pub use path::{path, Path, PathComponent, PathComponents, PathElement};
 pub use schema::{ChildrenKey, FieldKey};
 pub use spec::{
     AttributeSpec, AttributeSpecMut, PrimSpec, PrimSpecMut, PseudoRootSpec, PseudoRootSpecMut, RelationshipSpec,

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -198,17 +198,65 @@ impl Path {
         Some((prim, name))
     }
 
-    /// Returns the parent path, or `None` for the pseudo-root `/` and empty paths.
+    /// Returns the final namespace element of this path and its kind, or `None`
+    /// for the pseudo-root `/` and empty paths. The inverse of the
+    /// `append_property` / `append_variant_selection` / child-`append_path`
+    /// family: an element appended to [`parent`](Self::parent) reconstructs the
+    /// path.
     ///
     /// ```text
-    /// "/A/B/C" -> Some("/A/B")
-    /// "/A"     -> Some("/")
-    /// "/"      -> None
-    /// ""       -> None
+    /// "/A/B"          -> Some(Prim("B"))
+    /// "/A.points"     -> Some(Property("points"))
+    /// "/A{set=sel}"   -> Some(Variant { set: "set", selection: "sel" })
+    /// ```
+    pub fn last_element(&self) -> Option<PathElement<'_>> {
+        if self.path.is_empty() || self.path == "/" {
+            return None;
+        }
+        if self.is_property_path() {
+            let dot = self.path.rfind('.')?;
+            return Some(PathElement::Property(&self.path[dot + 1..]));
+        }
+        if self.path.ends_with('}') {
+            if let Some(open) = self.path.rfind('{') {
+                let inner = &self.path[open + 1..self.path.len() - 1];
+                if let Some((set, selection)) = inner.split_once('=') {
+                    return Some(PathElement::Variant { set, selection });
+                }
+            }
+        }
+        match self.path.rsplit_once('/') {
+            Some((_, name)) => Some(PathElement::Prim(name)),
+            None => Some(PathElement::Prim(&self.path)),
+        }
+    }
+
+    /// Returns the parent path, or `None` for the pseudo-root `/` and empty
+    /// paths. Mirrors C++ `SdfPath::GetParentPath`: a property's parent is its
+    /// owning prim, a variant selection's parent is the prim (or enclosing
+    /// variant) it qualifies, and a prim's parent is its namespace parent.
+    ///
+    /// ```text
+    /// "/A/B/C"      -> Some("/A/B")
+    /// "/A"          -> Some("/")
+    /// "/A.attr"     -> Some("/A")
+    /// "/A{x=y}"     -> Some("/A")
+    /// "/A{x=y}{p=q}"-> Some("/A{x=y}")
+    /// "/"           -> None
+    /// ""            -> None
     /// ```
     pub fn parent(&self) -> Option<Path> {
         if self.path.is_empty() || self.path == "/" {
             return None;
+        }
+        if self.is_property_path() {
+            return Some(self.prim_path());
+        }
+        // Drop a trailing `{set=sel}` variant selection.
+        if self.path.ends_with('}') {
+            if let Some(open) = self.path.rfind('{') {
+                return Some(Path::from_str_unchecked(&self.path[..open]));
+            }
         }
         match self.path.rsplit_once('/') {
             Some(("", _)) => Some(Path::abs_root()),
@@ -456,6 +504,23 @@ pub enum PathComponent<'a> {
     },
 }
 
+/// The final namespace element of a [`Path`], returned by
+/// [`Path::last_element`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathElement<'a> {
+    /// A prim name.
+    Prim(&'a str),
+    /// A property name (the segment after the final `.`).
+    Property(&'a str),
+    /// A `{set=sel}` variant selection.
+    Variant {
+        /// The variant set name.
+        set: &'a str,
+        /// The selected variant.
+        selection: &'a str,
+    },
+}
+
 /// Iterator over the prim-namespace components of a [`Path`]. See
 /// [`Path::components`].
 pub struct PathComponents<'a> {
@@ -692,6 +757,28 @@ mod tests {
     }
 
     #[test]
+    fn test_last_element() {
+        // Render the element as an owned string so it doesn't borrow the
+        // temporary `Path`: `name`, `.name` for a property, `{set=sel}`.
+        let last = |s: &str| -> Option<String> {
+            Path::from_str_unchecked(s).last_element().map(|e| match e {
+                PathElement::Prim(name) => name.to_owned(),
+                PathElement::Property(name) => format!(".{name}"),
+                PathElement::Variant { set, selection } => format!("{{{set}={selection}}}"),
+            })
+        };
+
+        assert_eq!(last("/A/B").as_deref(), Some("B"));
+        assert_eq!(last("/A").as_deref(), Some("A"));
+        assert_eq!(last("/A.points").as_deref(), Some(".points"));
+        assert_eq!(last("/A.inputs:diffuse").as_deref(), Some(".inputs:diffuse"));
+        assert_eq!(last("/A{set=sel}").as_deref(), Some("{set=sel}"));
+        assert_eq!(last("/A{x=y}{p=q}").as_deref(), Some("{p=q}"));
+        assert_eq!(last("/"), None);
+        assert_eq!(last(""), None);
+    }
+
+    #[test]
     fn test_split_property() {
         let split = |s: &str| {
             Path::from_str_unchecked(s)
@@ -788,11 +875,21 @@ mod tests {
     fn test_parent() {
         #[rustfmt::skip]
         let cases: &[(&str, Option<&str>)] = &[
-            ("/A/B/C", Some("/A/B")),
-            ("/A/B",   Some("/A")),
-            ("/A",     Some("/")),
-            ("/",      None),
-            ("",       None),
+            ("/A/B/C",       Some("/A/B")),
+            ("/A/B",         Some("/A")),
+            ("/A",           Some("/")),
+            ("/",            None),
+            ("",             None),
+            // A property's parent is its owning prim.
+            ("/A.attr",      Some("/A")),
+            ("/A/B.attr",    Some("/A/B")),
+            ("/A.foo:bar",   Some("/A")),
+            // A variant selection's parent is the prim (or enclosing variant).
+            ("/A{x=y}",      Some("/A")),
+            ("/A/B{x=y}",    Some("/A/B")),
+            ("/A{x=y}{p=q}",  Some("/A{x=y}")),
+            ("/A{x=y}/B",    Some("/A{x=y}")),
+            ("/A{x=y}.attr", Some("/A{x=y}")),
         ];
 
         for &(path, expected) in cases {

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -176,6 +176,28 @@ impl Path {
         &self.path[self.prim_path().as_str().len()..]
     }
 
+    /// Splits a property path into its owning prim and the property name (the
+    /// portion after the `.`), or `None` if this is not a property path. The
+    /// inverse of [`append_property`](Self::append_property).
+    ///
+    /// The property name is returned verbatim and may carry namespaces (`:`)
+    /// or further target/connection syntax (`[..]`, `.`); callers that require
+    /// a plain property name should validate it.
+    ///
+    /// ```text
+    /// "/World/Mesh.points"   -> Some(("/World/Mesh", "points"))
+    /// "/Mat.inputs:diffuse"  -> Some(("/Mat", "inputs:diffuse"))
+    /// "/World/Mesh"          -> None
+    /// ```
+    pub fn split_property(&self) -> Option<(Path, &str)> {
+        if !self.is_property_path() {
+            return None;
+        }
+        let prim = self.prim_path();
+        let name = self.path[prim.as_str().len()..].strip_prefix('.')?;
+        Some((prim, name))
+    }
+
     /// Returns the parent path, or `None` for the pseudo-root `/` and empty paths.
     ///
     /// ```text
@@ -210,6 +232,32 @@ impl Path {
         match self.path.rsplit_once('/') {
             Some((_, after)) => Some(after),
             None => Some(&self.path),
+        }
+    }
+
+    /// Iterates the prim-namespace components of this path — prim names and
+    /// `{set=sel}` variant selections — in root → leaf order.
+    ///
+    /// The iterator is lenient and does no validation: it yields the raw
+    /// slices between delimiters and stops at the first thing it cannot parse
+    /// as a prim/variant component (a property suffix, a malformed variant, or
+    /// a stray separator), leaving that tail in
+    /// [`remainder`](PathComponents::remainder). It is the single definition of
+    /// the prim-path grammar; validating consumers layer their checks on top.
+    ///
+    /// Unlike [`strip_all_variant_selections`](Self::strip_all_variant_selections),
+    /// which is a blunt string strip that also removes variant segments
+    /// embedded inside relationship-target brackets, this models only the
+    /// structured prim namespace.
+    ///
+    /// ```text
+    /// "/A{x=y}/B" -> [Prim("A"), Variant{x, y}, Prim("B")]
+    /// "/A.attr"   -> [Prim("A")]  (remainder ".attr")
+    /// ```
+    pub fn components(&self) -> PathComponents<'_> {
+        PathComponents {
+            rest: self.path.strip_prefix('/').unwrap_or(&self.path),
+            in_variants: false,
         }
     }
 
@@ -393,6 +441,86 @@ impl Path {
     }
 }
 
+/// A prim-namespace component of a [`Path`], yielded by [`Path::components`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathComponent<'a> {
+    /// A prim name (registered under its parent's `primChildren`).
+    Prim(&'a str),
+    /// A `{set=sel}` variant selection on the current prim.
+    Variant {
+        /// The variant set name (between `{` and `=`).
+        set: &'a str,
+        /// The selected variant (between `=` and `}`); may be empty for a
+        /// variant-set path like `/Prim{set=}`.
+        selection: &'a str,
+    },
+}
+
+/// Iterator over the prim-namespace components of a [`Path`]. See
+/// [`Path::components`].
+pub struct PathComponents<'a> {
+    /// Unparsed remainder of the path string.
+    rest: &'a str,
+    /// `false` when the next component is a prim name; `true` while collecting
+    /// the variant selections that follow a prim name.
+    in_variants: bool,
+}
+
+impl<'a> PathComponents<'a> {
+    /// The unparsed tail left after iteration: empty for a well-formed prim
+    /// path, otherwise the property suffix or the malformed segment at which
+    /// parsing stopped.
+    pub fn remainder(&self) -> &'a str {
+        self.rest
+    }
+}
+
+impl<'a> Iterator for PathComponents<'a> {
+    type Item = PathComponent<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if !self.in_variants {
+                if self.rest.is_empty() {
+                    return None;
+                }
+                // A prim name runs up to the next separator, variant opener, or
+                // property separator.
+                let end = self.rest.find(['/', '{', '.']).unwrap_or(self.rest.len());
+                let name = &self.rest[..end];
+                if name.is_empty() {
+                    return None;
+                }
+                self.rest = &self.rest[end..];
+                self.in_variants = true;
+                return Some(PathComponent::Prim(name));
+            }
+
+            // Variant selections attach directly to the prim name.
+            if let Some(after_open) = self.rest.strip_prefix('{') {
+                let Some(close) = after_open.find('}') else {
+                    return None; // unterminated; left in `rest`
+                };
+                let Some((set, selection)) = after_open[..close].split_once('=') else {
+                    return None; // missing `=`; left in `rest`
+                };
+                self.rest = &after_open[close + 1..];
+                return Some(PathComponent::Variant { set, selection });
+            }
+
+            // A single `/` separates the next prim; anything else (trailing or
+            // doubled `/`, a property `.`, junk) ends the prim namespace.
+            match self.rest.strip_prefix('/') {
+                Some(next) if !next.is_empty() && !next.starts_with('/') => {
+                    self.rest = next;
+                    self.in_variants = false;
+                }
+                _ => return None,
+            }
+        }
+    }
+}
+
 impl From<&Path> for Path {
     fn from(p: &Path) -> Self {
         p.clone()
@@ -561,6 +689,60 @@ mod tests {
             let p = Path::new(input).unwrap();
             assert_eq!(p.strip_all_variant_selections().as_str(), *expected, "input {input}");
         }
+    }
+
+    #[test]
+    fn test_split_property() {
+        let split = |s: &str| {
+            Path::from_str_unchecked(s)
+                .split_property()
+                .map(|(p, n)| (p.path, n.to_owned()))
+        };
+        let owned = |p: &str, n: &str| Some((p.to_owned(), n.to_owned()));
+
+        assert_eq!(split("/World/Mesh.points"), owned("/World/Mesh", "points"));
+        assert_eq!(split("/Mat.inputs:diffuse"), owned("/Mat", "inputs:diffuse"));
+        // Not a property path.
+        assert_eq!(split("/World/Mesh"), None);
+        assert_eq!(split("/"), None);
+    }
+
+    #[test]
+    fn test_components() {
+        // Render each component as an owned string so the result doesn't borrow
+        // the temporary `Path`: a prim is its name, a variant is `{set=sel}`.
+        let parse = |s: &str| -> (Vec<String>, String) {
+            let p = Path::from_str_unchecked(s);
+            let mut it = p.components();
+            let items = it
+                .by_ref()
+                .map(|c| match c {
+                    PathComponent::Prim(name) => name.to_owned(),
+                    PathComponent::Variant { set, selection } => format!("{{{set}={selection}}}"),
+                })
+                .collect();
+            (items, it.remainder().to_owned())
+        };
+        let case = |items: &[&str]| items.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+        // Prim names and variant selections, in order, fully consumed.
+        assert_eq!(parse("/A/B/C"), (case(&["A", "B", "C"]), String::new()));
+        assert_eq!(parse("/A{x=y}/B"), (case(&["A", "{x=y}", "B"]), String::new()));
+        assert_eq!(parse("/A{x=y}{p=q}"), (case(&["A", "{x=y}", "{p=q}"]), String::new()));
+        // An empty selection (variant-set path) is yielded verbatim.
+        assert_eq!(parse("/A{x=}"), (case(&["A", "{x=}"]), String::new()));
+
+        // A property suffix ends the prim namespace and stays in the remainder.
+        assert_eq!(parse("/A.attr"), (case(&["A"]), ".attr".to_owned()));
+
+        // Malformed input stops parsing, leaving the bad tail in the remainder.
+        assert_eq!(parse("/A{x=y"), (case(&["A"]), "{x=y".to_owned()));
+        assert_eq!(parse("/A{x}"), (case(&["A"]), "{x}".to_owned()));
+        assert_eq!(parse("/A/"), (case(&["A"]), "/".to_owned()));
+        assert_eq!(parse("/A//B"), (case(&["A"]), "//B".to_owned()));
+
+        // The root and empty paths have no components.
+        assert_eq!(parse("/"), (Vec::<String>::new(), String::new()));
     }
 
     #[test]

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -217,18 +217,12 @@ impl Path {
             let dot = self.path.rfind('.')?;
             return Some(PathElement::Property(&self.path[dot + 1..]));
         }
-        if self.path.ends_with('}') {
-            if let Some(open) = self.path.rfind('{') {
-                let inner = &self.path[open + 1..self.path.len() - 1];
-                if let Some((set, selection)) = inner.split_once('=') {
-                    return Some(PathElement::Variant { set, selection });
-                }
-            }
-        }
-        match self.path.rsplit_once('/') {
-            Some((_, name)) => Some(PathElement::Prim(name)),
-            None => Some(PathElement::Prim(&self.path)),
-        }
+        // For a prim or variant path the last element is the last component;
+        // reuse the single variant-grammar definition in `components`.
+        self.components().last().map(|c| match c {
+            PathComponent::Prim(name) => PathElement::Prim(name),
+            PathComponent::Variant { set, selection } => PathElement::Variant { set, selection },
+        })
     }
 
     /// Returns the parent path, or `None` for the pseudo-root `/` and empty
@@ -249,14 +243,14 @@ impl Path {
         if self.path.is_empty() || self.path == "/" {
             return None;
         }
-        if self.is_property_path() {
-            return Some(self.prim_path());
-        }
         // Drop a trailing `{set=sel}` variant selection.
-        if self.path.ends_with('}') {
+        if self.is_prim_variant_selection_path() {
             if let Some(open) = self.path.rfind('{') {
                 return Some(Path::from_str_unchecked(&self.path[..open]));
             }
+        }
+        if self.is_property_path() {
+            return Some(self.prim_path());
         }
         match self.path.rsplit_once('/') {
             Some(("", _)) => Some(Path::abs_root()),

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -141,6 +141,19 @@ impl Path {
         // Split at last slash.
         // "/A/B/C.foo[target].bar:baz" will become "/A/B" and "C.foo[target].bar:baz"
         let Some((before, after)) = self.path.rsplit_once('/') else {
+            // Relative single segment (no slash): strip a trailing property or
+            // variant selection. `is_property_path` separates `Foo.bar` from a
+            // relative `..`, which has no property tail and is its own prim.
+            if self.is_property_path() {
+                if let Some(dot) = self.path.find('.') {
+                    return Path::from_str_unchecked(&self.path[..dot]);
+                }
+            }
+            if self.path.ends_with('}') {
+                if let Some(open) = self.path.rfind('{') {
+                    return Path::from_str_unchecked(&self.path[..open]);
+                }
+            }
             return self.clone();
         };
 
@@ -218,8 +231,16 @@ impl Path {
             return Some(PathElement::Property(&self.path[dot + 1..]));
         }
         // For a prim or variant path the last element is the last component;
-        // reuse the single variant-grammar definition in `components`.
-        self.components().last().map(|c| match c {
+        // reuse the single variant-grammar definition in `components`. A
+        // non-empty remainder means the path has an unparsed tail (malformed,
+        // or syntax this method doesn't model), so there is no clean final
+        // element.
+        let mut components = self.components();
+        let last = components.by_ref().last();
+        if !components.remainder().is_empty() {
+            return None;
+        }
+        last.map(|c| match c {
             PathComponent::Prim(name) => PathElement::Prim(name),
             PathComponent::Variant { set, selection } => PathElement::Variant { set, selection },
         })
@@ -695,6 +716,13 @@ mod tests {
 
             ("../.foo[target].bar", ".."),
             ("../.foo[target].bar:baz", ".."),
+
+            // Relative single segment (no slash): strip the property/variant.
+            ("Foo.bar", "Foo"),
+            ("Foo{x=y}", "Foo"),
+            ("Foo", "Foo"),
+            (".bar", ""),
+            ("..", ".."),
         ];
 
         for (path, expected) in cases {
@@ -770,6 +798,11 @@ mod tests {
         assert_eq!(last("/A{x=y}{p=q}").as_deref(), Some("{p=q}"));
         assert_eq!(last("/"), None);
         assert_eq!(last(""), None);
+        // An unparsed tail (malformed, or target syntax this method doesn't
+        // model) has no clean final element — None, not the last parsed prim.
+        assert_eq!(last("/A{bad"), None);
+        assert_eq!(last("/A.rel[/Target]"), None);
+        assert_eq!(last("/{x=y}"), None);
     }
 
     #[test]
@@ -783,9 +816,24 @@ mod tests {
 
         assert_eq!(split("/World/Mesh.points"), owned("/World/Mesh", "points"));
         assert_eq!(split("/Mat.inputs:diffuse"), owned("/Mat", "inputs:diffuse"));
+        // Relative property (no slash) decomposes too — the inverse of
+        // append_property.
+        assert_eq!(split("Foo.bar"), owned("Foo", "bar"));
         // Not a property path.
         assert_eq!(split("/World/Mesh"), None);
         assert_eq!(split("/"), None);
+    }
+
+    #[test]
+    fn test_property_suffix() {
+        let suffix = |s: &str| Path::from_str_unchecked(s).property_suffix().to_owned();
+
+        assert_eq!(suffix("/A.points"), ".points");
+        assert_eq!(suffix("/A/B.inputs:diffuse"), ".inputs:diffuse");
+        // Relative property (no slash).
+        assert_eq!(suffix("Foo.bar"), ".bar");
+        // A prim path has no property suffix.
+        assert_eq!(suffix("/A"), "");
     }
 
     #[test]
@@ -884,14 +932,18 @@ mod tests {
             ("/A{x=y}{p=q}",  Some("/A{x=y}")),
             ("/A{x=y}/B",    Some("/A{x=y}")),
             ("/A{x=y}.attr", Some("/A{x=y}")),
+            // Relative paths must not self-parent (would loop a parent walk).
+            ("Foo.bar",      Some("Foo")),
+            ("Foo",          None),
+            ("..",           None),
         ];
 
         for &(path, expected) in cases {
-            assert_eq!(
-                Path::new(path).unwrap().parent().as_ref().map(|p| p.as_str()),
-                expected,
-                "parent of {path:?}",
-            );
+            let parent = Path::new(path).unwrap().parent();
+            let parent = parent.as_ref().map(|p| p.as_str());
+            assert_eq!(parent, expected, "parent of {path:?}");
+            // A parent must make progress — never return the path itself.
+            assert_ne!(parent, Some(path), "self-parent on {path:?}");
         }
     }
 

--- a/src/sdf/path.rs
+++ b/src/sdf/path.rs
@@ -226,9 +226,12 @@ impl Path {
         if self.path.is_empty() || self.path == "/" {
             return None;
         }
-        if self.is_property_path() {
-            let dot = self.path.rfind('.')?;
-            return Some(PathElement::Property(&self.path[dot + 1..]));
+        // A property's element is the whole property name (everything after
+        // the owning prim's `.`), matching `parent()`/`split_property()` so an
+        // element appended to `parent()` reconstructs the path — including
+        // names that themselves contain dots, e.g. `append_property("foo.bar")`.
+        if let Some((_, name)) = self.split_property() {
+            return Some(PathElement::Property(name));
         }
         // For a prim or variant path the last element is the last component;
         // reuse the single variant-grammar definition in `components`. A
@@ -794,6 +797,9 @@ mod tests {
         assert_eq!(last("/A").as_deref(), Some("A"));
         assert_eq!(last("/A.points").as_deref(), Some(".points"));
         assert_eq!(last("/A.inputs:diffuse").as_deref(), Some(".inputs:diffuse"));
+        // The whole property name, even one containing dots (so parent() plus
+        // this element reconstruct the path) — `append_property("foo.bar")`.
+        assert_eq!(last("/A.foo.bar").as_deref(), Some(".foo.bar"));
         assert_eq!(last("/A{set=sel}").as_deref(), Some("{set=sel}"));
         assert_eq!(last("/A{x=y}{p=q}").as_deref(), Some("{p=q}"));
         assert_eq!(last("/"), None);

--- a/src/usdc/writer.rs
+++ b/src/usdc/writer.rs
@@ -14,7 +14,7 @@ use bytemuck::{bytes_of, Pod};
 use half::f16;
 use num_traits::{AsPrimitive, PrimInt};
 
-use crate::sdf::{AbstractData, LayerOffset, ListOp, Path, Payload, Reference, Value};
+use crate::sdf::{AbstractData, LayerOffset, ListOp, Path, PathElement, Payload, Reference, Value};
 
 use super::coding;
 use super::layout::{
@@ -136,8 +136,7 @@ impl<'w, W: Write + Seek> Packer<'w, W> {
                 if p.as_str() == "/" {
                     continue;
                 }
-                let (segment, _) = last_segment(p);
-                segment.to_owned()
+                path_element_token(p).0
             };
             self.tokens.intern(segment);
         }
@@ -149,7 +148,7 @@ impl<'w, W: Write + Seek> Packer<'w, W> {
     /// time [`encode_paths`] DFSes from the root.
     fn intern_path(&mut self, path: Path) -> u32 {
         if !self.paths.index.contains_key(&path) {
-            if let Some(parent) = parent_of(&path) {
+            if let Some(parent) = path.parent() {
                 self.intern_path(parent);
             }
         }
@@ -354,7 +353,9 @@ impl<'w, W: Write + Seek> Packer<'w, W> {
             if p.as_str() == "/" || p.is_empty() {
                 continue;
             }
-            let parent = parent_of(p).ok_or_else(|| anyhow::anyhow!("path {p} has no parent but is not root"))?;
+            let parent = p
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("path {p} has no parent but is not root"))?;
             children.entry(parent).or_default().push(p.clone());
         }
         for list in children.values_mut() {
@@ -403,8 +404,8 @@ impl<'w, W: Write + Seek> Packer<'w, W> {
         if is_root_chain_root {
             tokens.push(0);
         } else {
-            let (segment, is_prop) = last_segment(node);
-            let tok_idx = self.tokens.intern(segment.to_owned()) as i32;
+            let (segment, is_prop) = path_element_token(node);
+            let tok_idx = self.tokens.intern(segment) as i32;
             tokens.push(if is_prop { -tok_idx } else { tok_idx });
         }
 
@@ -1119,54 +1120,18 @@ fn kid_had_child(existing: &i32) -> bool {
     *existing == -1 || *existing > 0
 }
 
-fn parent_of(path: &Path) -> Option<Path> {
-    let s = path.as_str();
-    if s.is_empty() || s == "/" {
-        return None;
+/// The path table stores each spec as `(parent, element-token, is-property)`.
+/// Returns the interned-token string for a path's final element and whether it
+/// is a property (the reader appends a property via `.`, encoded as a negative
+/// token index). Variant selections are stored with their braces so they
+/// round-trip verbatim.
+fn path_element_token(path: &Path) -> (String, bool) {
+    match path.last_element() {
+        Some(PathElement::Prim(name)) => (name.to_owned(), false),
+        Some(PathElement::Property(name)) => (name.to_owned(), true),
+        Some(PathElement::Variant { set, selection }) => (format!("{{{set}={selection}}}"), false),
+        None => (String::new(), false),
     }
-
-    // Variant segment parent: /Prim{set=sel} → /Prim
-    if s.ends_with('}') {
-        if let Some(pos) = s.rfind('{') {
-            return Path::new(&s[..pos]).ok();
-        }
-    }
-
-    // Property path: /Prim.x → /Prim (prim path).
-    if path.is_property_path() {
-        return Some(path.prim_path());
-    }
-
-    // Regular prim path.
-    match s.rsplit_once('/') {
-        Some(("", _)) => Some(Path::abs_root()),
-        Some((before, _)) => Path::new(before).ok(),
-        None => None,
-    }
-}
-
-/// Returns `(segment, is_property)` where `segment` is the last element of the
-/// path and `is_property` is true if the element was attached via `.`.
-fn last_segment(path: &Path) -> (&str, bool) {
-    let s = path.as_str();
-
-    if s.ends_with('}') {
-        if let Some(pos) = s.rfind('{') {
-            return (&s[pos..], false);
-        }
-    }
-
-    if path.is_property_path() {
-        if let Some(pos) = s.rfind('.') {
-            return (&s[pos + 1..], true);
-        }
-    }
-
-    if let Some(pos) = s.rfind('/') {
-        return (&s[pos + 1..], false);
-    }
-
-    (s, false)
 }
 
 fn lz4_compress_single_chunk(input: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Adds more Path APIs

  - `Path::components()` — iterator over a path's prim-namespace components
    (`PathComponent::Prim`/`Variant`). `sdf::layer::parse_prim_path` becomes a thin
    validator over it, dropping the local tokenizer and raw `{/}` byte-scanning.
  - `Path::split_property()` — inverse of `append_property`, returning
    `(owning_prim, property_name)`. `split_property_path` uses it.
  - `Path::last_element()` / `PathElement` — the final namespace element and its
    kind (Prim/Property/Variant), the inverse of the `append_*` family.
  - `Path::parent()` is now namespace-correct — matches C++
    `SdfPath::GetParentPath` for property (`/A.attr` → `/A`) and variant
    (`/A{x=y}` → `/A`) paths; previously a naive `rsplit('/')` returned `/` for
    both.