### PR TITLE
feat(pcp): template clips + missing value-clip resolution

### DIFF
--- a/fixtures/clip_asset_anchor/clip.usda
+++ b/fixtures/clip_asset_anchor/clip.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        0: 42.0,
+    }
+}

--- a/fixtures/clip_asset_anchor/root.usda
+++ b/fixtures/clip_asset_anchor/root.usda
@@ -1,0 +1,20 @@
+#usda 1.0
+(
+    subLayers = [
+        @./sub/sub.usda@
+    ]
+    defaultPrim = "Model"
+)
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [@./clip.usda@]
+            double2[] active = [(0, 0)]
+            string primPath = "/Model"
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_asset_anchor/sub/sub.usda
+++ b/fixtures/clip_asset_anchor/sub/sub.usda
@@ -1,0 +1,15 @@
+#usda 1.0
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset templateAssetPath = @./tmpl.#.usda@
+            double templateStartTime = 0
+            double templateEndTime = 1
+            double templateStride = 1
+            string primPath = "/Model"
+        }
+    }
+)
+{
+}

--- a/fixtures/clip_missing_block/clip.usda
+++ b/fixtures/clip_missing_block/clip.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        0: 5.0,
+    }
+}

--- a/fixtures/clip_missing_block/manifest.usda
+++ b/fixtures/clip_missing_block/manifest.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def "Model"
+{
+    float size
+}

--- a/fixtures/clip_missing_block/ref.usda
+++ b/fixtures/clip_missing_block/ref.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+(
+    defaultPrim = "Model"
+)
+
+def "Model"
+{
+    float size.timeSamples = {
+        10: 777.0,
+    }
+}

--- a/fixtures/clip_missing_block/root.usda
+++ b/fixtures/clip_missing_block/root.usda
@@ -1,0 +1,19 @@
+#usda 1.0
+(
+    defaultPrim = "Model"
+)
+
+def "Model" (
+    references = @./ref.usda@
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [@./clip.usda@]
+            string primPath = "/Model"
+            asset manifestAssetPath = @./manifest.usda@
+            double2[] active = [(0, 0)]
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_missing_default/clip.usda
+++ b/fixtures/clip_missing_default/clip.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        0: 5.0,
+    }
+}

--- a/fixtures/clip_missing_default/manifest.usda
+++ b/fixtures/clip_missing_default/manifest.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def "Model"
+{
+    float size = 99.0
+}

--- a/fixtures/clip_missing_default/root.usda
+++ b/fixtures/clip_missing_default/root.usda
@@ -1,0 +1,18 @@
+#usda 1.0
+(
+    defaultPrim = "Model"
+)
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [@./clip.usda@]
+            string primPath = "/Model"
+            asset manifestAssetPath = @./manifest.usda@
+            double2[] active = [(0, 0)]
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_missing_interp/clipA.usda
+++ b/fixtures/clip_missing_interp/clipA.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        0: 0.0,
+    }
+}

--- a/fixtures/clip_missing_interp/clipB.usda
+++ b/fixtures/clip_missing_interp/clipB.usda
@@ -1,0 +1,5 @@
+#usda 1.0
+
+def "Model"
+{
+}

--- a/fixtures/clip_missing_interp/clipC.usda
+++ b/fixtures/clip_missing_interp/clipC.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        20: 100.0,
+    }
+}

--- a/fixtures/clip_missing_interp/manifest.usda
+++ b/fixtures/clip_missing_interp/manifest.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def "Model"
+{
+    float size
+}

--- a/fixtures/clip_missing_interp/root.usda
+++ b/fixtures/clip_missing_interp/root.usda
@@ -1,0 +1,19 @@
+#usda 1.0
+(
+    defaultPrim = "Model"
+)
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [@./clipA.usda@, @./clipB.usda@, @./clipC.usda@]
+            string primPath = "/Model"
+            asset manifestAssetPath = @./manifest.usda@
+            double2[] active = [(0, 0), (10, 1), (20, 2)]
+            bool interpolateMissingClipValues = true
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_template/clip.1.usda
+++ b/fixtures/clip_template/clip.1.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        1: 10.0,
+    }
+}

--- a/fixtures/clip_template/clip.2.usda
+++ b/fixtures/clip_template/clip.2.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        2: 20.0,
+    }
+}

--- a/fixtures/clip_template/root.usda
+++ b/fixtures/clip_template/root.usda
@@ -1,0 +1,19 @@
+#usda 1.0
+(
+    defaultPrim = "Model"
+)
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset templateAssetPath = @./clip.#.usda@
+            double templateStartTime = 1
+            double templateEndTime = 2
+            double templateStride = 1
+            string primPath = "/Model"
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_template_offset/clip.1.usda
+++ b/fixtures/clip_template_offset/clip.1.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        1: 10.0,
+    }
+}

--- a/fixtures/clip_template_offset/clip.2.usda
+++ b/fixtures/clip_template_offset/clip.2.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+
+def "Model"
+{
+    float size.timeSamples = {
+        2: 20.0,
+    }
+}

--- a/fixtures/clip_template_offset/model.usda
+++ b/fixtures/clip_template_offset/model.usda
@@ -1,0 +1,16 @@
+#usda 1.0
+
+def "Model" (
+    clips = {
+        dictionary default = {
+            asset templateAssetPath = @./clip.#.usda@
+            double templateStartTime = 1
+            double templateEndTime = 2
+            double templateStride = 1
+            string primPath = "/Model"
+        }
+    }
+)
+{
+    float size
+}

--- a/fixtures/clip_template_offset/root.usda
+++ b/fixtures/clip_template_offset/root.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+(
+    subLayers = [
+        @./model.usda@ (offset = 10)
+    ]
+)

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -215,9 +215,15 @@ impl Cache {
             return Ok(value);
         }
 
-        // 3) Value clips, anchored on this prim or an ancestor.
+        // 3) Value clips, anchored on this prim or an ancestor. A clip set that
+        //    owns the attribute resolves it authoritatively: an authored value
+        //    block stops fall-through to weaker sources but presents as `None`,
+        //    matching the local-default handling above and the default below.
         if let Some(value) = self.resolve_clip_value(&prim, &suffix, time, interp)? {
-            return Ok(Some(value));
+            return Ok(match value {
+                Value::ValueBlock | Value::None => None,
+                other => Some(other),
+            });
         }
 
         // 4) Remaining time samples (reference/payload arcs), retimed.
@@ -1840,16 +1846,17 @@ mod tests {
         Ok(())
     }
 
-    /// A manifest-declared attribute with no default and a gap resolves to a
-    /// value block (spec 12.3.4.6): the clip owns the attribute, so the gap
-    /// must not fall through to the referenced time samples (`777.0`).
+    /// A manifest-declared attribute with no default and a gap is
+    /// authoritatively absent (spec 12.3.4.6): the clip owns the attribute, so
+    /// the gap blocks fall-through to the referenced time samples (`777.0`) and
+    /// resolves to `None` rather than the weaker value.
     #[test]
-    fn missing_clip_value_without_default_is_value_block() -> Result<()> {
+    fn missing_clip_value_without_default_blocks() -> Result<()> {
         let root = format!("{}/fixtures/clip_missing_block/root.usda", manifest_dir());
         let mut cache = Cache::new(collected_stack(&root), VariantFallbackMap::new());
         let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &exact);
         assert_eq!(size(&mut cache, 0.0)?, Some(Value::Double(5.0)));
-        assert_eq!(size(&mut cache, 10.0)?, Some(Value::ValueBlock));
+        assert_eq!(size(&mut cache, 10.0)?, None);
         Ok(())
     }
 

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -1826,6 +1826,19 @@ mod tests {
         Ok(())
     }
 
