### PR TITLE
fix(pcp): materialize instance prototypes reached through a non-root reference

### DIFF
--- a/fixtures/instancing_ancestral_reference.usda
+++ b/fixtures/instancing_ancestral_reference.usda
@@ -1,0 +1,52 @@
+#usda 1.0
+(
+    doc = """Instancing reached through a reference on a non-root prim (spec 11.3.3).
+
+    /Inner/A is instanceable and references /Proto. Two outer prims bring /Inner
+    onto the stage: /Shallow references it directly, putting the instance at
+    /Shallow/A (namespace depth 2), while /Deep/G references it one level lower,
+    putting the instance at /Deep/G/A (namespace depth 3).
+
+    Nesting the prim that carries the outer reference must not change what
+    composes. The instanceable arc onto /Proto is authored at /Inner/A, whose own
+    namespace depth (2) is shallower than /Deep/G/A's stage depth (3), so it must
+    be told apart from the outer reference by where its arc was introduced
+    relative to the instance rather than by comparing that depth against the
+    instance's. Both instances bring in the same shared subtree, so they share one
+    prototype."""
+)
+
+def Scope "Proto"
+{
+    double protoAttr = 3.0
+
+    def Scope "ProtoChild"
+    {
+        double size = 7.0
+    }
+}
+
+def Scope "Inner"
+{
+    def Scope "A" (
+        instanceable = true
+        references = </Proto>
+    )
+    {
+    }
+}
+
+def Scope "Shallow" (
+    references = </Inner>
+)
+{
+}
+
+def Scope "Deep"
+{
+    def Scope "G" (
+        references = </Inner>
+    )
+    {
+    }
+}

--- a/fixtures/instancing_prototype_root_instanceable.usda
+++ b/fixtures/instancing_prototype_root_instanceable.usda
@@ -1,0 +1,41 @@
+#usda 1.0
+(
+    doc = """An instanceable opinion carried into the prototype (spec 11.3.3).
+
+    /Asset authors `instanceable = true` on itself, and /World/Place references
+    it, which is how a published asset usually declares that it wants to be
+    instanced. The opinion therefore arrives at /World/Place on the instanceable
+    arc itself rather than at the instance's own namespace, so it is shared
+    content the prototype keeps: /__Prototype_0 composes with
+    `instanceable = true` resolving true.
+
+    A prototype root is still not an instance — the opinion describes the prims
+    that share the prototype, not the prototype — so it must not mint a prototype
+    of its own, and its plain content must compose in place instead of redirecting
+    back through it."""
+)
+
+def Scope "Asset" (
+    instanceable = true
+    references = </Body>
+)
+{
+}
+
+def Scope "Body"
+{
+    double bodyAttr = 4.0
+
+    def Scope "BodyChild"
+    {
+    }
+}
+
+def Scope "World"
+{
+    def Scope "Place" (
+        references = </Asset>
+    )
+    {
+    }
+}

