### PR TITLE
Add docstring to T_GENERATIVE_PROCEDURAL constant

### DIFF
--- a/src/schemas/proc/tokens.rs
+++ b/src/schemas/proc/tokens.rs
@@ -3,6 +3,7 @@
 //! Mirrors Pixar's `pxr/usd/usdProc/tokens.h`.
 
 // ── Concrete prim type names ────────────────────────────────────────
+/// Concrete prim type name for GenerativeProcedural.
 pub const T_GENERATIVE_PROCEDURAL: &str = "GenerativeProcedural";
 
 // ── GenerativeProcedural attribute names ────────────────────────────


### PR DESCRIPTION
## Problem Background

In the file `src/schemas/proc/tokens.rs`, the public constant `T_GENERATIVE_PROCEDURAL` only has a line comment, which is insufficient for proper documentation generation (e.g., via `cargo doc`) and can reduce API readability.

## Changes Made

Added a docstring comment to the constant: `/// Concrete prim type name for GenerativeProcedural.` This ensures the constant is properly documented in generated docs and improves code clarity.

## Verification

- Run `cargo doc` and inspect the generated documentation to confirm the docstring appears correctly.
- Review the code to ensure the added comment aligns with the existing documentation style in the repository.