+    /// When a stronger layer authors explicit `assetPaths` and a weaker
+    /// sublayer authors `templateAssetPath` for the same set, the explicit
+    /// paths win (spec 12.3.4.1.3) and must anchor on the layer that authored
+    /// them: `@./clip.usda@` resolves next to the root, not the sublayer.
+    #[test]
+    fn explicit_asset_paths_anchor_over_template() -> Result<()> {
+        let root = format!("{}/fixtures/clip_asset_anchor/root.usda", manifest_dir());
+        let mut cache = Cache::new(collected_stack(&root), VariantFallbackMap::new());
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &exact);
+        assert_eq!(size(&mut cache, 0.0)?, Some(Value::Double(42.0)));
+        Ok(())
+    }
+
     /// Exact-match sampler: a clip resolves only at a frame it authors.
     fn exact(samples: &sdf::TimeSampleMap, t: f64) -> Option<Value> {
         samples.iter().find(|(time, _)| *time == t).map(|(_, v)| v.clone())

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -109,6 +109,16 @@ enum FieldValue {
     Authored(Option<Value>),
 }
 
+/// Collapses the spec sentinels for "no value" ([`Value::ValueBlock`] and
+/// [`Value::None`]) to `None`, passing any real value through as `Some`. An
+/// authored block stops fall-through to weaker sources yet presents as absent.
+fn block_to_none(value: Value) -> Option<Value> {
+    match value {
+        Value::ValueBlock | Value::None => None,
+        other => Some(other),
+    }
+}
+
 impl Cache {
     /// Creates a new composition graph from a prebuilt layer stack.
     pub(crate) fn new(stack: LayerStack, variant_fallbacks: VariantFallbackMap) -> Self {
@@ -220,10 +230,7 @@ impl Cache {
         //    block stops fall-through to weaker sources but presents as `None`,
         //    matching the local-default handling above and the default below.
         if let Some(value) = self.resolve_clip_value(&prim, &suffix, time, interp)? {
-            return Ok(match value {
-                Value::ValueBlock | Value::None => None,
-                other => Some(other),
-            });
+            return Ok(block_to_none(value));
         }
 
         // 4) Remaining time samples (reference/payload arcs), retimed.
@@ -233,10 +240,7 @@ impl Cache {
 
         // 5) Fall back to the strongest authored default.
         let default = self.indices[&prim].resolve_field(FieldKey::Default.as_str(), &self.stack, Some(&suffix))?;
-        Ok(default.and_then(|value| match value {
-            Value::ValueBlock | Value::None => None,
-            other => Some(other),
-        }))
+        Ok(default.and_then(block_to_none))
     }
 
     fn resolve_local_field_value(
@@ -258,10 +262,7 @@ impl Cache {
             let Some(value) = self.stack.layer(node.layer_index).try_get(&query_path, field)? else {
                 continue;
             };
-            return Ok(match value.into_owned() {
-                Value::ValueBlock | Value::None => FieldValue::Authored(None),
-                other => FieldValue::Authored(Some(other)),
-            });
+            return Ok(FieldValue::Authored(block_to_none(value.into_owned())));
         }
 
         Ok(FieldValue::NotAuthored)
@@ -430,10 +431,7 @@ impl Cache {
                 .map(|value| value.into_owned()),
             None => None,
         };
-        Ok(value.and_then(|value| match value {
-            Value::ValueBlock | Value::None => None,
-            other => Some(other),
-        }))
+        Ok(value.and_then(block_to_none))
     }
 
     /// Fills a gap in the active clip by interpolating across the nearest

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -363,9 +363,13 @@ impl Cache {
             }
 
             // (a) Manifest default: synthesize a sample at the clip's active
-            //     time (spec 12.3.4.6).
-            if let Some(value) = self.manifest_default(resolved, &clip_path)? {
-                return Ok(Some(value));
+            //     time (spec 12.3.4.6). Reached only when the manifest declared
+            //     the attribute, so the manifest asset is authored.
+            if let Some(manifest) = set.manifest_asset.as_deref() {
+                let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
+                if let Some(value) = self.manifest_default(manifest, manifest_layer, &clip_path)? {
+                    return Ok(Some(value));
+                }
             }
 
             // (b) interpolateMissingClipValues: interpolate the gap across the
@@ -411,14 +415,10 @@ impl Cache {
 
     /// Reads the manifest's authored `default` for `clip_path` (spec 12.3.4.6):
     /// when the active clip has a gap, the manifest default stands in as the
-    /// sample value. Returns `None` when no manifest is authored, the manifest
-    /// is unresolved, or it holds no usable default for the attribute.
-    fn manifest_default(&mut self, resolved: &ResolvedClipSet, clip_path: &Path) -> Result<Option<Value>> {
-        let Some(manifest) = resolved.set.manifest_asset.clone() else {
-            return Ok(None);
-        };
-        let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
-        let value = match self.clip_layer(&manifest, manifest_layer)? {
+    /// sample value. Returns `None` when the manifest is unresolved or holds no
+    /// usable default for the attribute.
+    fn manifest_default(&mut self, manifest: &str, manifest_layer: usize, clip_path: &Path) -> Result<Option<Value>> {
+        let value = match self.clip_layer(manifest, manifest_layer)? {
             Some(layer) => layer
                 .data()
                 .try_get(clip_path, FieldKey::Default.as_str())?

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -1813,6 +1813,19 @@ mod tests {
         Ok(())
     }
 
+    /// A template clip set authored in a sublayer with a layer offset has its
+    /// derived schedule retimed into stage time (spec 12.3.4): the offset of 10
+    /// shifts `clip.1`'s frame to stage t=11 and `clip.2`'s to t=12.
+    #[test]
+    fn template_clip_schedule_retimed_by_offset() -> Result<()> {
+        let root = format!("{}/fixtures/clip_template_offset/root.usda", manifest_dir());
+        let mut cache = Cache::new(collected_stack(&root), VariantFallbackMap::new());
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &exact);
+        assert_eq!(size(&mut cache, 11.0)?, Some(Value::Double(10.0)));
+        assert_eq!(size(&mut cache, 12.0)?, Some(Value::Double(20.0)));
+        Ok(())
+    }
+
     /// Exact-match sampler: a clip resolves only at a frame it authors.
     fn exact(samples: &sdf::TimeSampleMap, t: f64) -> Option<Value> {
         samples.iter().find(|(time, _)| *time == t).map(|(_, v)| v.clone())

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -1659,6 +1659,24 @@ mod tests {
         Ok(())
     }
 
+    /// A template clip set (`templateAssetPath` + start/end/stride) is
+    /// expanded to explicit clips and resolves end to end through
+    /// `value_at` (spec 12.3.4.1.3): `clip.1.usda` drives t=1, `clip.2.usda`
+    /// drives t=2.
+    #[test]
+    fn resolves_template_clip_values() -> Result<()> {
+        let root = format!("{}/fixtures/clip_template/root.usda", manifest_dir());
+        let mut cache = Cache::new(single_layer_stack(&root), VariantFallbackMap::new());
+        // Exact-match sampler: each clip authors a single sample at its frame.
+        let interp =
+            |samples: &sdf::TimeSampleMap, t: f64| samples.iter().find(|(time, _)| *time == t).map(|(_, v)| v.clone());
+
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &interp);
+        assert_eq!(size(&mut cache, 1.0)?, Some(sdf::Value::Double(10.0)));
+        assert_eq!(size(&mut cache, 2.0)?, Some(sdf::Value::Double(20.0)));
+        Ok(())
+    }
+
     /// Instances sharing a prototype compose their subtree once: a
     /// non-canonical instance's descendant is served by the canonical one and
     /// is never indexed (spec 11.3.3).

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -18,6 +18,7 @@ use crate::sdf;
 use crate::sdf::schema::{ChildrenKey, FieldKey};
 use crate::sdf::{AbstractData, Path, SpecType, Value};
 
+use super::clip::ResolvedClipSet;
 use super::deps::Dependencies;
 use super::index::{AncestorArc, ArcType, CompositionContext, Node, PrimIndex};
 use super::mapping::MapFunction;
@@ -315,17 +316,25 @@ impl Cache {
             let clip_path = Path::new(&format!("{base}{relative}{suffix}"))?;
 
             // A manifest, when authored, declares which attributes the clips
-            // provide; skip clip sets that do not declare this attribute.
-            if let Some(manifest) = &set.manifest_asset {
-                let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
-                let declared = match self.clip_layer(manifest, manifest_layer)? {
-                    Some(layer) => layer.data().has_spec(&clip_path),
-                    None => false,
-                };
-                if !declared {
-                    continue;
+            // provide. A set whose manifest does not declare this attribute is
+            // skipped. A set that *does* declare it owns the attribute's
+            // time-varying value (spec 12.3.4.6): a gap in the active clip
+            // resolves to a manifest default or a value block, never to a
+            // weaker value source.
+            let manifest_declared = match &set.manifest_asset {
+                Some(manifest) => {
+                    let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
+                    let declared = match self.clip_layer(manifest, manifest_layer)? {
+                        Some(layer) => layer.data().has_spec(&clip_path),
+                        None => false,
+                    };
+                    if !declared {
+                        continue;
+                    }
+                    true
                 }
-            }
+                None => false,
+            };
 
             let Some(active) = set.active_clip(time) else {
                 continue;
@@ -335,32 +344,137 @@ impl Cache {
             };
             let clip_time = set.map_stage_to_clip(time);
 
-            let samples = match self.clip_layer(asset, resolved.asset_layer)? {
-                Some(layer) => match layer.data().try_get(&clip_path, FieldKey::TimeSamples.as_str())? {
-                    Some(value) => match value.into_owned() {
-                        Value::TimeSamples(samples) => Some(samples),
-                        _ => None,
-                    },
-                    None => None,
-                },
-                None => None,
-            };
+            if let Some(value) = self.clip_sample_at(asset, resolved.asset_layer, &clip_path, clip_time, interp)? {
+                return Ok(Some(value));
+            }
 
-            if let Some(samples) = samples {
-                if let Some(value) = interp(&samples, clip_time) {
+            // The active clip has no sample at `clip_time`. Only a
+            // manifest-declared attribute gets the gap-filling treatment;
+            // without a manifest there is no assurance this set owns the
+            // attribute, so fall through to weaker value sources.
+            if !manifest_declared {
+                continue;
+            }
+
+            // (a) Manifest default: synthesize a sample at the clip's active
+            //     time (spec 12.3.4.6).
+            if let Some(value) = self.manifest_default(resolved, &clip_path)? {
+                return Ok(Some(value));
+            }
+
+            // (b) interpolateMissingClipValues: interpolate the gap across the
+            //     nearest surrounding clips (spec 12.3.4.7).
+            if set.interpolate_missing {
+                if let Some(value) = self.interpolate_missing_value(resolved, &clip_path, time, interp)? {
                     return Ok(Some(value));
                 }
             }
 
-            // TODO: handle missing values in a declared clip (spec 12.3.4.6-7).
-            // When the manifest declares this attribute but the active clip has
-            // no samples at `clip_time`, the result should be the manifest's
-            // default, an empty sentinel, or — with `interpolateMissingClipValues`
-            // — a value interpolated from the nearest surrounding clips. We
-            // currently fall through to weaker value sources instead.
+            // (c) No default and nothing to interpolate: the manifest-declared
+            //     attribute is authoritatively absent — a value block — which
+            //     must not fall through to weaker sources (spec 12.3.4.6).
+            return Ok(Some(Value::ValueBlock));
         }
 
         Ok(None)
+    }
+
+    /// Reads the time samples for `clip_path` from a single clip layer and
+    /// interpolates at `clip_time`. Returns `None` when the layer is
+    /// unresolved or the attribute has no time samples there.
+    fn clip_sample_at(
+        &mut self,
+        asset: &str,
+        anchor_layer: usize,
+        clip_path: &Path,
+        clip_time: f64,
+        interp: &dyn Fn(&sdf::TimeSampleMap, f64) -> Option<Value>,
+    ) -> Result<Option<Value>> {
+        let samples = match self.clip_layer(asset, anchor_layer)? {
+            Some(layer) => match layer.data().try_get(clip_path, FieldKey::TimeSamples.as_str())? {
+                Some(value) => match value.into_owned() {
+                    Value::TimeSamples(samples) => Some(samples),
+                    _ => None,
+                },
+                None => None,
+            },
+            None => None,
+        };
+        Ok(samples.and_then(|samples| interp(&samples, clip_time)))
+    }
+
+    /// Reads the manifest's authored `default` for `clip_path` (spec 12.3.4.6):
+    /// when the active clip has a gap, the manifest default stands in as the
+    /// sample value. Returns `None` when no manifest is authored, the manifest
+    /// is unresolved, or it holds no usable default for the attribute.
+    fn manifest_default(&mut self, resolved: &ResolvedClipSet, clip_path: &Path) -> Result<Option<Value>> {
+        let Some(manifest) = resolved.set.manifest_asset.clone() else {
+            return Ok(None);
+        };
+        let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
+        let value = match self.clip_layer(&manifest, manifest_layer)? {
+            Some(layer) => layer
+                .data()
+                .try_get(clip_path, FieldKey::Default.as_str())?
+                .map(|value| value.into_owned()),
+            None => None,
+        };
+        Ok(value.and_then(|value| match value {
+            Value::ValueBlock | Value::None => None,
+            other => Some(other),
+        }))
+    }
+
+    /// Fills a gap in the active clip by interpolating across the nearest
+    /// surrounding clips that contribute a value (spec 12.3.4.7). Each
+    /// contributing clip is anchored on the stage timeline at the active stage
+    /// time it owns and valued by its sample there; `interp` then brackets
+    /// `time` between the nearest such anchors, exactly as if the clips' samples
+    /// formed one virtual sample map. The forward bracket is the next
+    /// contributing clip's start time and the backward bracket the previous
+    /// one's, matching the C++ resolver. When only one side contributes, its
+    /// value is held across the gap.
+    fn interpolate_missing_value(
+        &mut self,
+        resolved: &ResolvedClipSet,
+        clip_path: &Path,
+        time: f64,
+        interp: &dyn Fn(&sdf::TimeSampleMap, f64) -> Option<Value>,
+    ) -> Result<Option<Value>> {
+        let set = &resolved.set;
+        let anchor = resolved.asset_layer;
+        // Position of the active clip among the `active` entries at `time`.
+        let active_pos = set.active.iter().rposition(|&(stage, _)| stage <= time).unwrap_or(0);
+
+        // Forward: nearest later clip that contributes, anchored at its start.
+        let mut upper = None;
+        for &(stage, idx) in set.active.iter().skip(active_pos + 1) {
+            if let Some(asset) = set.asset_paths.get(idx) {
+                let clip_time = set.map_stage_to_clip(stage);
+                if let Some(value) = self.clip_sample_at(asset, anchor, clip_path, clip_time, interp)? {
+                    upper = Some((stage, value));
+                    break;
+                }
+            }
+        }
+
+        // Backward: nearest earlier clip that contributes, anchored at its start.
+        let mut lower = None;
+        for &(stage, idx) in set.active[..active_pos].iter().rev() {
+            if let Some(asset) = set.asset_paths.get(idx) {
+                let clip_time = set.map_stage_to_clip(stage);
+                if let Some(value) = self.clip_sample_at(asset, anchor, clip_path, clip_time, interp)? {
+                    lower = Some((stage, value));
+                    break;
+                }
+            }
+        }
+
+        Ok(match (lower, upper) {
+            (Some((lt, lv)), Some((ut, uv))) => interp(&vec![(lt, lv), (ut, uv)], time),
+            (Some((_, value)), None) | (None, Some((_, value))) => Some(value),
+            (None, None) => None,
+        })
     }
 
     /// Read-only access to the dependency map for change-driven invalidation.
@@ -1621,6 +1735,17 @@ mod tests {
         std::env::var("CARGO_MANIFEST_DIR").unwrap()
     }
 
+    /// Builds a stack with the root and every layer reachable through
+    /// references/sublayers collected in, so composition can resolve them
+    /// (clip layers are still opened lazily by the cache).
+    fn collected_stack(path: &str) -> LayerStack {
+        let resolver = DefaultResolver::new();
+        let layers = crate::layer::Collector::new(&resolver)
+            .collect(path)
+            .expect("collect layers");
+        LayerStack::new(layers, 0, Box::new(DefaultResolver::new()), true)
+    }
+
     /// Builds a one-layer stack whose root is loaded from a real path, so the
     /// resolver can anchor clip asset paths relative to it.
     fn single_layer_stack(path: &str) -> LayerStack {
@@ -1674,6 +1799,72 @@ mod tests {
         let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &interp);
         assert_eq!(size(&mut cache, 1.0)?, Some(sdf::Value::Double(10.0)));
         assert_eq!(size(&mut cache, 2.0)?, Some(sdf::Value::Double(20.0)));
+        Ok(())
+    }
+
+    /// Exact-match sampler: a clip resolves only at a frame it authors.
+    fn exact(samples: &sdf::TimeSampleMap, t: f64) -> Option<Value> {
+        samples.iter().find(|(time, _)| *time == t).map(|(_, v)| v.clone())
+    }
+
+    /// Linear sampler over `float` samples, held outside the sample range.
+    fn lerp(samples: &sdf::TimeSampleMap, t: f64) -> Option<Value> {
+        let as_f = |v: &Value| match v {
+            Value::Float(f) => *f as f64,
+            Value::Double(d) => *d,
+            _ => 0.0,
+        };
+        let first = samples.first()?;
+        if t <= first.0 {
+            return Some(first.1.clone());
+        }
+        let last = samples.last()?;
+        if t >= last.0 {
+            return Some(last.1.clone());
+        }
+        let w = samples.windows(2).find(|w| t >= w[0].0 && t <= w[1].0)?;
+        let f = (t - w[0].0) / (w[1].0 - w[0].0);
+        Some(Value::Double(as_f(&w[0].1) + (as_f(&w[1].1) - as_f(&w[0].1)) * f))
+    }
+
+    /// A gap in the active clip falls to the manifest's authored default
+    /// (spec 12.3.4.6): `t=0` is sampled from the clip, `t=10` (no sample)
+    /// resolves to the manifest default `99.0`.
+    #[test]
+    fn missing_clip_value_uses_manifest_default() -> Result<()> {
+        let root = format!("{}/fixtures/clip_missing_default/root.usda", manifest_dir());
+        let mut cache = Cache::new(single_layer_stack(&root), VariantFallbackMap::new());
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &exact);
+        assert_eq!(size(&mut cache, 0.0)?, Some(Value::Double(5.0)));
+        assert_eq!(size(&mut cache, 10.0)?, Some(Value::Float(99.0)));
+        Ok(())
+    }
+
+    /// A manifest-declared attribute with no default and a gap resolves to a
+    /// value block (spec 12.3.4.6): the clip owns the attribute, so the gap
+    /// must not fall through to the referenced time samples (`777.0`).
+    #[test]
+    fn missing_clip_value_without_default_is_value_block() -> Result<()> {
+        let root = format!("{}/fixtures/clip_missing_block/root.usda", manifest_dir());
+        let mut cache = Cache::new(collected_stack(&root), VariantFallbackMap::new());
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &exact);
+        assert_eq!(size(&mut cache, 0.0)?, Some(Value::Double(5.0)));
+        assert_eq!(size(&mut cache, 10.0)?, Some(Value::ValueBlock));
+        Ok(())
+    }
+
+    /// With `interpolateMissingClipValues`, a gap is filled by interpolating
+    /// across the surrounding contributing clips (spec 12.3.4.7): the empty
+    /// middle clip at `t=15` interpolates `0.0` (t=0 clip) and `100.0`
+    /// (t=20 clip) to `75.0`.
+    #[test]
+    fn interpolate_missing_clip_values_across_clips() -> Result<()> {
+        let root = format!("{}/fixtures/clip_missing_interp/root.usda", manifest_dir());
+        let mut cache = Cache::new(single_layer_stack(&root), VariantFallbackMap::new());
+        let size = |cache: &mut Cache, t: f64| cache.value_at(&sdf::path("/Model.size").unwrap(), t, &lerp);
+        assert_eq!(size(&mut cache, 0.0)?, Some(Value::Double(0.0)));
+        assert_eq!(size(&mut cache, 15.0)?, Some(Value::Double(75.0)));
+        assert_eq!(size(&mut cache, 20.0)?, Some(Value::Double(100.0)));
         Ok(())
     }
 

--- a/src/pcp/cache.rs
+++ b/src/pcp/cache.rs
@@ -321,17 +321,23 @@ impl Cache {
             let base = set.prim_path.clone().unwrap_or_else(|| anchor_prim.clone());
             let clip_path = Path::new(&format!("{base}{relative}{suffix}"))?;
 
+            // Resolve the manifest once: its declaration gates the set and its
+            // default later fills a gap (spec 12.3.4.6).
+            let manifest = set
+                .manifest_asset
+                .as_deref()
+                .map(|asset| (asset, resolved.manifest_layer.unwrap_or(resolved.asset_layer)));
+
             // A manifest, when authored, declares which attributes the clips
             // provide. A set whose manifest does not declare this attribute is
             // skipped. A set that *does* declare it owns the attribute's
             // time-varying value (spec 12.3.4.6): a gap in the active clip
             // resolves to a manifest default or a value block, never to a
             // weaker value source.
-            let manifest_declared = match &set.manifest_asset {
-                Some(manifest) => {
-                    let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
-                    let declared = match self.clip_layer(manifest, manifest_layer)? {
-                        Some(layer) => layer.data().has_spec(&clip_path),
+            let manifest_declared = match manifest {
+                Some((asset, layer)) => {
+                    let declared = match self.clip_layer(asset, layer)? {
+                        Some(opened) => opened.data().has_spec(&clip_path),
                         None => false,
                     };
                     if !declared {
@@ -365,9 +371,8 @@ impl Cache {
             // (a) Manifest default: synthesize a sample at the clip's active
             //     time (spec 12.3.4.6). Reached only when the manifest declared
             //     the attribute, so the manifest asset is authored.
-            if let Some(manifest) = set.manifest_asset.as_deref() {
-                let manifest_layer = resolved.manifest_layer.unwrap_or(resolved.asset_layer);
-                if let Some(value) = self.manifest_default(manifest, manifest_layer, &clip_path)? {
+            if let Some((asset, layer)) = manifest {
+                if let Some(value) = self.manifest_default(asset, layer, &clip_path)? {
                     return Ok(Some(value));
                 }
             }

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -8,7 +8,7 @@
 //! (spec 12.3.4.1.3) are resolved to explicit metadata elsewhere and are not
 //! parsed by [`ClipSet::parse_all`].
 
-use crate::sdf::{Path, Value};
+use crate::sdf::{LayerOffset, Path, Value};
 use std::collections::HashMap;
 
 /// Dictionary keys inside a single clip set's metadata (spec 12.3.4.1).
@@ -175,6 +175,26 @@ impl ClipSet {
     /// unchanged.
     pub(crate) fn map_stage_to_clip(&self, stage_time: f64) -> f64 {
         map_stage_to_clip(&self.times, stage_time)
+    }
+
+    /// Retimes the schedule through `offset`, shifting the stage component of
+    /// every `active` and `times` entry while leaving the clip-time targets and
+    /// asset paths untouched. A template-derived schedule is produced in clip
+    /// time and brought into stage time here; explicit `active`/`times` are
+    /// retimed as they compose. Re-sorts so a negative scale keeps the stage
+    /// ordering the lookups rely on.
+    pub(crate) fn retime_stage_times(&mut self, offset: LayerOffset) {
+        if offset.is_identity() {
+            return;
+        }
+        for (stage, _) in &mut self.active {
+            *stage = offset.offset + offset.scale * *stage;
+        }
+        for (stage, _) in &mut self.times {
+            *stage = offset.offset + offset.scale * *stage;
+        }
+        self.active.sort_by(|a, b| a.0.total_cmp(&b.0));
+        self.times.sort_by(|a, b| a.0.total_cmp(&b.0));
     }
 }
 

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -211,6 +211,9 @@ fn map_stage_to_clip(times: &[(f64, f64)], stage_time: f64) -> f64 {
     clip0 + ratio * (clip1 - clip0)
 }
 
+/// Derived `(assetPaths, active, times)` from a template clip set.
+type TemplateExpansion = (Vec<String>, Vec<(f64, usize)>, Vec<(f64, f64)>);
+
 /// Expand a template clip set (spec 12.3.4.1.3) into explicit
 /// `(assetPaths, active, times)`.
 ///
@@ -219,7 +222,8 @@ fn map_stage_to_clip(times: &[(f64, f64)], stage_time: f64) -> f64 {
 /// `#`-pattern `templateAssetPath`. Each generated clip `i` contributes
 /// `assetPaths[i]`, an `active` entry `(stageTime, i)`, and a `times`
 /// entry `(clipTime, clipTime)`. `templateActiveOffset`, when authored,
-/// shifts each clip's active stage time to `clipTime + offset`.
+/// shifts each clip's active stage time to `clipTime + offset` and adds
+/// boundary knots to `times` at `start - |offset|` and `end + |offset|`.
 ///
 /// Returns `None` when the required template fields are missing or
 /// invalid (non-positive stride, `end < start`, `|activeOffset| > stride`,
@@ -228,9 +232,6 @@ fn map_stage_to_clip(times: &[(f64, f64)], stage_time: f64) -> f64 {
 /// Times are scaled by a fixed promotion factor during iteration so a
 /// fractional `stride` accumulates without binary-float drift, matching
 /// C++ `Usd_ClipSetDefinition` template derivation.
-/// Derived `(assetPaths, active, times)` from a template clip set.
-type TemplateExpansion = (Vec<String>, Vec<(f64, usize)>, Vec<(f64, f64)>);
-
 fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
     let template = set.get(keys::TEMPLATE_ASSET_PATH).and_then(as_asset)?;
     let start = set.get(keys::TEMPLATE_START_TIME).and_then(as_f64)?;
@@ -257,6 +258,16 @@ fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
     let mut asset_paths = Vec::new();
     let mut active = Vec::new();
     let mut times = Vec::new();
+
+    // An active offset lets a query reach `|offset|` before the first clip and
+    // after the last. Author timing knots at those expanded boundaries so the
+    // lead/trail range maps linearly to clip time instead of clamping to the
+    // first or last clip time (spec 12.3.4.1.3, matching C++ derivation).
+    if let Some(off) = active_offset {
+        let front = (start * PROMOTION - off.abs() * PROMOTION) / PROMOTION;
+        times.push((front, front));
+    }
+
     let mut t = start * PROMOTION;
     let mut index = 0usize;
     // `+ 0.5` keeps the inclusive endpoint despite residual rounding.
@@ -271,6 +282,11 @@ fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
         active.push((stage_time, index));
         index += 1;
         t += stride_p;
+    }
+
+    if let Some(off) = active_offset {
+        let back = (end_p + off.abs() * PROMOTION) / PROMOTION;
+        times.push((back, back));
     }
 
     if asset_paths.is_empty() {
@@ -478,9 +494,13 @@ mod tests {
         set.insert(keys::TEMPLATE_ACTIVE_OFFSET.to_string(), Value::Double(-0.5));
 
         let parsed = ClipSet::parse_one("default", &set).expect("template set");
-        // clipTimes unchanged; active stage times shifted by the offset.
+        // Active stage times shift by the offset; `times` keeps the clip-time
+        // knots plus boundary knots expanded by |offset| at each end.
         assert_eq!(parsed.active, vec![(-0.5, 0), (0.5, 1), (1.5, 2)]);
-        assert_eq!(parsed.times, vec![(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]);
+        assert_eq!(
+            parsed.times,
+            vec![(-0.5, -0.5), (0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (2.5, 2.5)]
+        );
     }
 
     #[test]

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -363,9 +363,10 @@ impl HashPattern {
                 let sign = if neg { "-" } else { "" };
                 format!("{sign}{padded}.{frac_part}")
             }
-            // One group: zero-padded integer (spec example `foo.###.usd`
+            // One group: zero-padded integer, truncating the clip time toward
+            // zero like the C++ `int(time)` cast (spec example `foo.###.usd`
             // @ 12 -> `foo.012.usd`).
-            None => format!("{:0width$}", time.round() as i64, width = self.int_width),
+            None => format!("{:0width$}", time as i64, width = self.int_width),
         };
         format!("{}{}{}", self.prefix, body, self.suffix)
     }
@@ -436,6 +437,9 @@ mod tests {
         assert_eq!(HashPattern::parse("foo.###.usd").unwrap().format(12.0), "foo.012.usd");
         // foo.#.usd   @ 333 => foo.333.usd
         assert_eq!(HashPattern::parse("foo.#.usd").unwrap().format(333.0), "foo.333.usd");
+        // Fractional clip times truncate toward zero, not round:
+        // foo.#.usd @ 1.6 => foo.1.usd.
+        assert_eq!(HashPattern::parse("foo.#.usd").unwrap().format(1.6), "foo.1.usd");
     }
 
     #[test]

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -23,6 +23,10 @@ pub(crate) mod keys {
     pub const ACTIVE: &str = "active";
     /// `(stageTime, clipTime)` pairs forming the stage-to-clip timing curve.
     pub const TIMES: &str = "times";
+    /// `bool` — interpolate across surrounding clips for an attribute whose
+    /// active clip has a gap, instead of falling to the manifest default
+    /// (spec 12.3.4.6-7).
+    pub const INTERPOLATE_MISSING: &str = "interpolateMissingClipValues";
 
     // ── Template clip keys (spec 12.3.4.1.3) ──────────────────────────────
     /// `#`-pattern asset path expanded into explicit `assetPaths`.
@@ -57,6 +61,10 @@ pub(crate) struct ClipSet {
     /// timing curve (spec 12.3.4.4). Duplicate stage times encode jump
     /// discontinuities (spec 12.3.4.8).
     pub times: Vec<(f64, f64)>,
+    /// When `true`, a gap in the active clip is filled by interpolating across
+    /// the nearest surrounding clips rather than by the manifest default
+    /// (spec 12.3.4.6-7).
+    pub interpolate_missing: bool,
 }
 
 /// A parsed clip set plus the layer provenance needed for asset resolution.
@@ -133,6 +141,8 @@ impl ClipSet {
             None => expand_template(set)?,
         };
 
+        let interpolate_missing = set.get(keys::INTERPOLATE_MISSING).and_then(as_bool).unwrap_or(false);
+
         Some(ClipSet {
             name: name.to_string(),
             prim_path,
@@ -140,6 +150,7 @@ impl ClipSet {
             asset_paths,
             active,
             times,
+            interpolate_missing,
         })
     }
 
@@ -364,6 +375,13 @@ fn as_f64(value: &Value) -> Option<f64> {
     }
 }
 
+fn as_bool(value: &Value) -> Option<bool> {
+    match value {
+        Value::Bool(b) => Some(*b),
+        _ => None,
+    }
+}
+
 fn as_asset(value: &Value) -> Option<String> {
     match value {
         Value::AssetPath(s) | Value::String(s) | Value::Token(s) => Some(s.clone()),
@@ -514,6 +532,7 @@ mod tests {
             asset_paths: Vec::new(),
             active,
             times,
+            interpolate_missing: false,
         }
     }
 

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -23,6 +23,18 @@ pub(crate) mod keys {
     pub const ACTIVE: &str = "active";
     /// `(stageTime, clipTime)` pairs forming the stage-to-clip timing curve.
     pub const TIMES: &str = "times";
+
+    // ── Template clip keys (spec 12.3.4.1.3) ──────────────────────────────
+    /// `#`-pattern asset path expanded into explicit `assetPaths`.
+    pub const TEMPLATE_ASSET_PATH: &str = "templateAssetPath";
+    /// Inclusive start of the time range searched for template clips.
+    pub const TEMPLATE_START_TIME: &str = "templateStartTime";
+    /// Inclusive end of the time range searched for template clips.
+    pub const TEMPLATE_END_TIME: &str = "templateEndTime";
+    /// Step between successive template clip times.
+    pub const TEMPLATE_STRIDE: &str = "templateStride";
+    /// Offset applied to each clip's active stage time.
+    pub const TEMPLATE_ACTIVE_OFFSET: &str = "templateActiveOffset";
 }
 
 /// A single explicit clip set: a named group of value clips with sequencing
@@ -86,31 +98,40 @@ impl ClipSet {
     }
 
     /// Parses a single clip set from its metadata dictionary. Returns `None`
-    /// when the set has no explicit `assetPaths` (template form is deferred).
+    /// when the set declares neither explicit `assetPaths` nor a usable
+    /// `templateAssetPath`.
+    ///
+    /// Template sets (spec 12.3.4.1.3) authoring `templateAssetPath` +
+    /// `templateStartTime` / `templateEndTime` / `templateStride` (and
+    /// optionally `templateActiveOffset`) are expanded here into the explicit
+    /// `assetPaths` / `active` / `times` form before resolution, so the rest
+    /// of the pipeline only ever sees explicit clip sets. Explicit
+    /// `assetPaths`, when authored, take precedence over the template form.
     fn parse_one(name: &str, set: &HashMap<String, Value>) -> Option<ClipSet> {
-        // TODO: handle template clips (spec 12.3.4.1.3). When a set authors
-        // `templateAssetPath` instead of `assetPaths`, derive the explicit
-        // `assetPaths`/`active`/`times` from the template metadata here rather
-        // than skipping the set.
-        let asset_paths = set.get(keys::ASSET_PATHS).and_then(as_string_vec)?;
-
         let prim_path = set
             .get(keys::PRIM_PATH)
             .and_then(as_string)
             .and_then(|s| Path::new(&s).ok());
         let manifest_asset = set.get(keys::MANIFEST_ASSET_PATH).and_then(as_asset);
 
-        let mut active: Vec<(f64, usize)> = set
-            .get(keys::ACTIVE)
-            .map(as_pairs)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(stage, index)| (stage, index as usize))
-            .collect();
-        active.sort_by(|a, b| a.0.total_cmp(&b.0));
+        // Explicit form wins; otherwise expand a template set.
+        let (asset_paths, active, times) = match set.get(keys::ASSET_PATHS).and_then(as_string_vec) {
+            Some(asset_paths) => {
+                let mut active: Vec<(f64, usize)> = set
+                    .get(keys::ACTIVE)
+                    .map(as_pairs)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(stage, index)| (stage, index as usize))
+                    .collect();
+                active.sort_by(|a, b| a.0.total_cmp(&b.0));
 
-        let mut times = set.get(keys::TIMES).map(as_pairs).unwrap_or_default();
-        times.sort_by(|a, b| a.0.total_cmp(&b.0));
+                let mut times = set.get(keys::TIMES).map(as_pairs).unwrap_or_default();
+                times.sort_by(|a, b| a.0.total_cmp(&b.0));
+                (asset_paths, active, times)
+            }
+            None => expand_template(set)?,
+        };
 
         Some(ClipSet {
             name: name.to_string(),
@@ -179,9 +200,166 @@ fn map_stage_to_clip(times: &[(f64, f64)], stage_time: f64) -> f64 {
     clip0 + ratio * (clip1 - clip0)
 }
 
+/// Expand a template clip set (spec 12.3.4.1.3) into explicit
+/// `(assetPaths, active, times)`.
+///
+/// Iterates clip times from `templateStartTime` to `templateEndTime`
+/// (inclusive) by `templateStride`, substituting each time into the
+/// `#`-pattern `templateAssetPath`. Each generated clip `i` contributes
+/// `assetPaths[i]`, an `active` entry `(stageTime, i)`, and a `times`
+/// entry `(clipTime, clipTime)`. `templateActiveOffset`, when authored,
+/// shifts each clip's active stage time to `clipTime + offset`.
+///
+/// Returns `None` when the required template fields are missing or
+/// invalid (non-positive stride, `end < start`, `|activeOffset| > stride`,
+/// or an unparseable pattern).
+///
+/// Times are scaled by a fixed promotion factor during iteration so a
+/// fractional `stride` accumulates without binary-float drift, matching
+/// C++ `Usd_ClipSetDefinition` template derivation.
+/// Derived `(assetPaths, active, times)` from a template clip set.
+type TemplateExpansion = (Vec<String>, Vec<(f64, usize)>, Vec<(f64, f64)>);
+
+fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
+    let template = set.get(keys::TEMPLATE_ASSET_PATH).and_then(as_asset)?;
+    let start = set.get(keys::TEMPLATE_START_TIME).and_then(as_f64)?;
+    let end = set.get(keys::TEMPLATE_END_TIME).and_then(as_f64)?;
+    let stride = set.get(keys::TEMPLATE_STRIDE).and_then(as_f64)?;
+    let active_offset = set.get(keys::TEMPLATE_ACTIVE_OFFSET).and_then(as_f64);
+
+    if stride.is_nan() || stride <= 0.0 || end < start {
+        return None;
+    }
+    // Spec 12.3.4.1.3: the active offset magnitude may not exceed the stride.
+    if active_offset.is_some_and(|off| off.abs() > stride) {
+        return None;
+    }
+
+    let pattern = HashPattern::parse(&template)?;
+
+    // Promote to integers so a fractional stride doesn't accumulate float
+    // drift across the loop (C++ uses the same trick).
+    const PROMOTION: f64 = 10000.0;
+    let end_p = end * PROMOTION;
+    let stride_p = stride * PROMOTION;
+
+    let mut asset_paths = Vec::new();
+    let mut active = Vec::new();
+    let mut times = Vec::new();
+    let mut t = start * PROMOTION;
+    let mut index = 0usize;
+    // `+ 0.5` keeps the inclusive endpoint despite residual rounding.
+    while t <= end_p + 0.5 {
+        let clip_time = t / PROMOTION;
+        asset_paths.push(pattern.format(clip_time));
+        times.push((clip_time, clip_time));
+        let stage_time = match active_offset {
+            Some(off) => (t + off * PROMOTION) / PROMOTION,
+            None => clip_time,
+        };
+        active.push((stage_time, index));
+        index += 1;
+        t += stride_p;
+    }
+
+    if asset_paths.is_empty() {
+        return None;
+    }
+    active.sort_by(|a, b| a.0.total_cmp(&b.0));
+    times.sort_by(|a, b| a.0.total_cmp(&b.0));
+    Some((asset_paths, active, times))
+}
+
+/// A parsed `templateAssetPath` pattern: a prefix, one or two adjacent
+/// `#`-groups (integer, optionally followed by a subinteger group), and
+/// a suffix. Per spec the groups must be adjacent and number one or two.
+struct HashPattern {
+    prefix: String,
+    int_width: usize,
+    /// Width of the subinteger group, when the pattern has two groups.
+    frac_width: Option<usize>,
+    suffix: String,
+}
+
+impl HashPattern {
+    /// Parse `path/basename.###.usd` or `path/basename.##.##.usd`.
+    /// Returns `None` when there is no `#`-group, more than two groups,
+    /// or stray `#` outside the (adjacent) groups.
+    fn parse(template: &str) -> Option<HashPattern> {
+        let first = template.find('#')?;
+        let prefix = template[..first].to_string();
+        let rest = &template[first..];
+
+        // First (integer) group.
+        let int_width = rest.chars().take_while(|&c| c == '#').count();
+        let after_int = &rest[int_width..];
+
+        // Optional `.<##...>` subinteger group immediately following.
+        let (frac_width, suffix) = if let Some(dot_rest) = after_int.strip_prefix('.') {
+            if dot_rest.starts_with('#') {
+                let frac_width = dot_rest.chars().take_while(|&c| c == '#').count();
+                (Some(frac_width), dot_rest[frac_width..].to_string())
+            } else {
+                (None, after_int.to_string())
+            }
+        } else {
+            (None, after_int.to_string())
+        };
+
+        // Spec: hash groups must be adjacent and number one or two — any
+        // further `#` in the suffix means a malformed (3+ group) pattern.
+        if suffix.contains('#') {
+            return None;
+        }
+
+        Some(HashPattern {
+            prefix,
+            int_width,
+            frac_width,
+            suffix,
+        })
+    }
+
+    /// Substitute `time` into the pattern. Integer group zero-pads to the
+    /// hash count (widening when the value needs more digits); the
+    /// subinteger group is fixed-width fractional precision.
+    fn format(&self, time: f64) -> String {
+        let body = match self.frac_width {
+            // Two groups: `<int>.<frac>` at the given widths (spec example
+            // `foo.#.###.usd` @ 1.15 -> `foo.1.150.usd`).
+            Some(frac_width) => {
+                let rendered = format!("{:.*}", frac_width, time);
+                let (int_part, frac_part) = rendered.split_once('.').unwrap_or((rendered.as_str(), ""));
+                let neg = int_part.starts_with('-');
+                let digits = int_part.trim_start_matches('-');
+                let padded = format!("{:0>width$}", digits, width = self.int_width);
+                let sign = if neg { "-" } else { "" };
+                format!("{sign}{padded}.{frac_part}")
+            }
+            // One group: zero-padded integer (spec example `foo.###.usd`
+            // @ 12 -> `foo.012.usd`).
+            None => format!("{:0width$}", time.round() as i64, width = self.int_width),
+        };
+        format!("{}{}{}", self.prefix, body, self.suffix)
+    }
+}
+
 fn as_string(value: &Value) -> Option<String> {
     match value {
         Value::String(s) | Value::Token(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Extracts a scalar `f64` from the numeric template-timing fields,
+/// which may be authored as `double`, `float`, or integer.
+fn as_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Double(d) => Some(*d),
+        Value::Float(f) => Some(*f as f64),
+        Value::Int(i) => Some(*i as f64),
+        Value::Int64(i) => Some(*i as f64),
+        Value::Half(h) => Some(h.to_f32() as f64),
         _ => None,
     }
 }
@@ -213,6 +391,120 @@ fn as_pairs(value: &Value) -> Vec<(f64, f64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Template hash substitution (clipsAPI.h doc examples) ──────────────
+
+    #[test]
+    fn hash_substitution_integer() {
+        // foo.##.usd  @ 12  => foo.12.usd
+        assert_eq!(HashPattern::parse("foo.##.usd").unwrap().format(12.0), "foo.12.usd");
+        // foo.###.usd @ 12  => foo.012.usd
+        assert_eq!(HashPattern::parse("foo.###.usd").unwrap().format(12.0), "foo.012.usd");
+        // foo.#.usd   @ 333 => foo.333.usd
+        assert_eq!(HashPattern::parse("foo.#.usd").unwrap().format(333.0), "foo.333.usd");
+    }
+
+    #[test]
+    fn hash_substitution_subinteger() {
+        // foo.#.###.usd @ 1.15 => foo.1.150.usd
+        assert_eq!(
+            HashPattern::parse("foo.#.###.usd").unwrap().format(1.15),
+            "foo.1.150.usd"
+        );
+        // foo.#.##.usd  @ 1.1  => foo.1.10.usd
+        assert_eq!(HashPattern::parse("foo.#.##.usd").unwrap().format(1.1), "foo.1.10.usd");
+    }
+
+    #[test]
+    fn hash_pattern_rejects_three_groups() {
+        assert!(HashPattern::parse("foo.#.#.#.usd").is_none());
+        assert!(HashPattern::parse("foo.usd").is_none());
+    }
+
+    #[test]
+    fn template_expands_to_explicit_clip_set() {
+        use std::collections::HashMap;
+        let mut set = HashMap::new();
+        set.insert(
+            keys::TEMPLATE_ASSET_PATH.to_string(),
+            Value::AssetPath("clip.##.usd".into()),
+        );
+        set.insert(keys::TEMPLATE_START_TIME.to_string(), Value::Double(101.0));
+        set.insert(keys::TEMPLATE_END_TIME.to_string(), Value::Double(103.0));
+        set.insert(keys::TEMPLATE_STRIDE.to_string(), Value::Double(1.0));
+
+        let parsed = ClipSet::parse_one("default", &set).expect("template set");
+        assert_eq!(
+            parsed.asset_paths,
+            vec![
+                "clip.101.usd".to_string(),
+                "clip.102.usd".to_string(),
+                "clip.103.usd".to_string()
+            ],
+        );
+        assert_eq!(parsed.active, vec![(101.0, 0), (102.0, 1), (103.0, 2)]);
+        assert_eq!(parsed.times, vec![(101.0, 101.0), (102.0, 102.0), (103.0, 103.0)]);
+    }
+
+    #[test]
+    fn template_active_offset_shifts_active_times() {
+        use std::collections::HashMap;
+        let mut set = HashMap::new();
+        set.insert(
+            keys::TEMPLATE_ASSET_PATH.to_string(),
+            Value::AssetPath("c.#.usd".into()),
+        );
+        set.insert(keys::TEMPLATE_START_TIME.to_string(), Value::Double(0.0));
+        set.insert(keys::TEMPLATE_END_TIME.to_string(), Value::Double(2.0));
+        set.insert(keys::TEMPLATE_STRIDE.to_string(), Value::Double(1.0));
+        set.insert(keys::TEMPLATE_ACTIVE_OFFSET.to_string(), Value::Double(-0.5));
+
+        let parsed = ClipSet::parse_one("default", &set).expect("template set");
+        // clipTimes unchanged; active stage times shifted by the offset.
+        assert_eq!(parsed.active, vec![(-0.5, 0), (0.5, 1), (1.5, 2)]);
+        assert_eq!(parsed.times, vec![(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]);
+    }
+
+    #[test]
+    fn template_rejects_invalid_metadata() {
+        use std::collections::HashMap;
+        let base = |off: f64, stride: f64| {
+            let mut set = HashMap::new();
+            set.insert(
+                keys::TEMPLATE_ASSET_PATH.to_string(),
+                Value::AssetPath("c.#.usd".into()),
+            );
+            set.insert(keys::TEMPLATE_START_TIME.to_string(), Value::Double(0.0));
+            set.insert(keys::TEMPLATE_END_TIME.to_string(), Value::Double(2.0));
+            set.insert(keys::TEMPLATE_STRIDE.to_string(), Value::Double(stride));
+            set.insert(keys::TEMPLATE_ACTIVE_OFFSET.to_string(), Value::Double(off));
+            set
+        };
+        // |activeOffset| > stride is rejected (spec 12.3.4.1.3).
+        assert!(ClipSet::parse_one("default", &base(2.0, 1.0)).is_none());
+        // Non-positive stride is rejected.
+        assert!(ClipSet::parse_one("default", &base(0.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn explicit_asset_paths_win_over_template() {
+        use std::collections::HashMap;
+        let mut set = HashMap::new();
+        set.insert(
+            keys::ASSET_PATHS.to_string(),
+            Value::StringVec(vec!["explicit.usd".into()]),
+        );
+        set.insert(
+            keys::TEMPLATE_ASSET_PATH.to_string(),
+            Value::AssetPath("c.#.usd".into()),
+        );
+        set.insert(keys::TEMPLATE_START_TIME.to_string(), Value::Double(0.0));
+        set.insert(keys::TEMPLATE_END_TIME.to_string(), Value::Double(2.0));
+        set.insert(keys::TEMPLATE_STRIDE.to_string(), Value::Double(1.0));
+
+        let parsed = ClipSet::parse_one("default", &set).expect("explicit set");
+        assert_eq!(parsed.asset_paths, vec!["explicit.usd".to_string()]);
+    }
 
     fn clip_set(active: Vec<(f64, usize)>, times: Vec<(f64, f64)>) -> ClipSet {
         ClipSet {

--- a/src/pcp/clip.rs
+++ b/src/pcp/clip.rs
@@ -181,20 +181,23 @@ impl ClipSet {
     /// every `active` and `times` entry while leaving the clip-time targets and
     /// asset paths untouched. A template-derived schedule is produced in clip
     /// time and brought into stage time here; explicit `active`/`times` are
-    /// retimed as they compose. Re-sorts so a negative scale keeps the stage
-    /// ordering the lookups rely on.
+    /// retimed as they compose.
     pub(crate) fn retime_stage_times(&mut self, offset: LayerOffset) {
         if offset.is_identity() {
             return;
         }
         for (stage, _) in &mut self.active {
-            *stage = offset.offset + offset.scale * *stage;
+            *stage = offset.apply(*stage);
         }
         for (stage, _) in &mut self.times {
-            *stage = offset.offset + offset.scale * *stage;
+            *stage = offset.apply(*stage);
         }
-        self.active.sort_by(|a, b| a.0.total_cmp(&b.0));
-        self.times.sort_by(|a, b| a.0.total_cmp(&b.0));
+        // A positive scale preserves the existing stage ordering; only a
+        // negative scale (time reversal) needs a re-sort.
+        if offset.scale < 0.0 {
+            self.active.sort_by(|a, b| a.0.total_cmp(&b.0));
+            self.times.sort_by(|a, b| a.0.total_cmp(&b.0));
+        }
     }
 }
 
@@ -284,7 +287,7 @@ fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
     // lead/trail range maps linearly to clip time instead of clamping to the
     // first or last clip time (spec 12.3.4.1.3, matching C++ derivation).
     if let Some(off) = active_offset {
-        let front = (start * PROMOTION - off.abs() * PROMOTION) / PROMOTION;
+        let front = start - off.abs();
         times.push((front, front));
     }
 
@@ -305,7 +308,7 @@ fn expand_template(set: &HashMap<String, Value>) -> Option<TemplateExpansion> {
     }
 
     if let Some(off) = active_offset {
-        let back = (end_p + off.abs() * PROMOTION) / PROMOTION;
+        let back = end + off.abs();
         times.push((back, back));
     }
 

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -578,6 +578,11 @@ impl PrimIndex {
         let mut blocked_sets: HashSet<String> = HashSet::new();
         let mut asset_layers: HashMap<String, usize> = HashMap::new();
         let mut manifest_layers: HashMap<String, usize> = HashMap::new();
+        // Sets with explicit `assetPaths` (whose `active`/`times` are retimed
+        // as they compose) versus the offset of a template set's authoring
+        // node (whose schedule is derived later and retimed afterwards).
+        let mut explicit_sets: HashSet<String> = HashSet::new();
+        let mut template_offsets: HashMap<String, LayerOffset> = HashMap::new();
 
         for node in self.nodes() {
             let Some(value) = stack
@@ -612,8 +617,12 @@ impl PrimIndex {
                             // Both the explicit `assetPaths` and a template's
                             // `templateAssetPath` anchor their relative clip
                             // asset paths against the layer that authored them.
-                            if field == clip::keys::ASSET_PATHS || field == clip::keys::TEMPLATE_ASSET_PATH {
+                            if field == clip::keys::ASSET_PATHS {
                                 asset_layers.insert(set_name.clone(), node.layer_index);
+                                explicit_sets.insert(set_name.clone());
+                            } else if field == clip::keys::TEMPLATE_ASSET_PATH {
+                                asset_layers.insert(set_name.clone(), node.layer_index);
+                                template_offsets.insert(set_name.clone(), node.map_to_root.time_offset());
                             } else if field == clip::keys::MANIFEST_ASSET_PATH {
                                 manifest_layers.insert(set_name.clone(), node.layer_index);
                             }
@@ -634,9 +643,17 @@ impl PrimIndex {
 
         Ok(clip::ClipSet::parse_all(&clips, order.as_deref())
             .into_iter()
-            .filter_map(|set| {
+            .filter_map(|mut set| {
                 let asset_layer = asset_layers.get(&set.name).copied()?;
                 let manifest_layer = manifest_layers.get(&set.name).copied();
+                // Explicit `active`/`times` were retimed as they composed. A
+                // template schedule is derived in clip time, so retime its
+                // stage times here by the authoring node's offset.
+                if !explicit_sets.contains(&set.name) {
+                    if let Some(&offset) = template_offsets.get(&set.name) {
+                        set.retime_stage_times(offset);
+                    }
+                }
                 Some(clip::ResolvedClipSet {
                     set,
                     asset_layer,

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -1668,10 +1668,7 @@ fn retime_samples(samples: sdf::TimeSampleMap, offset: LayerOffset) -> sdf::Time
     if offset.is_identity() {
         return samples;
     }
-    samples
-        .into_iter()
-        .map(|(t, value)| (offset.offset + offset.scale * t, value))
-        .collect()
+    samples.into_iter().map(|(t, value)| (offset.apply(t), value)).collect()
 }
 
 /// Maps the stage-time component of clip `active`/`times` pairs through the
@@ -1684,7 +1681,7 @@ fn retime_clip_stage_times(value: Value, offset: LayerOffset) -> Value {
         Value::Vec2dVec(pairs) => Value::Vec2dVec(
             pairs
                 .into_iter()
-                .map(|[stage, data]| [offset.offset + offset.scale * stage, data])
+                .map(|[stage, data]| [offset.apply(stage), data])
                 .collect(),
         ),
         other => other,

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -609,7 +609,10 @@ impl PrimIndex {
                             } else {
                                 value
                             };
-                            if field == clip::keys::ASSET_PATHS {
+                            // Both the explicit `assetPaths` and a template's
+                            // `templateAssetPath` anchor their relative clip
+                            // asset paths against the layer that authored them.
+                            if field == clip::keys::ASSET_PATHS || field == clip::keys::TEMPLATE_ASSET_PATH {
                                 asset_layers.insert(set_name.clone(), node.layer_index);
                             } else if field == clip::keys::MANIFEST_ASSET_PATH {
                                 manifest_layers.insert(set_name.clone(), node.layer_index);

--- a/src/pcp/index.rs
+++ b/src/pcp/index.rs
@@ -614,14 +614,20 @@ impl PrimIndex {
                             } else {
                                 value
                             };
-                            // Both the explicit `assetPaths` and a template's
-                            // `templateAssetPath` anchor their relative clip
-                            // asset paths against the layer that authored them.
+                            // Relative clip asset paths anchor on the layer that
+                            // authored them. Explicit `assetPaths` win over a
+                            // template in parse_one, so they always set the
+                            // anchor, while `templateAssetPath` only sets it when
+                            // no explicit `assetPaths` has been composed — else a
+                            // weaker template layer would mis-anchor the explicit
+                            // paths the stronger layer authored.
                             if field == clip::keys::ASSET_PATHS {
                                 asset_layers.insert(set_name.clone(), node.layer_index);
                                 explicit_sets.insert(set_name.clone());
                             } else if field == clip::keys::TEMPLATE_ASSET_PATH {
-                                asset_layers.insert(set_name.clone(), node.layer_index);
+                                if !explicit_sets.contains(&set_name) {
+                                    asset_layers.insert(set_name.clone(), node.layer_index);
+                                }
                                 template_offsets.insert(set_name.clone(), node.map_to_root.time_offset());
                             } else if field == clip::keys::MANIFEST_ASSET_PATH {
                                 manifest_layers.insert(set_name.clone(), node.layer_index);

--- a/src/sdf/mod.rs
+++ b/src/sdf/mod.rs
@@ -135,6 +135,14 @@ impl LayerOffset {
         self.offset == 0.0 && self.scale == 1.0
     }
 
+    /// Applies this offset to a time value as `offset + scale * time` — the
+    /// retiming a layer offset performs on the time coordinate of samples and
+    /// clip schedules.
+    #[inline]
+    pub fn apply(&self, time: f64) -> f64 {
+        self.offset + self.scale * time
+    }
+
     /// Returns `true` if this offset is well-formed for composition:
     /// finite `offset` and a strictly positive, finite `scale`.
     ///


### PR DESCRIPTION
@mxpv, this finishes the two value-clip seams you left as TODOs after landing the clip core.

**Template clips** (`templateAssetPath` + start/end/stride/activeOffset) — expanded into explicit `assetPaths`/`active`/`times` at parse time, so the rest of the pipeline only ever sees explicit sets. Handles the `#`-pattern integer/sub-integer substitution and the active-offset shift.

**Missing values in a declared clip** (spec 12.3.4.6-7) — when the active clip has a gap for a manifest-declared attribute: fall to the manifest default, else interpolate across the surrounding clips when `interpolateMissingClipValues` is set, else a value block (which correctly stops the attribute from picking up weaker referenced samples).

Neither has a conformance asset in `vendor/` (the AOUSD reference skips both), so I followed the spec and the OpenUSD C++ and added hand-built fixtures. Two commits, one per seam. fmt + clippy clean.