--- a/src/pcp/index_cache.rs
+++ b/src/pcp/index_cache.rs
@@ -1416,11 +1416,11 @@ impl IndexCache {
         let mut seen: HashSet<(Path, Path)> = HashSet::new();
         {
             let index = self.cached(resolved_prim);
-            for node in index.nodes() {
+            for (id, node) in index.nodes_with_ids() {
                 if node.arc != ArcType::Inherit || !node.has_specs() {
                     continue;
                 }
-                let class_path = node.path_at_introduction();
+                let class_path = index.graph().path_at_introduction(id);
                 let members = graph.layer_stack(node.layer_stack_id());
                 let class_layers: Vec<LayerId> = members.iter().map(|(l, _)| *l).collect();
                 let map = index.map_to_root_for_targets(node);
@@ -1601,7 +1601,8 @@ impl IndexCache {
         // The instance-local partition is keyed by the prim's own namespace depth
         // ([`PrimIndex::instance_local_nodes`]); empty when not dropping locals.
         let local = if drop_local {
-            index.instance_local_nodes(path.prim_element_count() as u16)
+            let depth = path.prim_element_count() as u16;
+            index.instance_local_nodes(depth, depth)
         } else {
             Vec::new()
         };
@@ -2057,7 +2058,7 @@ impl IndexCache {
         // implied classes. Runs before deriving instance state below so the
         // suppressed opinions are already inert.
         if let Some(depth) = parent_ctx.instance_depth {
-            index.mark_instance_local_inert(depth);
+            index.mark_instance_local_inert(path.prim_element_count() as u16, depth);
         }
 
         // This prim is an instance when its composition declares
@@ -3240,11 +3241,9 @@ def "Scope"
     /// A reference nested inside the prototype (below the instanceable arc) is
     /// shared (spec 11.3.3): its opinions reach the instance through the direct
     /// instanceable arc, so they survive in the instance's child names and
-    /// descendants. The nested arc is authored in the referenced namespace, so
-    /// its namespace depth is shallow — a flat `namespace_depth < instance_depth`
-    /// test would wrongly drop it as an outer reference; the structural trunk
-    /// partition keeps it because its parent (the prototype root) is not on the
-    /// instance trunk.
+    /// descendants. The structural trunk partition keeps it shared on two counts:
+    /// the arc is authored on the prim it targets rather than above the instance,
+    /// and its parent (the prototype root) is not on the instance trunk.
     #[test]
     fn nested_reference_in_prototype_shared() -> Result<()> {
         let root = format!("{}/fixtures/instancing_nested_reference.usda", manifest_dir());
@@ -3278,6 +3277,94 @@ def "Scope"
             cache.value_at(&graph, &sdf::path("/World/Inst.otherAttr")?, 0.0, &interp)?,
             Some(Value::Double(5.0)),
             "nested-reference attribute survives on the instance root"
+        );
+        Ok(())
+    }
+
+    /// An instanceable prim reached through a reference on a non-root prim
+    /// materializes the same prototype as one reached through a reference on a
+    /// root prim (spec 11.3.3): the depth of the prim carrying the outer
+    /// reference does not change what composes. The instanceable arc is authored
+    /// in the referenced namespace, so its namespace depth is shallower than the
+    /// nested instance's stage depth and must be told apart from the outer
+    /// reference by where its arc was introduced relative to the instance.
+    #[test]
+    fn ancestral_reference_prototype() -> Result<()> {
+        let root = format!("{}/fixtures/instancing_ancestral_reference.usda", manifest_dir());
+        let (graph, mut cache) = single_layer_stack(&root);
+        let interp = |_: &sdf::TimeSampleMap, _: f64| None;
+
+        // The instance one level below the root and the instance at the root are
+        // the same shared composition, so they share a single prototype.
+        let shallow = cache.prototype_of(&graph, &sdf::path("/Shallow/A")?)?;
+        let deep = cache.prototype_of(&graph, &sdf::path("/Deep/G/A")?)?;
+        assert_eq!(shallow, deep, "nesting the referencing prim must not change the key");
+        let proto = deep.expect("nested instance resolves a prototype");
+        assert_eq!(cache.prototypes(), vec![proto.clone()]);
+
+        // The prototype materializes: the instanceable arc stayed shared, so the
+        // referenced subtree is there rather than an empty root.
+        assert_eq!(cache.prim_children(&graph, &proto)?, vec![Token::from("ProtoChild")]);
+        assert_eq!(
+            cache.value_at(&graph, &sdf::path("/__Prototype_0.protoAttr")?, 0.0, &interp)?,
+            Some(Value::Double(3.0)),
+        );
+
+        // And the nested instance's own namespace serves that shared content.
+        assert_eq!(
+            cache.prim_children(&graph, &sdf::path("/Deep/G/A")?)?,
+            vec![Token::from("ProtoChild")]
+        );
+        assert_eq!(
+            cache.value_at(&graph, &sdf::path("/Deep/G/A/ProtoChild.size")?, 0.0, &interp)?,
+            Some(Value::Double(7.0)),
+        );
+        Ok(())
+    }
+
+    /// A prototype root whose shared content carries `instanceable = true` — the
+    /// opinion an asset authors on the prim its referencing layer targets — is
+    /// still not an instance (spec 11.3.3). The opinion describes the prims that
+    /// share the prototype, so the prototype keeps it as content but mints no
+    /// prototype of its own and composes its plain content in place.
+    #[test]
+    fn prototype_root_instanceable() -> Result<()> {
+        let root = format!(
+            "{}/fixtures/instancing_prototype_root_instanceable.usda",
+            manifest_dir()
+        );
+        let (graph, mut cache) = single_layer_stack(&root);
+        let interp = |_: &sdf::TimeSampleMap, _: f64| None;
+
+        let proto = cache
+            .prototype_of(&graph, &sdf::path("/World/Place")?)?
+            .expect("the referencing prim is an instance");
+
+        // The opinion resolves true on the prototype root, yet the root is not an
+        // instance and so mints nothing further.
+        assert_eq!(
+            cache
+                .cached(&proto)
+                .resolve_field(FieldKey::Instanceable.as_str(), &graph, None)?,
+            Some(Value::Bool(true)),
+            "the instanceable opinion is shared content of the prototype"
+        );
+        assert!(
+            !cache.is_instance(&graph, &proto)?,
+            "a prototype root is never an instance"
+        );
+        assert_eq!(cache.prototype_of(&graph, &proto)?, None);
+        assert_eq!(cache.prototypes(), vec![proto.clone()]);
+
+        // Its content composes in place rather than redirecting back through it.
+        assert_eq!(cache.prim_children(&graph, &proto)?, vec![Token::from("BodyChild")]);
+        assert_eq!(
+            cache.value_at(&graph, &sdf::path("/__Prototype_0.bodyAttr")?, 0.0, &interp)?,
+            Some(Value::Double(4.0)),
+        );
+        assert_eq!(
+            cache.value_at(&graph, &sdf::path("/World/Place.bodyAttr")?, 0.0, &interp)?,
+            Some(Value::Double(4.0)),
         );
         Ok(())
     }

--- a/src/pcp/instancing.rs
+++ b/src/pcp/instancing.rs
@@ -271,7 +271,7 @@ impl PrototypeRegistry {
 /// rules, already re-rooted onto its own path (`LoadRules::make_relative_to`),
 /// so two instances also only share a prototype when their load state agrees.
 fn instance_key(index: &PrimIndex, instance_depth: u16, load_rules: LoadRules) -> InstanceKey {
-    let local = index.instance_local_nodes(instance_depth);
+    let local = index.instance_local_nodes(instance_depth, instance_depth);
     let mut arcs = Vec::new();
     let mut selections = Vec::new();
     for (id, node) in index.nodes_with_ids() {
@@ -333,6 +333,19 @@ impl IndexCache {
     /// the strongest `instanceable` opinion is `true` and the prim has at
     /// least one composition arc.
     ///
+    /// A `/__Prototype_N` root is never an instance, whatever its composed
+    /// `instanceable` opinion says. The opinion is routinely `true` there: an
+    /// asset commonly authors `instanceable = true` on the very prim its
+    /// referencing layer targets, so the opinion arrives on the instanceable arc
+    /// itself and is shared content the prototype must keep. It describes the
+    /// instances that share this prototype, not the prototype, which stands
+    /// outside the instance namespace as the single composition those instances
+    /// redirect onto. Exempting the root here is also what lets
+    /// [`Self::redirect_anchor`] compose plain prototype content in place: were
+    /// the root an instance, its own descendants would redirect back through it.
+    /// A *nested* instance inside a prototype namespace is not a prototype root,
+    /// so it still resolves as an instance and mints its own prototype.
+    ///
     /// Reads `instanceable` off the index that actually composes `path` — for an
     /// instance proxy that is the shared `/__Prototype_N` index, reached through
     /// [`Self::effective_path`], not a throwaway per-instance copy. So checking
@@ -343,7 +356,7 @@ impl IndexCache {
     /// to a shorter path and bottoms out at the root, so the recursion
     /// terminates.
     pub(crate) fn is_instance(&mut self, graph: &LayerGraph, path: &Path) -> Result<bool> {
-        if path.is_abs_root() {
+        if path.is_abs_root() || self.is_prototype(path) {
             return Ok(false);
         }
         let composed = self.effective_path(graph, path)?;
@@ -403,12 +416,12 @@ impl IndexCache {
     /// — and its namespace is re-anchored onto the prototype root.
     ///
     /// The prototype root's child context is seeded as a namespace root with
-    /// `instance_depth` cleared (it is not itself an instance — its `instanceable`
-    /// opinion is inert), so a descendant built by deepening this graph composes
-    /// as prototype content rather than instance-suppressed. Every instance
-    /// proxy redirects onto this namespace through [`Self::redirect_anchor`], so
-    /// the prototype subtree is the one place a set of identical instances'
-    /// descendants compose.
+    /// `instance_depth` cleared — a prototype root is not an instance (see
+    /// [`Self::is_instance`]) — so a descendant built by deepening this graph
+    /// composes as prototype content rather than instance-suppressed. Every
+    /// instance proxy redirects onto this namespace through
+    /// [`Self::redirect_anchor`], so the prototype subtree is the one place a set
+    /// of identical instances' descendants compose.
     //
     // TODO(rayon): distinct prototypes (distinct instancing keys) compose
     // independent subtrees, so they can be materialized in parallel. The
@@ -417,7 +430,8 @@ impl IndexCache {
     // insert) and the shared `LayerGraph` handed to workers as `&`/`Arc`.
     fn materialize_prototype(&mut self, graph: &LayerGraph, canonical: &Path, prototype: &Path) {
         let mut index = self.cached(canonical).clone();
-        index.mark_instance_local_inert(canonical.prim_element_count() as u16);
+        let depth = canonical.prim_element_count() as u16;
+        index.mark_instance_local_inert(depth, depth);
         // Re-anchor the seeding instance's composed namespace onto the prototype
         // root so the root's own target translation lands in the prototype
         // namespace, not the canonical instance's.
@@ -426,20 +440,6 @@ impl IndexCache {
         let (mut context, _) = index.context_for_children(graph, &self.root_parent_context());
         context.instance_depth = None;
 
-        // `redirect_anchor` composes a prim in place when it has no enclosing
-        // instance, and relies on the prototype root never being one: its
-        // `instanceable` opinion must read inert here (the root node is
-        // instance-local, so `mark_instance_local_inert` above drops it).
-        // Otherwise plain prototype content would wrongly redirect and the root
-        // would self-redirect. Guard the invariant against a future change to the
-        // instance-local partition.
-        debug_assert!(
-            !matches!(
-                index.resolve_field(FieldKey::Instanceable.as_str(), graph, None),
-                Ok(Some(Value::Bool(true)))
-            ),
-            "materialized prototype root's instanceable must be inert",
-        );
         self.cache_index(graph, prototype, index, context, Vec::new(), ExprVarDeps::default());
     }
 
@@ -505,8 +505,8 @@ impl IndexCache {
     /// (`/A/child`) and inside a prototype namespace under a *nested* instance
     /// (`/__Prototype_N/.../NestedInstance/child`): each has an enclosing
     /// instance. Prototype content not under a nested instance has no enclosing
-    /// instance (the prototype root's `instanceable` opinion is inert), so it is
-    /// in a prototype, not a proxy.
+    /// instance (a prototype root is never one; see [`Self::is_instance`]), so it
+    /// is in a prototype, not a proxy.
     ///
     /// A proxy stands in for a real prim in the shared prototype, so a path under
     /// an instance that composes to no prim (e.g. a misspelled child) is not a
@@ -587,10 +587,9 @@ impl IndexCache {
     ///
     /// A prim with no enclosing instance composes in place: an instance *root*
     /// (spec 11.3.3 lets it override property values), the prototype root and its
-    /// plain content (the materialized prototype root's `instanceable` opinion is
-    /// inert, so it is never an enclosing instance — the shared subtree lives
-    /// there, composed by deepening the materialized index), and every
-    /// non-instanced prim.
+    /// plain content (a prototype root is never an instance, so never an enclosing
+    /// one; see [`Self::is_instance`] — the shared subtree lives there, composed by
+    /// deepening the materialized index), and every non-instanced prim.
     pub(super) fn redirect_anchor(&mut self, graph: &LayerGraph, prim: &Path) -> Result<Option<(Path, Path)>> {
         if let Some(instance) = self.enclosing_instance(graph, prim)? {
             let (_canonical, prototype) = self.register_prototype(graph, &instance)?;

--- a/src/pcp/prim_graph.rs
+++ b/src/pcp/prim_graph.rs
@@ -159,7 +159,7 @@ pub struct Node {
     /// `PcpNode::GetNamespaceDepth`): the prim-element count of the parent
     /// site's path when this node was added. Used by implied inherits/specializes
     /// that propagate toward the root, and by
-    /// [`depth_below_introduction`](Self::depth_below_introduction).
+    /// [`PrimIndexGraph::depth_below_introduction`].
     pub(crate) namespace_depth: u16,
     /// This node's index among the same-arc-type siblings at its origin (C++
     /// `GetSiblingNumAtOrigin`): the arc number a class-based arc was authored
@@ -290,31 +290,6 @@ impl Node {
     /// Namespace depth at which the introducing arc was authored.
     pub fn namespace_depth(&self) -> u16 {
         self.namespace_depth
-    }
-
-    /// Number of namespace levels this node's site sits below the level at which
-    /// its arc was introduced (C++ `PcpNode::GetDepthBelowIntroduction`): the
-    /// node path's prim-element count minus its namespace depth. A direct arc
-    /// node has depth 0; a node reached by extending that arc to a child has 1,
-    /// and so on. Implied-class propagation uses this to tell a class's true
-    /// namespace descendants from the arc that continues an ancestral chain.
-    pub(crate) fn depth_below_introduction(&self) -> u16 {
-        (self.path.prim_element_count() as u16).saturating_sub(self.namespace_depth)
-    }
-
-    /// This node's path at the level where its arc was introduced (C++
-    /// `PcpNode::GetPathAtIntroduction`): the node path with its
-    /// [`depth_below_introduction`](Self::depth_below_introduction) trailing
-    /// elements stripped.
-    pub(crate) fn path_at_introduction(&self) -> Path {
-        let mut path = self.path.clone();
-        for _ in 0..self.depth_below_introduction() {
-            match path.parent() {
-                Some(parent) => path = parent,
-                None => break,
-            }
-        }
-        path
     }
 
     /// Whether any layer in this node's stack authors a spec at its path (C++
@@ -785,6 +760,55 @@ impl PrimIndexGraph {
         self.nodes[id.idx()].origin.unwrap_or(NodeId::INVALID)
     }
 
+    /// Number of namespace levels a node's site sits below the level at which its
+    /// arc was introduced (C++ `PcpNode::GetDepthBelowIntroduction`): the
+    /// prim-element count of the *parent* site's path minus this node's
+    /// [`namespace_depth`](Node::namespace_depth). A direct arc node has depth 0;
+    /// a node reached by extending that arc into a child has 1, and so on.
+    ///
+    /// The measurement is anchored on the parent because a node's namespace depth
+    /// records the parent site's depth at arc introduction, and deepening a graph
+    /// to a child appends the same name to every site
+    /// ([`append_child_name_to_all_sites`](Self::append_child_name_to_all_sites)).
+    /// The parent's path therefore grows by exactly the number of levels the graph
+    /// has been deepened since the arc was introduced, whatever namespace depth
+    /// the arc's own target happens to sit at. A reference or payload whose target
+    /// is shallower or deeper than the prim that authored it — `@ref@</Deep/Target>`
+    /// on a root prim, say — is the case that distinguishes this from measuring on
+    /// the node's own path.
+    ///
+    /// A root node has no parent and so is never below its introduction.
+    pub(crate) fn depth_below_introduction(&self, id: NodeId) -> u16 {
+        let parent = self.parent_of(id);
+        if !parent.is_valid() {
+            return 0;
+        }
+        (self.nodes[parent.idx()].path.prim_element_count() as u16).saturating_sub(self.nodes[id.idx()].namespace_depth)
+    }
+
+    /// Whether a node's arc was introduced above the prim this graph composes
+    /// (C++ `PcpNodeRef::IsDueToAncestor`), rather than authored on the prim
+    /// itself: its [`depth_below_introduction`](Self::depth_below_introduction) is
+    /// non-zero.
+    pub(crate) fn is_due_to_ancestor(&self, id: NodeId) -> bool {
+        self.depth_below_introduction(id) > 0
+    }
+
+    /// A node's path at the level where its arc was introduced (C++
+    /// `PcpNode::GetPathAtIntroduction`): the node path with its
+    /// [`depth_below_introduction`](Self::depth_below_introduction) trailing
+    /// elements stripped.
+    pub(crate) fn path_at_introduction(&self, id: NodeId) -> Path {
+        let mut path = self.nodes[id.idx()].path.clone();
+        for _ in 0..self.depth_below_introduction(id) {
+            match path.parent() {
+                Some(parent) => path = parent,
+                None => break,
+            }
+        }
+        path
+    }
+
     /// Whether two nodes carry the same site: same layer stack and path
     /// (C++ `GetSite() ==`).
     pub(crate) fn same_site(&self, a: NodeId, b: NodeId) -> bool {
@@ -874,10 +898,10 @@ impl PrimIndexGraph {
             instance = self.origin_of(instance);
         }
         let mut class_node = NodeId::INVALID;
-        let depth = self.nodes[instance.idx()].depth_below_introduction();
+        let depth = self.depth_below_introduction(instance);
         while instance.is_valid()
             && is_class_based_arc(self.arc_of(instance))
-            && self.nodes[instance.idx()].depth_below_introduction() == depth
+            && self.depth_below_introduction(instance) == depth
         {
             class_node = instance;
             let parent = self.parent_of(instance);
@@ -1007,31 +1031,73 @@ impl std::ops::Deref for PrimIndexGraph {
 mod tests {
     use super::*;
 
-    fn node(path: &str, namespace_depth: u16) -> Node {
-        let mut n = Node::new(
-            LayerStackId::from_raw(1),
-            LayerId::from_raw(0),
-            Path::from(path),
-            ArcType::Inherit,
-            MapFunction::identity(),
+    /// A graph rooted at `local` carrying a single `arc` node onto `target`, as
+    /// [`add_child`](PrimIndexGraph::add_child) would build it, then deepened by
+    /// each name in `deepen`.
+    fn arc_graph(local: &str, arc: ArcType, target: &str, deepen: &[&str]) -> (PrimIndexGraph, NodeId) {
+        let stack = LayerStackId::from_raw(1);
+        let layer = LayerId::from_raw(0);
+        let mut g = PrimIndexGraph::default();
+        g.init_root(stack, layer, Path::from(local));
+        let root = g.add_child(
+            NodeId::INVALID,
+            stack,
+            layer,
+            Path::from(local),
+            ArcType::Root,
             MapFunction::identity(),
             false,
         );
-        n.namespace_depth = namespace_depth;
-        n
+        let id = g.add_child(
+            root,
+            stack,
+            layer,
+            Path::from(target),
+            arc,
+            MapFunction::identity(),
+            false,
+        );
+        let mut prim = Path::from(local);
+        for name in deepen {
+            prim = prim.append_path(*name).expect("child path");
+            g.append_child_name_to_all_sites(&prim);
+        }
+        (g, id)
     }
 
     #[test]
     fn introduction_depth_and_path() {
         // An arc introduced at the prim's own level: depth 0, path unchanged.
-        let direct = node("/Model", 1);
-        assert_eq!(direct.depth_below_introduction(), 0);
-        assert_eq!(direct.path_at_introduction(), Path::from("/Model"));
+        let (g, id) = arc_graph("/Model", ArcType::Inherit, "/_class_Model", &[]);
+        assert_eq!(g.depth_below_introduction(id), 0);
+        assert!(!g.is_due_to_ancestor(id));
+        assert_eq!(g.path_at_introduction(id), Path::from("/_class_Model"));
 
-        // The same arc extended two levels into a child: depth 2, and the
+        // The same arc deepened two levels into a descendant: depth 2, and the
         // introduction path strips the two trailing elements.
-        let extended = node("/Model/Rig/Anim", 1);
-        assert_eq!(extended.depth_below_introduction(), 2);
-        assert_eq!(extended.path_at_introduction(), Path::from("/Model"));
+        let (g, id) = arc_graph("/Model", ArcType::Inherit, "/_class_Model", &["Rig", "Anim"]);
+        assert_eq!(g.depth_below_introduction(id), 2);
+        assert!(g.is_due_to_ancestor(id));
+        assert_eq!(g.path_at_introduction(id), Path::from("/_class_Model"));
+    }
+
+    /// The depth is measured on the introducing parent's site, so an arc whose
+    /// target sits at a different namespace depth than the prim that authored it
+    /// still reports the number of levels the graph has been deepened.
+    #[test]
+    fn introduction_depth_uneven_target() {
+        // A reference from a depth-2 prim onto a depth-1 target.
+        let (g, id) = arc_graph("/World/G", ArcType::Reference, "/Ref", &[]);
+        assert_eq!(g.depth_below_introduction(id), 0);
+        assert_eq!(g.path_at_introduction(id), Path::from("/Ref"));
+
+        let (g, id) = arc_graph("/World/G", ArcType::Reference, "/Ref", &["A"]);
+        assert_eq!(g.depth_below_introduction(id), 1);
+        assert_eq!(g.path_at_introduction(id), Path::from("/Ref"));
+
+        // And the reverse: a depth-1 prim referencing a depth-2 target.
+        let (g, id) = arc_graph("/World", ArcType::Reference, "/Ref/Inner", &["A"]);
+        assert_eq!(g.depth_below_introduction(id), 1);
+        assert_eq!(g.path_at_introduction(id), Path::from("/Ref/Inner"));
     }
 }

--- a/src/pcp/prim_index.rs
+++ b/src/pcp/prim_index.rs
@@ -429,6 +429,12 @@ impl PrimIndex {
     /// namespace, which an instance's child names, descendants, and instance key
     /// must drop.
     ///
+    /// `prim_depth` is the namespace depth of the prim this index composes, which
+    /// is `instance_depth` for the instance prim's own index and deeper for a
+    /// descendant composed inside the instance. Both are needed because a node
+    /// records how far below its arc's introduction its site sits, not the
+    /// absolute level the arc was introduced at; the level follows from the two.
+    ///
     /// This is the C++ `!PcpNodeRef::HasTransitiveDirectDependency` partition.
     /// Instance-local = the local root plus the contiguous *trunk* of ancestral
     /// references/payloads the instance prim is nested under — the outer arcs
@@ -437,17 +443,19 @@ impl PrimIndex {
     /// own depth) and everything below it stay shared, as do the implied classes
     /// (class-based arcs).
     ///
-    /// Trunk membership is structural, not a flat depth test: a node is on the
-    /// trunk only if it is a reference/payload introduced above the instance
-    /// (`namespace_depth < instance_depth`) *and* its parent is also on the
-    /// trunk. The parent check is what keeps a reference or payload nested
-    /// *inside* the prototype (below the instanceable arc) shared — such an arc
-    /// is authored in the referenced layer's namespace, so its `namespace_depth`
-    /// is shallow and would otherwise be misread as an outer arc.
+    /// Trunk membership is structural: a node is on the trunk only if its arc was
+    /// introduced strictly above the instance *and* its parent is also on the
+    /// trunk. The parent check makes the trunk contiguous, which is what keeps a
+    /// reference or payload nested inside the prototype shared along with the
+    /// implied classes an outer arc helped derive.
     ///
     /// The arena is append-only with each node's parent preceding it, so one
     /// forward pass propagates trunk-ness parent→child.
-    pub(crate) fn instance_local_nodes(&self, instance_depth: u16) -> Vec<bool> {
+    pub(crate) fn instance_local_nodes(&self, prim_depth: u16, instance_depth: u16) -> Vec<bool> {
+        // An arc introduced at the instance or below leaves this many namespace
+        // levels between its introduction and the prim being composed; anything
+        // deeper below its introduction was introduced above the instance.
+        let below_instance = prim_depth.saturating_sub(instance_depth);
         let nodes = &self.graph.nodes;
         let mut local = vec![false; nodes.len()];
         for (i, node) in nodes.iter().enumerate() {
@@ -462,7 +470,8 @@ impl PrimIndex {
                 // The local site (and the synthetic root) is always instance-local.
                 ArcType::Root => true,
                 ArcType::Reference | ArcType::Payload => {
-                    node.namespace_depth < instance_depth && node.parent.is_some_and(|p| local[p.idx()])
+                    self.graph.depth_below_introduction(NodeId(i as u32)) > below_instance
+                        && node.parent.is_some_and(|p| local[p.idx()])
                 }
                 _ => false,
             };
@@ -472,16 +481,17 @@ impl PrimIndex {
 
     /// Inerts the instance-namespace opinions on a prim composed inside an
     /// instance (spec 11.3.3), so value resolution sees only the shared subtree
-    /// the instance brings in. `instance_depth` is the nearest enclosing
-    /// instance prim's namespace depth; the partition is
+    /// the instance brings in. `prim_depth` is the namespace depth of the prim
+    /// this index composes and `instance_depth` the nearest enclosing instance
+    /// prim's; the partition is
     /// [`instance_local_nodes`](Self::instance_local_nodes).
     ///
     /// Each node is inerted individually, not its subtree: the implied classes a
     /// dropped reference helped derive are children in the graph yet stay shared.
     /// (The local root is also inerted earlier by the indexer via
     /// [`CompositionContext::within_instance`](super::prim_index::CompositionContext::within_instance).)
-    pub(crate) fn mark_instance_local_inert(&mut self, instance_depth: u16) {
-        let local = self.instance_local_nodes(instance_depth);
+    pub(crate) fn mark_instance_local_inert(&mut self, prim_depth: u16, instance_depth: u16) {
+        let local = self.instance_local_nodes(prim_depth, instance_depth);
         for (node, &is_local) in self.graph.nodes.iter_mut().zip(local.iter()) {
             if is_local {
                 node.flags |= NodeFlags::INERT;

--- a/src/pcp/prim_indexer.rs
+++ b/src/pcp/prim_indexer.rs
@@ -1934,7 +1934,7 @@ impl<'a, 'f> Indexer<'a, 'f> {
         }
         // Re-apply a variant selection the resting node carries at introduction,
         // so the storage site lookup hits the right `{set=sel}` namespace.
-        let intro = self.node(cur_node).path_at_introduction();
+        let intro = self.output.path_at_introduction(cur_node);
         let stripped = intro.strip_all_variant_selections();
         if intro != stripped {
             if let Some(p) = cur_path.replace_prefix(&stripped, &intro) {
@@ -2078,7 +2078,7 @@ impl<'a, 'f> Indexer<'a, 'f> {
         let mut cur = node;
         loop {
             let n = self.node(cur);
-            if is_class_based_arc(n.arc) && n.depth_below_introduction() == 0 && !n.is_inert() {
+            if is_class_based_arc(n.arc) && !self.output.is_due_to_ancestor(cur) && !n.is_inert() {
                 return true;
             }
             match n.parent() {
@@ -2335,7 +2335,7 @@ impl<'a, 'f> Indexer<'a, 'f> {
         }
 
         let src_is_class = is_class_based_arc(self.node(src).arc);
-        let src_depth = self.node(src).depth_below_introduction();
+        let src_depth = self.output.depth_below_introduction(src);
         // Crossing a sub-root arc (a reference/payload to a non-root prim)
         // collapses depth: the transfer maps the deep target (`/Set/Model`) to
         // the referencing prim, but a class the seed deepened keeps its map at the
@@ -2363,7 +2363,7 @@ impl<'a, 'f> Indexer<'a, 'f> {
             }
             // Skip the arc that continues an ancestral class chain rather than a
             // true namespace child: it must not be implied directly to dest.
-            if start_of_tree && src_is_class && src_depth == c.depth_below_introduction() {
+            if start_of_tree && src_is_class && src_depth == self.output.depth_below_introduction(child) {
                 continue;
             }
 
@@ -2431,7 +2431,7 @@ impl<'a, 'f> Indexer<'a, 'f> {
             let (instance, class) = self.output.starting_node_of_class_hierarchy(start);
             start = instance;
             if is_class_based_arc(self.node(instance).arc) {
-                let ancestral = self.node(instance).path_at_introduction();
+                let ancestral = self.output.path_at_introduction(instance);
                 if self.node(class).path.has_prefix(&ancestral) {
                     break;
                 }
@@ -2463,13 +2463,13 @@ impl<'a, 'f> Indexer<'a, 'f> {
     ) -> Option<NodeId> {
         let parent_is_relocate = self.node(parent).arc == ArcType::Relocate
             || (!self.root_contributes && parent == self.output.local_root());
-        let origin_depth = self.node(origin).depth_below_introduction();
+        let origin_depth = self.output.depth_below_introduction(origin);
         self.node(parent).children().iter().copied().find(|&c| {
             let cn = self.node(c);
             if parent_is_relocate {
                 cn.arc == arc
                     && cn.map_to_parent == *map
-                    && cn.origin().map(|o| self.node(o).depth_below_introduction()) == Some(origin_depth)
+                    && cn.origin().map(|o| self.output.depth_below_introduction(o)) == Some(origin_depth)
             } else {
                 cn.layer_id() == rep_layer && &cn.path == path
             }

--- a/src/usd/editor.rs
+++ b/src/usd/editor.rs
@@ -970,7 +970,7 @@ fn classify_source_nodes(
         }
         let introduced_away = node
             .map_to_root()
-            .map_source_to_target(&node.path_at_introduction())
+            .map_source_to_target(&index.graph().path_at_introduction(id))
             .is_some_and(|intro| &intro != origin);
         if node.arc() != pcp::ArcType::Root && introduced_away {
             realized = true;
@@ -989,7 +989,7 @@ fn classify_source_nodes(
                     // from another layer stack or from an internal reference
                     // within N's own stack. A direct arc on the prim itself (an
                     // inherit, a same-prim reference) moves with the spec.
-                    below_target |= node.depth_below_introduction() > 0;
+                    below_target |= index.graph().is_due_to_ancestor(id);
                 } else {
                     outside = true;
                 }


### PR DESCRIPTION
Fixes #127

## Root cause

A node's `namespace_depth` records the prim-element count of its **parent** site's path at arc introduction (C++ `PcpNode_GetNonVariantPathElementCount(parentNode.GetPath())`), but `Node::depth_below_introduction` subtracted it from the node's *own* path. The two agree only when an arc's target sits at the same namespace depth as the prim that authored it, so the error stayed invisible in the common case and `saturating_sub` clamped away the rest.

Two separate composition bugs followed, both hit by the Moana Island Scene.

### 1. The reported bug: an empty prototype through a non-root reference

`instance_local_nodes` compared that value's raw input against a stage-namespace depth (`namespace_depth < instance_depth`) to tell an outer, instance-local arc from the instanceable arc. For `/World/G/A`, the instanceable payload is authored at `/Root/A` — namespace depth 2 — so it tested `2 < 3` and was classified instance-local. `materialize_prototype` then inerted the very arc that brings in the content:

```
Root      /World/G/A   ns=1  local=true
Reference /Root/A      ns=2  local=true      <- outer reference, correct
Payload   /P           ns=2  local=true      <- the instanceable arc, WRONG
```

The prototype composed empty while `prototype()` still returned its path, so a consumer walked a childless prototype and imported nothing — no error, no warning. At `/World/A` the depths coincidentally matched (`2 < 2` is false), which is why only the depth of the prim carrying the reference distinguished the working case from the broken one.

### 2. A prototype root that legitimately carries `instanceable = true`

`materialize_prototype` asserted that a materialized prototype root's `instanceable` opinion always reads inert, and `redirect_anchor` relied on it. An asset that authors `instanceable = true` on the prim its referencing layer targets breaks that — the opinion arrives on the instanceable arc itself and is shared content the prototype must keep. This is exactly how the island's elements are authored:

```usda
# elements/isIronwoodB/element.usda
def Xform "isIronwoodB" (
    instanceable = true
    payload = @./instance.usda@</isIronwoodB>
) { }
```

In debug builds this trips the `debug_assert`; in release the prototype root would be treated as an enclosing instance for its own descendants. This one reproduces on `main` independently of the first bug.

## The fix

- `depth_below_introduction` and `path_at_introduction` move from `Node` onto `PrimIndexGraph`, where the introducing parent is reachable, and are anchored on the parent's path per C++ `PcpNode::GetDepthBelowIntroduction`. `is_due_to_ancestor` joins them (C++ `PcpNodeRef::IsDueToAncestor`). This also fixes `path_at_introduction`, which was mismeasured the same way and would strip too few elements for any arc whose target depth differs from its source's.
- `instance_local_nodes` now tests whether an arc was introduced strictly above the instance. That needs the composed prim's depth carried in alongside the instance's, because one caller partitions a *descendant's* index against an enclosing instance rather than the instance's own.
- `IndexCache::is_instance` exempts prototype roots structurally — a prototype root is never an instance, matching C++ where prototypes are non-instances by construction — which replaces the false invariant rather than papering over it. Nested instances *inside* a prototype are unaffected, since they are not prototype roots.

## Verification

Minimal repro from #127 — the nested case now matches the root case exactly:

```
outer_nested.usda  instance /World/G/A
  prototype()      = Some(/__Prototype_0)
  proto type_name  = Ok(Some("Xform"))     (was None)
  proto children   = Ok(1)                 (was 0)
  proto is_active  = Ok(true)              (was false)
```

Disney's Moana Island Scene through its own `usd/island.usda`:

| | before | after |
|---|---|---|
| instances with empty prototypes | 42 | **0** |
| prototypes | 32 | 45 |
| meshes composed in prototypes | 99,676 | 106,139 |

The workaround in #127 (re-authoring each element onto a stage-root prim) is no longer needed.

Two regression fixtures and tests, each confirmed to fail when its corresponding fix is reverted:

- `instancing_ancestral_reference.usda` / `ancestral_reference_prototype` — asserts the shallow and nested instances share one prototype and that it materializes.
- `instancing_prototype_root_instanceable.usda` / `prototype_root_instanceable` — asserts the opinion resolves true as prototype content while the root is still not an instance.

`cargo test --all-targets --all-features` shows no regressions: the set of failing test names is identical before and after (this checkout has pre-existing failures from an unfetched `vendor/usd-wg-assets` submodule). `cargo fmt --check` is clean and `cargo clippy --all-targets --all-features -- -D warnings` reports nothing in the changed code.

No ROADMAP.md change: scene-graph instancing (§11.3.3) is already marked complete, and this adds no newly deferred work.
