### PR TITLE
Add SPDX `license` field (`MIT`) to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "openusd"
 version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/mxpv/openusd"
+license = "MIT"
 license-file = "LICENSE"
 exclude = ["/vendor", "/fixtures", "/docs", "/.github", "/.claude"]
 description = "Rust native USD library"


### PR DESCRIPTION
`Cargo.toml` declares the license via `license-file` only. This adds the SPDX `license = "MIT"` field so tooling that reads the SPDX expression — crates.io metadata, license scanners, `cargo-deny` — picks it up directly.

Both fields are valid together and complementary: `license` gives the SPDX identifier, and `license-file` keeps the full MIT text with its required copyright line (`Copyright (c) 2024 Maksym Pavlenko`). No change to the `LICENSE` file.

crates.io even [renders your license as `non-standard`](https://crates.io/crates/openusd/0.5.0) because of this, and `cargo-deny` emits a `no-license-field` warning for `openusd` — which `-D warnings` promotes to a hard error. A `[[licenses.clarify]]` entry resolves the license *expression* (to MIT, from the `LICENSE` text) but does not opt out of that lint, so downstream consumers currently have to pass `--allow no-license-field` on the CLI. Adding the SPDX field removes the need for that workaround.
